### PR TITLE
chore: add CODEOWNERS for per-module review assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,48 @@
+# ──────────────────────────────────────────────────────────────
+# CODEOWNERS — auto-assign reviewers based on changed paths
+#
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Rules:
+#   - Later rules override earlier ones (last match wins)
+#   - Owners can be @username, @org/team-name, or email
+#   - To enforce, enable "Require review from Code Owners"
+#     in Settings → Branches → Branch protection rules
+# ──────────────────────────────────────────────────────────────
+
+# ── Global fallback ──────────────────────────────────────────
+*                                          @xforce-io @sh00tg0a1
+
+# ── ADP (Application Delivery Platform) ─────────────────────
+adp/bkn/**                                 @kenlee1988
+adp/context-loader/**                      @criller
+adp/dataflow/**                            @kerrykuang2023 @zhangaishucn
+adp/execution-factory/**                   @criller
+adp/vega/**                                @kenlee1988 @Flynn-Zh
+adp/docs/**                                @kenlee1988
+
+# ── Decision Agent ───────────────────────────────────────────
+decision-agent/**                          @guodawn @kerrykuang2023
+
+# ── Infrastructure ───────────────────────────────────────────
+infra/mf-model-api/**                      @jiankang-kw
+infra/mf-model-manager/**                  @jiankang-kw
+infra/oss-gateway-backend/**               @jiankang-kw
+infra/sandbox/**                           @guodawn
+
+# ── Trace AI (Observability) ────────────────────────────────
+trace-ai/**                                @guodawn @kerrykuang2023
+
+# ── Deployment ───────────────────────────────────────────────
+deploy/**                                  @sh00tg0a1 @tangkelu
+
+# ── Website / Docs ───────────────────────────────────────────
+website/**                                 @xforce-io
+help/**                                    @FennyXCHF @sh00tg0a1
+
+# ── CI / CD / GitHub config ─────────────────────────────────
+.github/**                                 @xforce-io @sh00tg0a1
+rules/**                                   @sh00tg0a1 @xforce-io
+
+# ── Release notes ────────────────────────────────────────────
+release-notes/**                           @sh00tg0a1 @xforce-io


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Add `.github/CODEOWNERS` with per-module reviewer assignments

---

## Why

- Background: As the monorepo grows, PRs need to be reviewed by the right people. CODEOWNERS auto-assigns reviewers based on which directories are changed, ensuring each module gets reviewed by its maintainer(s).

---

## How

- Key implementation points:
  - Global fallback: @xforce-io @sh00tg0a1
  - ADP modules: @kenlee1988, @criller, @kerrykuang2023, @zhangaishucn, @Flynn-Zh
  - Decision Agent: @guodawn, @kerrykuang2023
  - Infrastructure: @jiankang-kw, @guodawn
  - Trace AI: @guodawn, @kerrykuang2023
  - Deploy: @sh00tg0a1, @tangkelu
  - Website/Help/CI/Rules/Release notes: @xforce-io, @sh00tg0a1, @FennyXCHF
- Breaking changes: None. To enforce mandatory Code Owner approval, enable "Require review from Code Owners" in branch protection settings.

---

## Testing

- [x] Verified all usernames exist in the kweaver-ai org
- [x] Verified path patterns match the repo directory structure

---

## Risk & Rollback

- Potential risks: None — CODEOWNERS only auto-assigns reviewers; it does not block merges unless branch protection is explicitly configured.
- Rollback plan: Delete the file or `git revert`.

Made with [Cursor](https://cursor.com)