### PR TITLE
chore(k8s): load br_netfilter at boot

### DIFF
--- a/deploy/scripts/services/k8s.sh
+++ b/deploy/scripts/services/k8s.sh
@@ -895,6 +895,13 @@ configure_system() {
     log_info "Loading kernel modules..."
     modprobe overlay 2>/dev/null || true
     modprobe br_netfilter 2>/dev/null || true
+
+    # Ensure required kernel modules load on boot
+    log_info "Configuring kernel modules to load on boot..."
+    mkdir -p /etc/modules-load.d 2>/dev/null || true
+    cat > /etc/modules-load.d/kubernetes.conf <<EOF
+br_netfilter
+EOF
     
     # Configure kernel parameters
     log_info "Configuring kernel parameters..."
@@ -954,4 +961,3 @@ reset_k8s() {
     log_warn "Reset completed. iptables/IPVS rules are not automatically cleaned by this script."
     log_info "Kubernetes reset done"
 }
-


### PR DESCRIPTION
提交下面的pr出现了下面的错误
Pull request creation failed. Validation failed: A pull request already exists for kweaver-ai:bugfix/k8s-br-netfilter-boot.


# Pull Request

## What Changed

Brief description of changes:

- [x] **K8s 部署脚本**：在 `configure_system()` 中新增开机自动加载内核模块配置，确保重启后 `br_netfilter` 仍然可用

---

## Why

- Related Issue: [49](https://github.com/kweaver-ai/kweaver/issues/49)
- Related Feature: Kubernetes 安装部署稳定性
- Background:
  安装部署完成后访问正常，但机器重启后出现大量 Pod 无法启动。根因是部分环境重启后 `br_netfilter` 未自动加载，导致 bridge/iptables 转发链路不生效，进而影响 CNI / kube-proxy 等网络相关组件，表现为 Pod 启动/就绪失败。该修复通过 modules-load 配置确保重启后模块状态一致，避免“首次安装 OK、重启后故障”。

---

## How

- Key implementation points:
  - 仍然在安装时执行 `modprobe overlay` / `modprobe br_netfilter`（忽略失败不中断）
  - 新增写入 `/etc/modules-load.d/kubernetes.conf`，让系统在开机时自动加载 `br_netfilter`
  - 使用 `2>/dev/null || true` 保持幂等与容错
- Breaking changes (API, config, database, etc.):
  - 无 API / DB 变更
  - 系统侧新增 modules-load 配置文件（重启后会自动加载 `br_netfilter`）

---

## Testing

- [ ] Unit tests passed locally (N/A)
- [ ] Integration tests passed locally
- [x] Verified in test environment

Test notes:
- 部署完成后确认 `lsmod | grep br_netfilter` 已加载
- 重启机器
- 重启后确认 `lsmod | grep br_netfilter` 仍存在，`kubelet` 正常
- `kubectl get pods -A`：重启后大量 Pod 无法启动问题消失/显著缓解

---

## Risk & Rollback

- Potential risks:
  - 覆盖写入 `/etc/modules-load.d/kubernetes.conf`：若该文件被复用可能冲突（文件名为 kubernetes.conf，风险较低）
  - 极少数环境模块不可用：重启加载可能在系统日志中提示，但不影响脚本执行
- Rollback plan:
  - 回滚该 PR，或删除 `/etc/modules-load.d/kubernetes.conf`
  - 临时验证可手动执行 `modprobe br_netfilter`

---

## Additional Notes

- Screenshots, logs, documentation links, etc.:
  - 变更文件：`deploy/scripts/services/k8s.sh`（`configure_system()`）
  - 新增文件：`/etc/modules-load.d/kubernetes.conf`（内容：`br_netfilter`）