### PR TITLE
fix(execution-factory) 修复流式转发在缺少 ResponseWriter 时 nil 指针解引用导致 panic

### DIFF
--- a/adp/execution-factory/operator-integration/server/logics/proxy/forwarder.go
+++ b/adp/execution-factory/operator-integration/server/logics/proxy/forwarder.go
@@ -63,7 +63,6 @@ func (f *forwarder) ForwardStream(ctx context.Context, req *interfaces.HTTPReque
 	// 获取响应写入器
 	headerWriter, ok := common.GetResponseWriterFromCtx(ctx)
 	if !ok {
-		headerWriter.WriteHeader(http.StatusInternalServerError)
 		err := fmt.Errorf("response writer not found in context")
 		f.logger.WithContext(ctx).Warnf("failed to forward stream, err: %v", err)
 		err = myErr.DefaultHTTPError(ctx, http.StatusInternalServerError, err.Error())

--- a/adp/execution-factory/operator-integration/server/logics/proxy/forwarder_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/proxy/forwarder_test.go
@@ -1,0 +1,42 @@
+package proxy
+
+import (
+	"context"
+	"testing"
+
+	myErr "github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/errors"
+	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/logger"
+	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/interfaces"
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+)
+
+func TestForwardStream_MissingResponseWriterDoesNotPanic(t *testing.T) {
+	Convey("ForwardStream handles missing response writer without panic", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		forwarder := &forwarder{
+			logger: logger.DefaultLogger(),
+		}
+
+		req := &interfaces.HTTPRequest{
+			HTTPRouter: interfaces.HTTPRouter{
+				Method: "GET",
+				URL:    "http://example.com",
+			},
+		}
+
+		So(func() {
+			resp, err := forwarder.ForwardStream(context.Background(), req)
+
+			So(resp, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+
+			httpErr, ok := err.(*myErr.HTTPError)
+			So(ok, ShouldBeTrue)
+			So(httpErr.HTTPCode, ShouldEqual, 500)
+			So(httpErr.ErrorDetails, ShouldEqual, "response writer not found in context")
+		}, ShouldNotPanic)
+	})
+}


### PR DESCRIPTION

 # fix(execution-factory): 修复流式转发缺少 ResponseWriter 时的 panic

  ## 背景

  关闭 #175 (https://github.com/kweaver-ai/kweaver-core/issues/175)

  `execution-factory/operator-integration` 的流式转发路径中，`ForwardStream` 在从 context 获取 `ResponseWriter` 失败时，错误分支仍然调用了
  `headerWriter.WriteHeader(...)`。由于此时 `headerWriter` 为 `nil`，会触发确定性 panic。

  ## 修改内容

  - 移除 `ForwardStream` 中 `ResponseWriter` 缺失分支里的 `headerWriter.WriteHeader(...)`
  - 保留原有告警日志
  - 在未获取到 `ResponseWriter` 时，直接返回 `myErr.DefaultHTTPError(...)`
  - 补充回归测试，覆盖 context 中未携带 `ResponseWriter` 的场景

  ## 根因分析

  错误处理分支对 `GetResponseWriterFromCtx(ctx)` 的返回结果判断后，仍然对空的 `headerWriter` 进行了方法调用，导致 nil 指针解引用。

  ## 修复效果

  当 context 中不存在 `ResponseWriter` 时：
  - 不再 panic
  - `ForwardStream` 返回 `500` 错误
  - 日志中记录 `response writer not found in context`

  ## 验证情况

  已执行：
  - `go test ./server/logics/proxy`

  测试通过。

  ## 影响范围

  该问题在标准 HTTP 入口下不容易暴露，因为正常 middleware 通常会注入 `ResponseWriter`。
  但在绕过标准 middleware 链的调用、测试或复用场景中，会稳定触发 panic。此次修复仅调整该异常分支，不影响正常流式转发逻辑。