### PR TITLE
fix: tighten find_skills entry validation

### DIFF
--- a/adp/context-loader/agent-retrieval/docs/apis/api_private/find_skills.yaml
+++ b/adp/context-loader/agent-retrieval/docs/apis/api_private/find_skills.yaml
@@ -2,11 +2,10 @@ openapi: 3.0.3
 info:
   title: Skill 召回接口
   description: |
-    基于业务上下文的 Skill 召回接口。Agent 在运行时传入知识网络 ID、可选的对象类型和实例标识，
+    基于业务上下文的 Skill 召回接口。Agent 在运行时传入知识网络 ID、对象类型和可选的实例标识，
     召回与当前业务上下文相关的 Skill 候选列表，返回最小化 Skill 元数据（skill_id、name、description）。
 
-    支持三种召回模式，由请求参数自动决定：
-    - **网络级**（仅 kn_id）：skills ObjectType 与任意其他 ObjectType 不存在 RelationType 时，直接返回全量 Skill 候选。
+    当前版本仅支持两种召回模式，由请求参数自动决定：
     - **对象类级**（kn_id + object_type_id）：沿 object_type_id 与 skills 之间的 RelationType 路径召回。
     - **实例级**（kn_id + object_type_id + instance_identities）：从具体实例出发召回，并补充对象类级结果。
   version: 1.0.0
@@ -30,12 +29,8 @@ paths:
 
         | 请求参数 | 召回模式 |
         |---------|---------|
-        | 仅 kn_id | 网络级（Mode 1） |
         | kn_id + object_type_id | 对象类级（Mode 2） |
         | kn_id + object_type_id + instance_identities | 实例级（Mode 3） |
-
-        **网络级特殊规则：** 仅当 skills ObjectType 与任意其他 ObjectType 都不存在 RelationType 时才返回结果，
-        否则返回空列表（需要更精确的 object_type_id 才能召回）。
 
         **skill_query 说明：** 传入时会对 skills 实例的 name/description 字段追加文本过滤条件（支持 knn/match/like，
         优先使用已构建的向量/索引能力），若 BKN 中 skills ObjectType 不存在或元数据获取失败则返回 502。
@@ -76,11 +71,6 @@ paths:
             schema:
               $ref: '#/components/schemas/FindSkillsRequest'
             examples:
-              network_level:
-                summary: 网络级召回（仅 kn_id）
-                value:
-                  kn_id: kn_legal
-                  top_k: 10
               object_type_level:
                 summary: 对象类级召回（kn_id + object_type_id）
                 value:
@@ -122,11 +112,6 @@ paths:
                       - skill_id: skill_clause_extract
                         name: 关键条款提取
                         description: 提取合同中的关键条款和义务
-                empty_result_network_scope:
-                  summary: 无匹配 Skill（网络级但 skills 有关联）
-                  value:
-                    entries: []
-                    message: "当前知识网络中的 Skill 不是全局生效，网络级范围未返回结果。请补充 object_type_id；如已定位到实例，再补充 instance_identities 后重试。"
                 empty_result_no_binding:
                   summary: 无匹配 Skill（对象类未配置 Skill 绑定）
                   value:
@@ -143,10 +128,54 @@ paths:
                   value:
                     code: INVALID_REQUEST
                     description: kn_id 为必填字段
+                missing_object_type_id:
+                  value:
+                    code: INVALID_REQUEST
+                    description: object_type_id 为必填字段
                 instance_without_object_type:
                   value:
                     code: INVALID_REQUEST
                     description: instance_identities 不为空时 object_type_id 也必须提供
+                skills_contract_incomplete:
+                  value:
+                    code: Public.BadRequest
+                    description: 参数错误
+                    details:
+                      kn_id: kn_legal
+                      skills_object_type_id: skills
+                      missing_data_properties:
+                        - skill_id
+                        - name
+                      reason: skills object type contract is incomplete
+                    solution: 请检查当前知识网络下 skills ObjectType 的数据属性定义，确保至少存在 skill_id 与 name
+                    link: 无
+        '404':
+          description: 当前知识网络中不存在指定对象类，或缺少 skills ObjectType
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                object_type_not_found:
+                  value:
+                    code: Public.NotFound
+                    description: 对象不存在
+                    details:
+                      kn_id: kn_legal
+                      object_type_id: contract
+                      reason: object_type_id not found in current knowledge network
+                    solution: 请确认 object_type_id 是否存在于当前知识网络后重试
+                    link: 无
+                skills_object_type_not_found:
+                  value:
+                    code: Public.NotFound
+                    description: 对象不存在
+                    details:
+                      kn_id: kn_legal
+                      skills_object_type_id: skills
+                      reason: skills object type not found in current knowledge network
+                    solution: 请先在当前知识网络中准备固定的 skills ObjectType 后重试
+                    link: 无
         '502':
           description: 上游服务不可用（BKN 或 ontology-query 异常）
           content:
@@ -165,6 +194,7 @@ components:
       type: object
       required:
         - kn_id
+        - object_type_id
       properties:
         kn_id:
           type: string
@@ -174,7 +204,7 @@ components:
           type: string
           description: |
             业务对象类型 ID（从 kn_search 或 kn_schema_search 返回的 concept_id 获取）。
-            不传时为网络级召回；传入时为对象类级或实例级召回。
+            当前版本为必填项；传入后为对象类级或实例级召回，且该对象类必须存在于当前知识网络中。
           example: contract
         instance_identities:
           type: array
@@ -198,6 +228,7 @@ components:
             可选的 Skill 语义过滤词，对 skills 实例的 name/description 字段追加文本过滤。
             BKN 已构建向量时使用 knn，已构建全文索引时使用 match，否则使用 like。
             若 skills ObjectType 元数据获取失败则返回 502。
+            入口会先校验 skills ObjectType 至少存在 `skill_id` 与 `name` 数据属性；`description` 可选。
           example: 合同审查
         top_k:
           type: integer
@@ -215,7 +246,7 @@ components:
         entries:
           type: array
           description: |
-            Skill 候选列表，按命中层级优先级（实例级 > 对象类级 > 网络级）和相关性分数降序排列。
+            Skill 候选列表，按命中层级优先级（实例级 > 对象类级）和相关性分数降序排列。
             同优先级同分数时按 skill_id 字典序排列，保证顺序稳定。
             无匹配时返回空数组。
           items:
@@ -243,7 +274,7 @@ components:
           example: 合同审查
         description:
           type: string
-          description: Skill 功能描述（可选，BKN 中无此属性时不返回）
+          description: Skill 功能描述（可选，BKN 中无此属性时不返回，也不作为 find_skills 的硬性前提）
           example: 对合同条款进行全面审查，识别风险点
 
     ErrorResponse:
@@ -257,3 +288,12 @@ components:
           type: string
           description: 错误详情
           example: kn_id 为必填字段
+        details:
+          type: object
+          description: 错误详情
+        solution:
+          type: string
+          description: 解决方案
+        link:
+          type: string
+          description: 错误链接

--- a/adp/context-loader/agent-retrieval/docs/release/overview.md
+++ b/adp/context-loader/agent-retrieval/docs/release/overview.md
@@ -20,7 +20,8 @@
 
 - 新增 `find_skills`，用于在指定 `kn_id` 和业务上下文边界内发现 Skill 候选
 - 工具体系补充 `find_*` 语义，用于承接“有边界的候选资源发现”场景
-- `find_skills` 支持网络级、对象类级、实例级三种召回模式，返回最小化 Skill 元数据（`skill_id`、`name`、`description`）
+- `find_skills` 当前版本支持对象类级、实例级两种召回模式（网络级召回暂未开放），返回最小化 Skill 元数据（`skill_id`、`name`、`description`）
+- `find_skills` 入口会校验 `skills` ObjectType 的基础契约：必须存在且至少定义 `skill_id`、`name` 数据属性；不满足时直接返回错误
 
 - 新增 `response_format`，支持 `json` 和 `toon`
 - HTTP 默认仍返回 `json`
@@ -61,6 +62,8 @@ docs/release/
 
 - `find_skills` 不是升级 Context Loader 后自动可用的能力；只有知识网络已完成 Skill 承接和绑定后，Skill recall 才能返回稳定结果。快速启用方式与前提说明见 `docs/release/tool-usage-guide.md` 的 `6.5 find_skills`
 - `find_skills` 属于候选资源发现工具，不替代 `kn_search` / `query_object_instance`
+- 当前版本 `object_type_id` 为必填参数，且必须存在于当前知识网络中；网络级召回暂未开放
+- `skills` ObjectType 必须至少定义 `skill_id`、`name` 两个数据属性（`description` 可选）；不满足时 `find_skills` 入口直接报错
 - 若调用方尚未明确对象类或实例，建议先使用 `kn_schema_search` / `kn_search` 与 `query_*` 工具获取上下文，再调用 `find_skills`
 - `find_skills` 的 `skill_query` 仅用于当前业务边界内过滤和排序，不用于跨知识网络搜索
 - HTTP 接口可通过 Query 参数 `response_format` 指定响应格式，默认 `json`
@@ -72,6 +75,6 @@ docs/release/
 
 - 交付清单验证：`docs/release/` 下的实际内容与本文档描述一致
 - 导入验证：`toolset/`、`tool-deps/`、`agent-deps/` 无缺失依赖
-- `find_skills` 验证：至少验证一种召回模式（网络级 / 对象类级 / 实例级），确认返回结构为候选 Skill 列表或空列表
+- `find_skills` 验证：至少验证一种召回模式（对象类级 / 实例级），确认返回结构为候选 Skill 列表或空列表
 - HTTP 验证：任选一个支持 `response_format` 的接口，确认默认返回 JSON，指定 `toon` 时返回 TOON
 - MCP 验证：任选一个 tool，确认默认返回 TOON 文本，显式指定 `json` 时返回 JSON 文本

--- a/adp/context-loader/agent-retrieval/docs/release/tool-usage-guide.md
+++ b/adp/context-loader/agent-retrieval/docs/release/tool-usage-guide.md
@@ -320,15 +320,16 @@ Data Agent 配置（建议）：
 - 在调用 `find_skills` 前，知识网络中必须已存在固定的 `skills` ObjectType
 - 该 ObjectType 的运行时识别键必须是 `object_type_id = "skills"`
 - `skills` ObjectType 不能由任意自定义对象类替代，它是 Skill 的固定承接面
+- `skills` ObjectType 必须至少定义 `skill_id`、`name` 两个数据属性；`description` 可选
 - `skills` ObjectType 下必须已有可见的 Skill 元数据实例
 - 业务对象与 `skills` 之间必须已配置绑定关系
 
-> 如果以上条件未满足，`find_skills` 虽然可以调用，但很可能只返回空结果。
+> 如果以上条件未满足，`find_skills` 在入口会直接返回错误，而不是继续执行召回。
 
 最短使用路径：
 
 - `kn_id` 必填
-- 已明确对象类时，优先传 `object_type_id`
+- `object_type_id` 必填，且必须存在于当前知识网络中
 - 已定位到实例时，再传 `instance_identities`
 - `skill_query` 只用于当前范围内过滤，不替代上下文定位
 
@@ -347,7 +348,8 @@ Data Agent 配置（建议）：
 接入前至少确认以下三件事：
 
 - 已存在固定的 `skills` ObjectType，且运行时识别键为 `object_type_id = "skills"`
-- `skills` ObjectType 下已有可见的 Skill 元数据实例，至少能返回 `skill_id`、`name`、`description`
+- `skills` ObjectType 的数据属性定义至少包含 `skill_id`、`name`；`description` 可选
+- `skills` ObjectType 下已有可见的 Skill 元数据实例，至少能返回 `skill_id`、`name`
 - 业务对象与 `skills` 之间已配置绑定关系；否则对象类级和实例级召回会天然为空
 
 <a id="find-skills-empty-results"></a>
@@ -358,10 +360,11 @@ Data Agent 配置（建议）：
 
 | 场景 | 常见含义 | 建议动作 |
 | :--- | :--- | :--- |
-| 仅传 `kn_id` 返回空结果 | 当前 Skill 不是全局生效，或当前知识网络下没有可见 Skill | 优先补 `object_type_id`；同时确认知识网络下是否已有可见的 Skill 元数据 |
 | 传 `object_type_id` 返回空结果 | 该对象类通常没有绑定 Skill | 确认该对象类与 `skills` 是否已配置绑定关系 |
 | 传 `object_type_id + instance_identities` 返回空结果 | 该实例通常没有命中 Skill，或不存在实例级绑定 | 可先回退到对象类级查看候选 Skill 是否存在 |
 | 传 `skill_query` 后返回空结果 | 当前过滤条件过严，或当前边界内本就没有匹配的 Skill | 放宽或去掉 `skill_query` 后重试 |
+| 传了不存在的 `object_type_id` | 当前知识网络中不存在该对象类 | 先通过 `kn_search` / `kn_schema_search` 确认合法对象类，再重试 |
+| 当前知识网络中缺少 `skills` ObjectType，或缺少 `skill_id` / `name` 属性 | `find_skills` 的基础契约未满足 | 先补齐固定的 `skills` ObjectType 及必要数据属性后，再调用 `find_skills` |
 
 #### 6.5.4 参数与调用方式
 
@@ -370,14 +373,14 @@ Data Agent 配置（建议）：
 | 字段 | 必填 | 说明 |
 | :--- | :--- | :--- |
 | `kn_id` | 是 | 业务知识网络 ID |
-| `object_type_id` | 否 | 业务对象类型 ID；传入时缩小到对象类级召回 |
+| `object_type_id` | 是 | 业务对象类型 ID；当前版本必须提供，且必须存在于当前知识网络中 |
 | `instance_identities` | 否 | 对象实例标识列表；传入时缩小到实例级召回，且必须同时提供 `object_type_id` |
 | `skill_query` | 否 | Skill 过滤词；仅在当前边界内做文本过滤和排序 |
 | `top_k` | 否 | 返回的最大 Skill 数量，默认 10，最大 20 |
 
 调用要点：
 
-- 仅传 `kn_id`：网络级召回，只适用于 Skill 以全局网络范围生效的场景
+- 当前版本暂不开放网络级召回
 - 传 `kn_id + object_type_id`：对象类级召回
 - 传 `kn_id + object_type_id + instance_identities`：实例级召回
 - `skill_query` 不替代 `kn_search`；若调用方尚未明确对象类或实例，应先使用 `search_*` / `query_*`
@@ -398,6 +401,7 @@ Data Agent 配置（建议）：
 | 背景项 | 用户需要知道什么 | 对使用 `find_skills` 的影响 |
 | :--- | :--- | :--- |
 | 固定模板 / 固定承接面 | Skill 不是任意对象类都能被召回，系统约定通过固定的 `skills` ObjectType 承接 | 如果没有这个固定承接面，`find_skills` 无法稳定识别 Skill 数据 |
+| 基础契约字段 | `find_skills` 运行时依赖 `skills` ObjectType 至少定义 `skill_id`、`name` 两个数据属性；`description` 只是可选补充信息 | 如果缺少 `skill_id` 或 `name`，`find_skills` 会在入口直接报错，而不是继续召回 |
 | 共享只读视图 | Skill 元数据由上游统一管理，BKN 默认承接的是只读视图，而不是每个知识网络各自维护一份副本 | 新增或变更 Skill 后，召回是否可见取决于该视图是否已同步可用 |
 | 运行时识别键 | 当前运行时固定通过 `object_type_id = "skills"` 识别 Skill ObjectType | 不是“同名即可”，必须满足固定识别键，否则 `find_skills` 不会把它当作 Skill 承接面 |
 
@@ -408,7 +412,7 @@ Data Agent 配置（建议）：
 | `x-account-id` | 应用变量 | Header 参数 | `header.x-account-id` |
 | `x-account-type` | 固定值/应用变量 | Header 参数 | `user` 或 `header.x-account-type` |
 | `kn_id` | 固定值/应用变量 | 请求体参数 | `"kn_legal"` 或 `self_config.data_source.knowledge_network[0].knowledge_network_id` |
-| `object_type_id` | 模型生成 | 请求体参数（可选） | `模型生成` |
+| `object_type_id` | 模型生成 | 请求体参数（必填） | `模型生成` |
 | `instance_identities` | 模型生成 | 请求体参数（可选） | `模型生成` |
 | `skill_query` | 模型生成 | 请求体参数（可选） | `模型生成` |
 | `top_k` | 固定值 | 请求体参数（可选） | `5` 或 `10` |

--- a/adp/context-loader/agent-retrieval/docs/release/toolset/context_loader_toolset.adp
+++ b/adp/context-loader/agent-retrieval/docs/release/toolset/context_loader_toolset.adp
@@ -3146,7 +3146,8 @@
                     "FindSkillsRequest": {
                       "type": "object",
                       "required": [
-                        "kn_id"
+                        "kn_id",
+                        "object_type_id"
                       ],
                       "properties": {
                         "top_k": {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/find_skills.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/find_skills.json
@@ -1,6 +1,7 @@
 {
   "input_schema": {
     "type": "object",
+    "required": ["object_type_id"],
     "properties": {
       "response_format": {
         "type": "string",
@@ -10,7 +11,7 @@
       },
       "object_type_id": {
         "type": "string",
-        "description": "对象类型 ID（可选）。提供时缩小技能召回范围至该对象类型"
+        "description": "对象类型 ID（必填）。当前版本仅支持对象类级或实例级技能召回，且该对象类型必须存在于当前知识网络中"
       },
       "instance_identities": {
         "type": "array",

--- a/adp/context-loader/agent-retrieval/server/interfaces/find_skills.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/find_skills.go
@@ -18,7 +18,7 @@ type FindSkillsReq struct {
 
 	// Body Parameters
 	KnID               string                   `json:"kn_id" validate:"required"`
-	ObjectTypeID       string                   `json:"object_type_id"`
+	ObjectTypeID       string                   `json:"object_type_id" validate:"required"`
 	InstanceIdentities []map[string]interface{} `json:"instance_identities"`
 	SkillQuery         string                   `json:"skill_query"`
 	TopK               int                      `json:"top_k" default:"10" validate:"min=1,max=20"`

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/context_normalizer.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/context_normalizer.go
@@ -16,6 +16,10 @@ import (
 // NormalizeAndDetectMode validates the request and determines the recall mode.
 // Returns an error (400) if instance_identities is present but object_type_id is missing.
 func NormalizeAndDetectMode(req *interfaces.FindSkillsReq, cfg *config.FindSkillsConfig) (interfaces.RecallMode, error) {
+	if req.ObjectTypeID == "" {
+		return 0, fmt.Errorf("%d:object_type_id is required", http.StatusBadRequest)
+	}
+
 	if len(req.InstanceIdentities) > 0 && req.ObjectTypeID == "" {
 		return 0, fmt.Errorf("%d:instance_identities requires object_type_id", http.StatusBadRequest)
 	}

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/context_normalizer_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/context_normalizer_test.go
@@ -8,6 +8,7 @@ package knfindskills
 import (
 	"testing"
 
+	validator "github.com/go-playground/validator/v10"
 	"github.com/kweaver-ai/adp/context-loader/agent-retrieval/server/infra/config"
 	"github.com/kweaver-ai/adp/context-loader/agent-retrieval/server/interfaces"
 )
@@ -20,17 +21,19 @@ func defaultFSConfig() *config.FindSkillsConfig {
 	}
 }
 
-func TestNormalizeAndDetectMode_NetworkMode(t *testing.T) {
+func TestNormalizeAndDetectMode_ObjectTypeRequired(t *testing.T) {
 	req := &interfaces.FindSkillsReq{KnID: "kn1"}
-	mode, err := NormalizeAndDetectMode(req, defaultFSConfig())
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	_, err := NormalizeAndDetectMode(req, defaultFSConfig())
+	if err == nil {
+		t.Fatal("expected error when object_type_id is missing")
 	}
-	if mode != interfaces.RecallModeNetwork {
-		t.Errorf("expected RecallModeNetwork(1), got %d", mode)
-	}
-	if req.TopK != 10 {
-		t.Errorf("expected default TopK=10, got %d", req.TopK)
+}
+
+func TestFindSkillsReq_ObjectTypeRequiredByValidator(t *testing.T) {
+	req := &interfaces.FindSkillsReq{KnID: "kn1", TopK: 10}
+	err := validator.New().Struct(req)
+	if err == nil {
+		t.Fatal("expected validator error when object_type_id is missing")
 	}
 }
 
@@ -75,14 +78,14 @@ func TestNormalizeAndDetectMode_TopKClamping(t *testing.T) {
 	cfg := defaultFSConfig()
 
 	// TopK=0 -> default
-	req := &interfaces.FindSkillsReq{KnID: "kn1", TopK: 0}
+	req := &interfaces.FindSkillsReq{KnID: "kn1", ObjectTypeID: "contract", TopK: 0}
 	_, _ = NormalizeAndDetectMode(req, cfg)
 	if req.TopK != 10 {
 		t.Errorf("expected TopK=10, got %d", req.TopK)
 	}
 
 	// TopK > MaxTopK -> clamped
-	req = &interfaces.FindSkillsReq{KnID: "kn1", TopK: 50}
+	req = &interfaces.FindSkillsReq{KnID: "kn1", ObjectTypeID: "contract", TopK: 50}
 	_, _ = NormalizeAndDetectMode(req, cfg)
 	if req.TopK != 20 {
 		t.Errorf("expected TopK=20, got %d", req.TopK)

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/find_skills_service_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/find_skills_service_test.go
@@ -7,11 +7,13 @@ package knfindskills
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/kweaver-ai/adp/context-loader/agent-retrieval/server/infra/common"
 	"github.com/kweaver-ai/adp/context-loader/agent-retrieval/server/infra/config"
+	infraErr "github.com/kweaver-ai/adp/context-loader/agent-retrieval/server/infra/errors"
 	"github.com/kweaver-ai/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
@@ -35,6 +37,18 @@ func enCtx() context.Context {
 	return common.SetLanguageByCtx(context.Background(), common.AmericanEnglish)
 }
 
+func makeSkillsObjectTypeWithProps(propNames ...string) *interfaces.ObjectType {
+	props := make([]*interfaces.DataProperty, 0, len(propNames))
+	for _, name := range propNames {
+		props = append(props, &interfaces.DataProperty{Name: name})
+	}
+	return &interfaces.ObjectType{
+		ID:             "skills",
+		Name:           "skills",
+		DataProperties: props,
+	}
+}
+
 func TestFindSkills_NonEmpty_NoMessage(t *testing.T) {
 	bkn := &testBknBackend{
 		searchRelationTypesFunc: func(_ context.Context, _ *interfaces.QueryConceptsReq) (*interfaces.RelationTypeConcepts, error) {
@@ -48,7 +62,7 @@ func TestFindSkills_NonEmpty_NoMessage(t *testing.T) {
 	}
 	svc := NewFindSkillsServiceWith(&testLogger{}, newTestConfig(), oq, bkn)
 
-	resp, err := svc.FindSkills(zhCtx(), &interfaces.FindSkillsReq{KnID: "kn1", TopK: 10})
+	resp, err := svc.FindSkills(zhCtx(), &interfaces.FindSkillsReq{KnID: "kn1", ObjectTypeID: "skills", TopK: 10})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -60,56 +74,26 @@ func TestFindSkills_NonEmpty_NoMessage(t *testing.T) {
 	}
 }
 
-func TestFindSkills_NetworkScopeTooWide(t *testing.T) {
-	bkn := &testBknBackend{
-		searchRelationTypesFunc: func(_ context.Context, _ *interfaces.QueryConceptsReq) (*interfaces.RelationTypeConcepts, error) {
-			return &interfaces.RelationTypeConcepts{
-				Entries: []*interfaces.RelationType{
-					{ID: "rt_1", SourceObjectTypeID: "contract", TargetObjectTypeID: "skills"},
-				},
-			}, nil
-		},
-	}
-	oq := &testOntologyQuery{}
-	svc := NewFindSkillsServiceWith(&testLogger{}, newTestConfig(), oq, bkn)
+func TestFindSkills_ObjectTypeRequired(t *testing.T) {
+	svc := NewFindSkillsServiceWith(&testLogger{}, newTestConfig(), &testOntologyQuery{}, &testBknBackend{})
 
 	resp, err := svc.FindSkills(zhCtx(), &interfaces.FindSkillsReq{KnID: "kn1", TopK: 10})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if err == nil {
+		t.Fatal("expected error when object_type_id is missing")
 	}
-	if len(resp.Entries) != 0 {
-		t.Fatalf("expected 0 entries, got %d", len(resp.Entries))
+	if resp != nil {
+		t.Fatalf("expected nil response on error, got %#v", resp)
 	}
-	if resp.Message == "" {
-		t.Fatal("expected message for empty result, got empty")
-	}
-	if !strings.Contains(resp.Message, "object_type_id") {
-		t.Errorf("network_scope_too_wide message should suggest object_type_id, got %q", resp.Message)
-	}
-}
 
-func TestFindSkills_NetworkNoSkills(t *testing.T) {
-	bkn := &testBknBackend{
-		searchRelationTypesFunc: func(_ context.Context, _ *interfaces.QueryConceptsReq) (*interfaces.RelationTypeConcepts, error) {
-			return &interfaces.RelationTypeConcepts{Entries: []*interfaces.RelationType{}}, nil
-		},
+	httpErr := &infraErr.HTTPError{}
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected HTTPError, got %T", err)
 	}
-	oq := &testOntologyQuery{
-		queryObjectInstancesFunc: func(_ context.Context, _ *interfaces.QueryObjectInstancesReq) (*interfaces.QueryObjectInstancesResp, error) {
-			return &interfaces.QueryObjectInstancesResp{Data: []any{}}, nil
-		},
+	if httpErr.HTTPCode != 400 {
+		t.Fatalf("expected HTTP 400, got %d", httpErr.HTTPCode)
 	}
-	svc := NewFindSkillsServiceWith(&testLogger{}, newTestConfig(), oq, bkn)
-
-	resp, err := svc.FindSkills(zhCtx(), &interfaces.FindSkillsReq{KnID: "kn1", TopK: 10})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(resp.Entries) != 0 {
-		t.Fatalf("expected 0 entries, got %d", len(resp.Entries))
-	}
-	if !strings.Contains(resp.Message, "Skill") {
-		t.Errorf("network_no_skills message should mention Skill, got %q", resp.Message)
+	if !strings.Contains(httpErr.Error(), "object_type_id") {
+		t.Fatalf("expected error to mention object_type_id, got %s", httpErr.Error())
 	}
 }
 
@@ -133,6 +117,164 @@ func TestFindSkills_ObjectTypeNoBinding(t *testing.T) {
 	}
 	if !strings.Contains(resp.Message, "绑定") {
 		t.Errorf("object_type_no_binding message should mention binding (绑定), got %q", resp.Message)
+	}
+}
+
+func TestFindSkills_ObjectTypeNotFound(t *testing.T) {
+	bkn := &testBknBackend{
+		getObjectTypeDetailFunc: func(_ context.Context, knID string, otIDs []string, includeDetail bool) ([]*interfaces.ObjectType, error) {
+			if knID != "kn1" {
+				t.Fatalf("expected knID=kn1, got %s", knID)
+			}
+			if len(otIDs) != 1 {
+				t.Fatalf("expected a single object type lookup, got %v", otIDs)
+			}
+			switch otIDs[0] {
+			case "skills":
+				if !includeDetail {
+					t.Fatal("expected includeDetail=true for skills contract check")
+				}
+				return []*interfaces.ObjectType{makeSkillsObjectTypeWithProps("skill_id", "name", "description")}, nil
+			case "contract":
+				if includeDetail {
+					t.Fatal("expected includeDetail=false for business object type existence check")
+				}
+				return []*interfaces.ObjectType{}, nil
+			default:
+				t.Fatalf("unexpected object type lookup: %v", otIDs)
+				return nil, nil
+			}
+		},
+	}
+	svc := NewFindSkillsServiceWith(&testLogger{}, newTestConfig(), &testOntologyQuery{}, bkn)
+
+	resp, err := svc.FindSkills(zhCtx(), &interfaces.FindSkillsReq{
+		KnID: "kn1", ObjectTypeID: "contract", TopK: 10,
+	})
+	if err == nil {
+		t.Fatal("expected error when object_type_id does not exist in current knowledge network")
+	}
+	if resp != nil {
+		t.Fatalf("expected nil response on error, got %#v", resp)
+	}
+
+	httpErr := &infraErr.HTTPError{}
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected HTTPError, got %T", err)
+	}
+	if httpErr.HTTPCode != 404 {
+		t.Fatalf("expected HTTP 404, got %d", httpErr.HTTPCode)
+	}
+
+	details, ok := httpErr.ErrorDetails.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected structured error details, got %T", httpErr.ErrorDetails)
+	}
+	if details["kn_id"] != "kn1" {
+		t.Fatalf("expected details.kn_id=kn1, got %#v", details["kn_id"])
+	}
+	if details["object_type_id"] != "contract" {
+		t.Fatalf("expected details.object_type_id=contract, got %#v", details["object_type_id"])
+	}
+}
+
+func TestFindSkills_SkillsObjectTypeNotFound(t *testing.T) {
+	bkn := &testBknBackend{
+		getObjectTypeDetailFunc: func(_ context.Context, _ string, otIDs []string, includeDetail bool) ([]*interfaces.ObjectType, error) {
+			if len(otIDs) != 1 {
+				t.Fatalf("expected a single object type lookup, got %v", otIDs)
+			}
+			switch otIDs[0] {
+			case "contract":
+				if includeDetail {
+					t.Fatal("expected includeDetail=false for business object type existence check")
+				}
+				return []*interfaces.ObjectType{{ID: "contract", Name: "contract"}}, nil
+			case "skills":
+				if !includeDetail {
+					t.Fatal("expected includeDetail=true for skills contract check")
+				}
+				return []*interfaces.ObjectType{}, nil
+			default:
+				t.Fatalf("unexpected object type lookup: %v", otIDs)
+				return nil, nil
+			}
+		},
+	}
+	svc := NewFindSkillsServiceWith(&testLogger{}, newTestConfig(), &testOntologyQuery{}, bkn)
+
+	resp, err := svc.FindSkills(zhCtx(), &interfaces.FindSkillsReq{
+		KnID: "kn1", ObjectTypeID: "contract", TopK: 10,
+	})
+	if err == nil {
+		t.Fatal("expected error when skills object type is missing")
+	}
+	if resp != nil {
+		t.Fatalf("expected nil response on error, got %#v", resp)
+	}
+
+	httpErr := &infraErr.HTTPError{}
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected HTTPError, got %T", err)
+	}
+	if httpErr.HTTPCode != 404 {
+		t.Fatalf("expected HTTP 404, got %d", httpErr.HTTPCode)
+	}
+}
+
+func TestFindSkills_SkillsContractMissingRequiredProperties(t *testing.T) {
+	bkn := &testBknBackend{
+		getObjectTypeDetailFunc: func(_ context.Context, _ string, otIDs []string, includeDetail bool) ([]*interfaces.ObjectType, error) {
+			if len(otIDs) != 1 {
+				t.Fatalf("expected a single object type lookup, got %v", otIDs)
+			}
+			switch otIDs[0] {
+			case "contract":
+				if includeDetail {
+					t.Fatal("expected includeDetail=false for business object type existence check")
+				}
+				return []*interfaces.ObjectType{{ID: "contract", Name: "contract"}}, nil
+			case "skills":
+				if !includeDetail {
+					t.Fatal("expected includeDetail=true for skills contract check")
+				}
+				return []*interfaces.ObjectType{makeSkillsObjectTypeWithProps("description")}, nil
+			default:
+				t.Fatalf("unexpected object type lookup: %v", otIDs)
+				return nil, nil
+			}
+		},
+	}
+	svc := NewFindSkillsServiceWith(&testLogger{}, newTestConfig(), &testOntologyQuery{}, bkn)
+
+	resp, err := svc.FindSkills(zhCtx(), &interfaces.FindSkillsReq{
+		KnID: "kn1", ObjectTypeID: "contract", TopK: 10,
+	})
+	if err == nil {
+		t.Fatal("expected error when skills contract is missing required properties")
+	}
+	if resp != nil {
+		t.Fatalf("expected nil response on error, got %#v", resp)
+	}
+
+	httpErr := &infraErr.HTTPError{}
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected HTTPError, got %T", err)
+	}
+	if httpErr.HTTPCode != 400 {
+		t.Fatalf("expected HTTP 400, got %d", httpErr.HTTPCode)
+	}
+
+	details, ok := httpErr.ErrorDetails.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected structured error details, got %T", httpErr.ErrorDetails)
+	}
+	missing, ok := details["missing_data_properties"].([]string)
+	if !ok {
+		t.Fatalf("expected missing_data_properties to be []string, got %T", details["missing_data_properties"])
+	}
+	if len(missing) != 2 {
+		t.Fatalf("expected 2 missing properties, got %v", missing)
 	}
 }
 
@@ -215,6 +357,7 @@ func TestFindSkills_SkillQueryNoMatch(t *testing.T) {
 				ID:   "skills",
 				Name: "skills",
 				DataProperties: []*interfaces.DataProperty{
+					{Name: "skill_id"},
 					{Name: "name", ConditionOperations: []interfaces.KnOperationType{interfaces.KnOperationTypeLike}},
 				},
 			}}, nil

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/index.go
@@ -24,6 +24,8 @@ import (
 	"github.com/kweaver-ai/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
+var requiredSkillsDataProperties = []string{"skill_id", "name"}
+
 type findSkillsServiceImpl struct {
 	logger        interfaces.Logger
 	config        *config.Config
@@ -94,22 +96,24 @@ func (s *findSkillsServiceImpl) FindSkills(ctx context.Context, req *interfaces.
 		return nil, infraErr.DefaultHTTPError(ctx, http.StatusBadRequest, err.Error())
 	}
 
+	skillsObjType, err := s.loadAndValidateSkillsContract(ctx, req.KnID, fsCfg.SkillsObjectTypeID)
+	if err != nil {
+		return nil, err
+	}
+
+	if req.ObjectTypeID != fsCfg.SkillsObjectTypeID {
+		if err = s.validateObjectTypeExists(ctx, req.KnID, req.ObjectTypeID); err != nil {
+			return nil, err
+		}
+	}
+
 	s.logger.WithContext(ctx).Infof("[FindSkills] kn_id=%s, mode=%d, object_type_id=%s, instance_count=%d, has_skill_query=%v",
 		req.KnID, mode, req.ObjectTypeID, len(req.InstanceIdentities), req.SkillQuery != "")
 
-	// 2. Build skill_query condition (needs skills ObjectType metadata)
+	// 2. Build skill_query condition (reuse validated skills ObjectType metadata)
 	var skillQueryCond *interfaces.KnCondition
 	if req.SkillQuery != "" {
-		skillsObjTypes, getErr := s.bknBackend.GetObjectTypeDetail(ctx, req.KnID, []string{fsCfg.SkillsObjectTypeID}, true)
-		if getErr != nil {
-			err = fmt.Errorf("skill_query requires skills ObjectType metadata but GetObjectTypeDetail failed: %w", getErr)
-			return nil, infraErr.DefaultHTTPError(ctx, http.StatusBadGateway, err.Error())
-		}
-		if len(skillsObjTypes) == 0 {
-			err = fmt.Errorf("skill_query requires skills ObjectType (id=%s) but none found in kn_id=%s", fsCfg.SkillsObjectTypeID, req.KnID)
-			return nil, infraErr.DefaultHTTPError(ctx, http.StatusBadGateway, err.Error())
-		}
-		skillQueryCond = BuildSkillQueryCondition(req.SkillQuery, skillsObjTypes[0], req.TopK)
+		skillQueryCond = BuildSkillQueryCondition(req.SkillQuery, skillsObjType, req.TopK)
 	}
 
 	// 3. Apply total timeout
@@ -150,6 +154,66 @@ func (s *findSkillsServiceImpl) FindSkills(ctx context.Context, req *interfaces.
 
 	s.logger.WithContext(ctx).Infof("[FindSkills] returning %d skills for kn_id=%s", len(resp.Entries), req.KnID)
 	return resp, nil
+}
+
+func (s *findSkillsServiceImpl) loadAndValidateSkillsContract(ctx context.Context, knID, skillsObjectTypeID string) (*interfaces.ObjectType, error) {
+	objectTypes, err := s.bknBackend.GetObjectTypeDetail(ctx, knID, []string{skillsObjectTypeID}, true)
+	if err != nil {
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusBadGateway, err.Error())
+	}
+	if len(objectTypes) == 0 {
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusNotFound, map[string]interface{}{
+			"kn_id":                 knID,
+			"skills_object_type_id": skillsObjectTypeID,
+			"reason":                "skills object type not found in current knowledge network",
+		})
+	}
+
+	skillsObjType := objectTypes[0]
+	existingProps := make(map[string]struct{}, len(skillsObjType.DataProperties))
+	for _, prop := range skillsObjType.DataProperties {
+		if prop == nil {
+			continue
+		}
+		name := strings.TrimSpace(prop.Name)
+		if name == "" {
+			continue
+		}
+		existingProps[name] = struct{}{}
+	}
+
+	var missingProps []string
+	for _, name := range requiredSkillsDataProperties {
+		if _, ok := existingProps[name]; !ok {
+			missingProps = append(missingProps, name)
+		}
+	}
+	if len(missingProps) > 0 {
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusBadRequest, map[string]interface{}{
+			"kn_id":                   knID,
+			"skills_object_type_id":   skillsObjectTypeID,
+			"missing_data_properties": missingProps,
+			"reason":                  "skills object type contract is incomplete",
+		})
+	}
+
+	return skillsObjType, nil
+}
+
+func (s *findSkillsServiceImpl) validateObjectTypeExists(ctx context.Context, knID, objectTypeID string) error {
+	objectTypes, err := s.bknBackend.GetObjectTypeDetail(ctx, knID, []string{objectTypeID}, false)
+	if err != nil {
+		return infraErr.DefaultHTTPError(ctx, http.StatusBadGateway, err.Error())
+	}
+	if len(objectTypes) > 0 {
+		return nil
+	}
+
+	return infraErr.DefaultHTTPError(ctx, http.StatusNotFound, map[string]interface{}{
+		"kn_id":          knID,
+		"object_type_id": objectTypeID,
+		"reason":         "object_type_id not found in current knowledge network",
+	})
 }
 
 func resolveEmptyResultMessageKey(hint interfaces.EmptyResultHint, mode interfaces.RecallMode, hasSkillQuery bool) string {

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/mock_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/mock_test.go
@@ -42,7 +42,16 @@ func (m *testBknBackend) GetObjectTypeDetail(ctx context.Context, knID string, o
 	if m.getObjectTypeDetailFunc != nil {
 		return m.getObjectTypeDetailFunc(ctx, knID, otIds, includeDetail)
 	}
-	return nil, nil
+	if len(otIds) == 0 {
+		return nil, nil
+	}
+	if otIds[0] == "skills" {
+		return []*interfaces.ObjectType{makeSkillsObjectTypeWithProps("skill_id", "name", "description")}, nil
+	}
+	return []*interfaces.ObjectType{{
+		ID:   otIds[0],
+		Name: otIds[0],
+	}}, nil
 }
 
 func (m *testBknBackend) GetKnowledgeNetworkDetail(ctx context.Context, knID string) (*interfaces.KnowledgeNetworkDetail, error) {


### PR DESCRIPTION
# Pull Request

## What Changed

本次变更主要收紧了 `find_skills` 的入口契约，并同步更新了测试与发布文档：

- [x] 收紧 `find_skills` 请求参数约束：`object_type_id` 改为必填，HTTP 与 MCP 两个入口统一生效
- [x] 在 `find_skills` logic 入口新增 `skills` ObjectType 契约校验：必须存在，且至少定义 `skill_id`、`name` 数据属性
- [x] `description` 保持为可选属性，不作为硬性前提
- [x] `skill_query` 分支复用已校验的 `skills` 元数据，避免重复查询
- [x] 补充/调整单元测试，覆盖对象类不存在、`skills` 不存在、`skills` 契约不完整等场景
- [x] 同步更新 API 文档、release 文档和 MCP schema，明确当前版本不开放网络级召回

---

## Why

- Related Issue: [Issue #109](https://github.com/kweaver-ai/kweaver-core/issues/109)
- Related Feature: `find_skills` 工具收口与契约校验
- Background:
  - 当前版本中，BKN 侧对网络级召回方案尚未完全确定，因此 `find_skills` 暂不开放网络级召回
  - 现有实现对 `skills` ObjectType 及其关键数据属性存在事实依赖，但缺少统一的入口校验，容易在运行时表现为空结果或不清晰的错误
  - 本次变更的目标是以最小改动方式，将这些前提条件显式化为工具契约，避免误用并提升错误可解释性

---

## How

- Key implementation points:
  - 将 `FindSkillsReq.object_type_id` 设为必填，统一收口 HTTP + MCP 入口
  - 在 `find_skills` logic 入口增加 `skills` ObjectType 预检查：
    - `skills` ObjectType 不存在时返回 `404`
    - 缺少 `skill_id` 或 `name` 时返回 `400`
    - 错误详情写入 `details`
  - 保留 `description` 为可选字段，不作为硬性失败条件
  - `skill_query` 分支直接复用入口已获取的 `skills` 元数据，不再额外查询
  - 同步更新 OpenAPI、tool usage guide、release overview、toolset schema

- Breaking changes (API, config, database, etc.):
  - `find_skills` 的 `object_type_id` 从可选变为必填
  - 当前版本不再支持仅传 `kn_id` 的网络级召回
  - `find_skills` 运行前提收紧：当前知识网络中必须存在固定 `skills` ObjectType，且至少定义 `skill_id`、`name`

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- 已执行：`go test ./server/logics/knfindskills -count=1`
- 已执行：`git diff --check`
- 新增/调整测试覆盖：
  - `object_type_id` 缺失
  - 指定 `object_type_id` 不存在
  - `skills` ObjectType 不存在
  - `skills` 缺少 `skill_id` / `name`
  - `description` 缺失但仍可继续执行的场景

---

## Risk & Rollback

- Potential risks:
  - 对调用方存在兼容性影响：原先仅传 `kn_id` 的请求将被拒绝
  - 如果部分知识网络未按约定建模 `skills` ObjectType，`find_skills` 会从“空结果”变为显式报错
  - 当前仅完成 logic 层单元测试，HTTP/MCP 端到端行为仍建议补集成验证

- Rollback plan:
  - 回滚本 PR 即可恢复原有入口约束与运行时行为
  - 如需临时放宽限制，可优先回退 `object_type_id` 必填约束与 `skills` 契约 precheck，不涉及主召回流程重构

---

## Additional Notes

- 本次变更不修改主召回流程，仅在入口增加参数与契约校验
- `object_type_id=skills` 仍然允许
- `description` 仍为可选字段，不作为 `find_skills` 的硬性前提
- 建议 reviewer 特别关注：
  - 这是一次“当前版本的临时收口”，不是删除未来网络级召回能力
  - 错误结构以当前实现为准，字段使用 `details`
