### PR TITLE
docs: add -k tip for self-signed TLS certs in kweaver auth login (EN/ZH)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,16 @@ npm install -g @kweaver-ai/kweaver-sdk
 kweaver auth login https://your-kweaver-instance.com
 ```
 
+> **Self-signed certificate?** If your instance uses a self-signed or untrusted TLS certificate (common for fresh deployments without a CA-issued cert), add `-k` to skip certificate verification:
+>
+> ```bash
+> kweaver auth login https://your-kweaver-instance.com -k
+> ```
+
 ### CLI
 
 ```bash
-kweaver auth login https://your-kweaver.com     # authenticate
+kweaver auth login https://your-kweaver.com     # authenticate (-k for self-signed certs)
 kweaver bkn list                                 # browse knowledge networks
 kweaver bkn object-type list <kn-id>            # inspect object types
 kweaver bkn action-type execute <kn-id> <at-id> # execute an action

--- a/README.zh.md
+++ b/README.zh.md
@@ -128,10 +128,16 @@ npm install -g @kweaver-ai/kweaver-sdk
 kweaver auth login https://your-kweaver-instance.com
 ```
 
+> **自签名证书？** 如果你的实例使用了自签名或不受信任的 TLS 证书（新部署且未配置 CA 签发证书时很常见），添加 `-k` 参数跳过证书验证：
+>
+> ```bash
+> kweaver auth login https://your-kweaver-instance.com -k
+> ```
+
 ### CLI
 
 ```bash
-kweaver auth login https://your-kweaver.com     # 登录认证
+kweaver auth login https://your-kweaver.com     # 登录认证（自签名证书加 -k）
 kweaver bkn list                                 # 浏览知识网络
 kweaver bkn object-type list <kn-id>            # 查看对象类型
 kweaver bkn action-type execute <kn-id> <at-id> # 执行 Action


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Docs: `README.md` — document `kweaver auth login -k` for self-signed / untrusted TLS (skip **TLS certificate verification**, not user authentication)
- [x] Docs: `README.zh.md` — 同上，中文说明自签名证书场景下使用 `-k` 跳过 **TLS 证书验证**

---

## Why

- Related Issue: N/A
- Related Feature: N/A
- Background: 新部署或未配置 CA 签发证书时，实例常用自签名 HTTPS；CLI 默认校验证书链，会导致 `kweaver auth login` 报错。需在文档中说明用 `-k` 跳过证书校验，并避免与「跳过登录/认证」混淆。

---

## How

- Key implementation points: 在 `kweaver auth login` 示例旁增加简短说明与带 `-k` 的示例命令；CLI 一行示例中加注释（英文 `authenticate (-k for self-signed certs)`，中文「自签名证书加 `-k`」）。
- Breaking changes (API, config, database, etc.): None

---

## Testing

- [ ] Unit tests passed locally — N/A（仅文档）
- [ ] Integration tests passed locally — N/A
- [x] Verified in test environment — 已核对 Markdown 与表述（`-k` = 跳过 TLS 证书验证）

Test notes: 本地预览 `README.md` / `README.zh.md`，确认 tip 与代码块格式正确。

---

## Risk & Rollback

- Potential risks: 无代码变更；若表述不清，可能仍有人误以为 `-k` 是跳过账号认证。
- Rollback plan: Revert 该文档 commit 即可。

---

## Additional Notes

- `-k` 表示不校验服务端 TLS 证书链；**仍会走正常 OAuth/登录流程**，不是「跳过认证」。
- Screenshots, logs, documentation links, etc.: （按需补充）