### PR TITLE
fix(bkn-backend): 将 fmt.Errorf 替换为结构化 HTTPError，修复下游状态码被吞为 502 的问题

### DIFF
--- a/adp/context-loader/agent-retrieval/server/drivenadapters/bkn_backend.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/bkn_backend.go
@@ -63,12 +63,14 @@ func (b *bknBackendAccess) GetKnowledgeNetworkDetail(ctx context.Context, knID s
 	result := &interfaces.KnowledgeNetworkDetail{ID: knID}
 	if err != nil {
 		b.logger.WithContext(ctx).Errorf("[BknBackendAccess] GetKnowledgeNetworkDetail request failed, err: %v", err)
-		return result, fmt.Errorf("[BknBackendAccess] GetKnowledgeNetworkDetail request failed, err: %v", err)
+		return result, infraErr.DefaultHTTPError(ctx, respCode,
+			fmt.Sprintf("[BknBackendAccess] GetKnowledgeNetworkDetail request failed, err: %v", err))
 	}
 
 	if respCode == http.StatusNotFound {
 		b.logger.WithContext(ctx).Warnf("[BknBackendAccess] request not found, [%s]", src)
-		return result, fmt.Errorf("[BknBackendAccess] request not found, [%s]", src)
+		return result, infraErr.DefaultHTTPError(ctx, respCode,
+			fmt.Sprintf("[BknBackendAccess] request not found, [%s]", src))
 	}
 
 	if (respCode < http.StatusOK) || (respCode >= http.StatusMultipleChoices) {
@@ -113,12 +115,14 @@ func (b *bknBackendAccess) SearchObjectTypes(ctx context.Context, query *interfa
 	objectTypes = &interfaces.ObjectTypeConcepts{}
 	if err != nil {
 		b.logger.WithContext(ctx).Errorf("[BknBackendAccess] SearchObjectTypes request failed, err: %v", err)
-		return objectTypes, fmt.Errorf("[BknBackendAccess] SearchObjectTypes request failed, err: %v", err)
+		return objectTypes, infraErr.DefaultHTTPError(ctx, respCode,
+			fmt.Sprintf("[BknBackendAccess] SearchObjectTypes request failed, err: %v", err))
 	}
 
 	if respCode == http.StatusNotFound {
 		b.logger.WithContext(ctx).Warnf("[BknBackendAccess] request not found, [%s]", src)
-		return objectTypes, fmt.Errorf("[BknBackendAccess] request not found, [%s]", src)
+		return objectTypes, infraErr.DefaultHTTPError(ctx, respCode,
+			fmt.Sprintf("[BknBackendAccess] request not found, [%s]", src))
 	}
 
 	if (respCode < http.StatusOK) || (respCode >= http.StatusMultipleChoices) {
@@ -167,12 +171,14 @@ func (b *bknBackendAccess) GetObjectTypeDetail(ctx context.Context, knID string,
 	var emptyObjectTypes []*interfaces.ObjectType
 	if err != nil {
 		b.logger.WithContext(ctx).Errorf("[BknBackendAccess] GetObjectTypeDetail request failed, err: %v", err)
-		return emptyObjectTypes, fmt.Errorf("[BknBackendAccess] GetObjectTypeDetail request failed, err: %v", err)
+		return emptyObjectTypes, infraErr.DefaultHTTPError(ctx, respCode,
+			fmt.Sprintf("[BknBackendAccess] GetObjectTypeDetail request failed, err: %v", err))
 	}
 
 	if respCode == http.StatusNotFound {
 		b.logger.WithContext(ctx).Warnf("[BknBackendAccess] request not found, [%s]", src)
-		return emptyObjectTypes, fmt.Errorf("[BknBackendAccess] request not found, [%s]", src)
+		return emptyObjectTypes, infraErr.DefaultHTTPError(ctx, respCode,
+			fmt.Sprintf("[BknBackendAccess] request not found, [%s]", src))
 	}
 
 	if (respCode < http.StatusOK) || (respCode >= http.StatusMultipleChoices) {
@@ -220,12 +226,14 @@ func (b *bknBackendAccess) SearchRelationTypes(ctx context.Context, query *inter
 
 	if err != nil {
 		b.logger.WithContext(ctx).Errorf("[BknBackendAccess] SearchRelationTypes request failed, err: %v", err)
-		return nil, fmt.Errorf("[BknBackendAccess] SearchRelationTypes request failed, err: %v", err)
+		return nil, infraErr.DefaultHTTPError(ctx, respCode,
+			fmt.Sprintf("[BknBackendAccess] SearchRelationTypes request failed, err: %v", err))
 	}
 
 	if respCode == http.StatusNotFound {
 		b.logger.WithContext(ctx).Warnf("[BknBackendAccess] request not found, [%s]", src)
-		return nil, fmt.Errorf("[BknBackendAccess] request not found, [%s]", src)
+		return nil, infraErr.DefaultHTTPError(ctx, respCode,
+			fmt.Sprintf("[BknBackendAccess] request not found, [%s]", src))
 	}
 
 	if (respCode < http.StatusOK) || (respCode >= http.StatusMultipleChoices) {
@@ -275,12 +283,14 @@ func (b *bknBackendAccess) GetRelationTypeDetail(ctx context.Context, knID strin
 	var emptyRelationTypes []*interfaces.RelationType
 	if err != nil {
 		b.logger.WithContext(ctx).Errorf("[BknBackendAccess] GetRelationTypeDetail request failed, err: %v", err)
-		return emptyRelationTypes, fmt.Errorf("[BknBackendAccess] GetRelationTypeDetail request failed, err: %v", err)
+		return emptyRelationTypes, infraErr.DefaultHTTPError(ctx, respCode,
+			fmt.Sprintf("[BknBackendAccess] GetRelationTypeDetail request failed, err: %v", err))
 	}
 
 	if respCode == http.StatusNotFound {
 		b.logger.WithContext(ctx).Warnf("[BknBackendAccess] request not found, [%s]", src)
-		return emptyRelationTypes, fmt.Errorf("[BknBackendAccess] request not found, [%s]", src)
+		return emptyRelationTypes, infraErr.DefaultHTTPError(ctx, respCode,
+			fmt.Sprintf("[BknBackendAccess] request not found, [%s]", src))
 	}
 
 	if (respCode < http.StatusOK) || (respCode >= http.StatusMultipleChoices) {
@@ -326,12 +336,14 @@ func (b *bknBackendAccess) SearchActionTypes(ctx context.Context, query *interfa
 
 	if err != nil {
 		b.logger.WithContext(ctx).Errorf("[BknBackendAccess] SearchActionTypes request failed, err: %v", err)
-		return nil, fmt.Errorf("[BknBackendAccess] SearchActionTypes request failed, err: %v", err)
+		return nil, infraErr.DefaultHTTPError(ctx, respCode,
+			fmt.Sprintf("[BknBackendAccess] SearchActionTypes request failed, err: %v", err))
 	}
 
 	if respCode == http.StatusNotFound {
 		b.logger.WithContext(ctx).Warnf("[BknBackendAccess] request not found, [%s]", src)
-		return nil, fmt.Errorf("[BknBackendAccess] request not found, [%s]", src)
+		return nil, infraErr.DefaultHTTPError(ctx, respCode,
+			fmt.Sprintf("[BknBackendAccess] request not found, [%s]", src))
 	}
 
 	if (respCode < http.StatusOK) || (respCode >= http.StatusMultipleChoices) {
@@ -381,12 +393,14 @@ func (b *bknBackendAccess) GetActionTypeDetail(ctx context.Context, knID string,
 	var emptyActionTypes []*interfaces.ActionType
 	if err != nil {
 		b.logger.WithContext(ctx).Errorf("[BknBackendAccess] GetActionTypeDetail request failed, err: %v", err)
-		return emptyActionTypes, fmt.Errorf("[BknBackendAccess] GetActionTypeDetail request failed, err: %v", err)
+		return emptyActionTypes, infraErr.DefaultHTTPError(ctx, respCode,
+			fmt.Sprintf("[BknBackendAccess] GetActionTypeDetail request failed, err: %v", err))
 	}
 
 	if respCode == http.StatusNotFound {
 		b.logger.WithContext(ctx).Warnf("[BknBackendAccess] request not found, [%s]", src)
-		return emptyActionTypes, fmt.Errorf("[BknBackendAccess] request not found, [%s]", src)
+		return emptyActionTypes, infraErr.DefaultHTTPError(ctx, respCode,
+			fmt.Sprintf("[BknBackendAccess] request not found, [%s]", src))
 	}
 
 	if (respCode < http.StatusOK) || (respCode >= http.StatusMultipleChoices) {
@@ -437,12 +451,14 @@ func (b *bknBackendAccess) CreateFullBuildOntologyJob(ctx context.Context, knID 
 	respCode, respBody, err := b.httpClient.PostNoUnmarshal(ctx, src, header, jobReq)
 	if err != nil {
 		b.logger.WithContext(ctx).Errorf("[BknBackendAccess] CreateFullBuildOntologyJob request failed, err: %v", err)
-		return nil, fmt.Errorf("[BknBackendAccess] CreateFullBuildOntologyJob request failed, err: %v", err)
+		return nil, infraErr.DefaultHTTPError(ctx, respCode,
+			fmt.Sprintf("[BknBackendAccess] CreateFullBuildOntologyJob request failed, err: %v", err))
 	}
 
 	if respCode == http.StatusNotFound {
 		b.logger.WithContext(ctx).Warnf("[BknBackendAccess] request not found, [%s]", src)
-		return nil, fmt.Errorf("[BknBackendAccess] request not found, [%s]", src)
+		return nil, infraErr.DefaultHTTPError(ctx, respCode,
+			fmt.Sprintf("[BknBackendAccess] request not found, [%s]", src))
 	}
 
 	if (respCode < http.StatusOK) || (respCode >= http.StatusMultipleChoices) {
@@ -503,12 +519,14 @@ func (b *bknBackendAccess) ListOntologyJobs(ctx context.Context, knID string, re
 	respCode, respBody, err := b.httpClient.GetNoUnmarshal(ctx, src, queryValues, header)
 	if err != nil {
 		b.logger.WithContext(ctx).Errorf("[BknBackendAccess] ListOntologyJobs request failed, err: %v", err)
-		return nil, fmt.Errorf("[BknBackendAccess] ListOntologyJobs request failed, err: %v", err)
+		return nil, infraErr.DefaultHTTPError(ctx, respCode,
+			fmt.Sprintf("[BknBackendAccess] ListOntologyJobs request failed, err: %v", err))
 	}
 
 	if respCode == http.StatusNotFound {
 		b.logger.WithContext(ctx).Warnf("[BknBackendAccess] request not found, [%s]", src)
-		return nil, fmt.Errorf("[BknBackendAccess] request not found, [%s]", src)
+		return nil, infraErr.DefaultHTTPError(ctx, respCode,
+			fmt.Sprintf("[BknBackendAccess] request not found, [%s]", src))
 	}
 
 	if (respCode < http.StatusOK) || (respCode >= http.StatusMultipleChoices) {

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/index.go
@@ -159,7 +159,7 @@ func (s *findSkillsServiceImpl) FindSkills(ctx context.Context, req *interfaces.
 func (s *findSkillsServiceImpl) loadAndValidateSkillsContract(ctx context.Context, knID, skillsObjectTypeID string) (*interfaces.ObjectType, error) {
 	objectTypes, err := s.bknBackend.GetObjectTypeDetail(ctx, knID, []string{skillsObjectTypeID}, true)
 	if err != nil {
-		return nil, infraErr.DefaultHTTPError(ctx, http.StatusBadGateway, err.Error())
+		return nil, err
 	}
 	if len(objectTypes) == 0 {
 		return nil, infraErr.DefaultHTTPError(ctx, http.StatusNotFound, map[string]interface{}{
@@ -203,7 +203,7 @@ func (s *findSkillsServiceImpl) loadAndValidateSkillsContract(ctx context.Contex
 func (s *findSkillsServiceImpl) validateObjectTypeExists(ctx context.Context, knID, objectTypeID string) error {
 	objectTypes, err := s.bknBackend.GetObjectTypeDetail(ctx, knID, []string{objectTypeID}, false)
 	if err != nil {
-		return infraErr.DefaultHTTPError(ctx, http.StatusBadGateway, err.Error())
+		return err
 	}
 	if len(objectTypes) > 0 {
 		return nil


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] `bkn_backend.go`: 将 9 个方法中所有 `fmt.Errorf` 错误包装替换为 `infraErr.DefaultHTTPError`，透传实际 `respCode` 并填充完整的错误字段（Code/Description/Solution/ErrorLink/ErrorDetails）
- [x] `knfindskills/index.go`: `loadAndValidateSkillsContract` 和 `validateObjectTypeExists` 中 `GetObjectTypeDetail` 返回的 error 直接透传，不再二次包装为 502

---

## Why

- 背景：调用 `find_skills` 接口时，传入不存在的 `object_type_id`，期望返回 HTTP 404，实际返回 502
- 根因：`bkn_backend.go` 中网络错误和 404 响应使用 `fmt.Errorf` 包装，丢失了结构化的 HTTP 状态码信息。上游 `knfindskills` 无法通过 `errors.As` 提取 `*HTTPError`，因此统一回退为 502

---

## How

- 关键实现：
  1. **适配器层（bkn_backend.go）**：所有 `fmt.Errorf` 替换为 `infraErr.DefaultHTTPError(ctx, respCode, details)`，保证错误对象携带真实的 HTTP 状态码和完整的 i18n 错误信息
  2. **业务逻辑层（knfindskills/index.go）**：移除 `DefaultHTTPError(ctx, http.StatusBadGateway, ...)` 的二次包装，直接 `return err` 透传适配器层已构造好的结构化错误
- 破坏性变更：无。错误返回类型从 `fmt.Errorf` 变为 `*infraErr.HTTPError`，上游通过 `errors.As` 或 `rest.ReplyError` 均可正确处理

---

## Testing

- [x] 本地单元测试通过（`go test ./server/drivenadapters/...` 和 `go test ./server/logics/knfindskills/...`）
- [x] 本地编译通过（`go build ./...`）

测试说明：已有测试覆盖了 404 和网络错误场景，验证返回的 error 类型为 `*infraErr.HTTPError` 且 HTTPCode 正确

---

## Risk & Rollback

- 潜在风险：`err != nil` 时 `respCode` 可能为 0（纯网络层错误如 DNS 解析失败），此时 `DefaultHTTPError` 会回退为 500（InternalServerError）而非 502。这是已知行为，后续可按需优化
- 回滚方案：revert 本次提交即可，无数据库或配置变更

---

## Additional Notes

- 涉及 `bkn_backend.go` 的 9 个方法：`GetKnowledgeNetworkDetail`、`SearchObjectTypes`、`GetObjectTypeDetail`、`SearchRelationTypes`、`GetRelationTypeDetail`、`SearchActionTypes`、`GetActionTypeDetail`、`CreateFullBuildOntologyJob`、`ListOntologyJobs`
- 每个方法修改 2 处（网络错误 + 404 响应），共 18 处