### PR TITLE
docs: add KWeaver Core 0.6.0 release notes (zh + en)

### DIFF
--- a/release-notes/0.6.0/KWeaver Core 0.6.0 Release Notes.md
+++ b/release-notes/0.6.0/KWeaver Core 0.6.0 Release Notes.md
@@ -1,0 +1,267 @@
+# KWeaver Core 0.6.0 Release Notes
+
+---
+
+## Overview
+
+### KWeaver Core 0.6.0 is Now Available
+
+**Enterprise Decision Intelligence Ecosystem — End-to-End Skill Pipeline**
+
+KWeaver Core 0.6.0 is centered on **end-to-end Skill pipeline integration**, connecting Skill capabilities across every platform layer: from business knowledge network modeling and Context Loader semantic retrieval, through the Execution Factory unified execution layer, to Decision Agent perception and invocation — forming a complete closed loop. This release also delivers seamless integration of VEGA with the AnyShare enterprise knowledge base, bringing mainstream enterprise unstructured data sources under unified business knowledge network management. The sandbox runtime gains archive upload with auto-extraction and shell script execution capabilities, greatly expanding agent code execution flexibility. Deployment memory footprint has been reduced to 24 GB. `kweaver-eval` ships its first Acceptance module, covering 104 test cases across 6 core modules with a dual-scoring framework (deterministic assertions + Agent Judge), marking a new phase of systematic quality governance for KWeaver Core.
+
+---
+
+## Highlights
+
+**1. End-to-End Skill Pipeline — Skills Integrated Across All Platform Layers**
+
+0.6.0 completes the full Skill pipeline across KWeaver Core: BKN supports modeling Skill object types within knowledge networks; Context Loader adds the `find_skills` tool for semantic Skill candidate retrieval within knowledge network boundaries; the Execution Factory adds a Skill execution endpoint with dual Dataset writes; Decision Agent gains native Skill loading from the Execution Factory; and KWeaver SDK fully integrates with the Execution Factory Skill management module. Skills are no longer isolated functional units — they are governable, retrievable, and executable agent capabilities deeply integrated with business knowledge networks.
+
+**2. AnyShare Enterprise Knowledge Base Integration — Unified Unstructured Data Source Management**
+
+VEGA completes Catalog integration with AnyShare enterprise knowledge bases, supporting Discover commands to scan and enumerate accessible knowledge bases (up to 1,000 entries per page), and modeling AnyShare document data into the business knowledge network via BKN object types. Three authentication methods are supported — application account, permanent token, and SSO single sign-on — enabling enterprise-grade permission-aware queries. The Resource layer adds real-time streaming incremental builds and custom view support, continuously enhancing data virtualization capabilities.
+
+**3. Sandbox Runtime Upgrade — Expanded Agent Execution Boundaries**
+
+Sandbox 0.3.2 adds archive upload with auto-extraction, supporting ZIP packages uploaded to Session Workspaces with automatic extraction to specified paths, including built-in path traversal protection. Shell script execution is now supported with a `working_directory` parameter, covering chained commands, relative path execution, and other complex scenarios. Together, these capabilities give agents complete Skill package deployment and script execution abilities in code execution contexts.
+
+**4. KWeaver SDK — Skill Management and Dataflow CLI, Significantly Improved Developer Experience**
+
+KWeaver SDK now fully integrates the Execution Factory Skill management module, adding the `kweaver skill` command family covering the complete Skill lifecycle: registration, installation, lookup, read, status query, and content download. The new `kweaver dataflow` command family supports uploading local files or triggering Dataflow unstructured data processing pipelines via remote URLs, enabling the SDK to cover the full end-to-end chain of "file upload → document parsing → knowledge network construction → agent Q&A". The new `kweaver explore` command launches a local browser SPA with four views: platform status overview, BKN browser, Decision Agent streaming chat (with Trace), and VEGA data preview. Multi-account profile management is also introduced.
+
+**5. Deployment Memory Reduced to 24 GB — Lower Enterprise Adoption Barrier**
+
+0.6.0 reduces full-stack deployment memory (ADP + ISF + Core) to under 24 GB, significantly lower than previous versions. Combined with the `kweaver-eval` first Acceptance module — 104 test cases across 6 core modules using a dual-scoring framework — this release provides a strong engineering foundation for ongoing platform quality governance.
+
+---
+
+## Detailed Feature Notes
+
+### [VEGA Data Virtualization]
+
+0.6.0 delivers significant capability expansions in both data source connectivity and Resource construction. AnyShare enterprise knowledge base integration is the most critical VEGA breakthrough in this release.
+
+**1. AnyShare Knowledge Base Integration (Catalog)**
+
+VEGA Catalog now supports AnyShare enterprise knowledge base connectivity. The Discover command automatically scans the list of knowledge bases accessible to the current account (up to 1,000 entries per page) and retrieves complete Resource metadata for each (name, ID, type, creator, modifier, DNS address, field definitions, etc.).
+
+Three authentication methods are supported to accommodate different enterprise deployment scenarios:
+- **Application Account**: AppID + Secret, suitable for integrated deployments
+- **Permanent Token**: suitable for high-privilege operations environments
+- **SSO Single Sign-On**: integrated with the KWeaver account system; the current user's permissions are passed through to AnyShare, enabling user-level data permission isolation
+
+The current version prioritizes AnyShare knowledge library type; document libraries and other types will be covered in subsequent iterations.
+
+**2. Real-Time Streaming Incremental Resource Builds**
+
+Resource now supports real-time streaming incremental build mode, enabling incremental data sync based on incremental fields in addition to full builds. Compared to full builds, incremental builds process only data added or changed since the last build, significantly reducing data update costs for time-sensitive scenarios.
+
+**3. Custom Resource Views**
+
+Custom views can now be defined for Resources, allowing flexible configuration of field mappings and vector index structures to meet different business retrieval needs, further enhancing VEGA's flexibility at the data virtualization layer.
+
+**4. Large Dataset Query Stability Optimization**
+
+Targeted performance optimization for Catalog and Resource list interfaces under large dataset conditions, improving system stability for large-scale knowledge base integration scenarios.
+
+---
+
+### [BKN Engine]
+
+0.6.0 completes BKN integration with VEGA Resources, allowing object types in business knowledge networks to be directly bound to VEGA data resources, connecting the business semantic modeling layer with the data virtualization layer.
+
+**1. BKN Integration with VEGA Resources**
+
+BKN object types can now be bound to VEGA Resource data sources (supporting AnyShare knowledge bases, MySQL, Dataset, and more), enabling unified querying and retrieval of data from multiple heterogeneous data sources through the business knowledge network. Once bound, real data in the corresponding Resource can be retrieved via BKN's `ontology_query` interface, closing the loop between semantic modeling and data access within the same knowledge network.
+
+Two object creation modes are supported:
+- **Strict Mode (`strict_mode=true`)**: validates the existence of the associated Resource when creating an object type; returns an error if not found
+- **Non-strict Mode (`strict_mode=false`)**: skips dependency existence checks and creates the object type directly, suitable for phased modeling workflows
+
+**2. Stability Fixes**
+
+Fixed an error when updating object types or action types without an associated branch; fixed abnormal list ordering after binding a Resource to an object type, improving stability of business knowledge network editing operations.
+
+---
+
+### [Context Loader]
+
+0.6.0 adds the `find_skills` tool, bringing Skill candidate discovery into the Context Loader toolset and closing the loop on Skills at the semantic retrieval layer.
+
+**1. find_skills: Skill Candidate Discovery within Knowledge Network Boundaries**
+
+The new `find_skills` tool supports discovering Skill candidates within a specified `kn_id` and business context boundary, completing coverage of the Context Loader `find_*` semantic tool family.
+
+Key features:
+- **Dual Retrieval Modes**: supports object-type-level retrieval (find Skills under a specified object type) and instance-level retrieval (find Skills associated with a specific instance); network-level retrieval will be released in a future version
+- **Minimal Metadata Response**: returns only `skill_id`, `name`, and `description`, minimizing token consumption
+- **Basic Contract Validation**: automatically validates that the `skills` ObjectType exists in the knowledge network and contains at least `skill_id` and `name` data properties at the entry point; returns a clear error if not satisfied, preventing invalid retrievals
+
+> Note: `find_skills` is a candidate resource discovery tool and does not replace `kn_search` / `query_object_instance`. `object_type_id` is a required parameter. Skills must already be registered and bound in the knowledge network for retrieval results to be reliable.
+
+**2. Unified Response Format Support**
+
+A new `response_format` parameter supports `json` and `toon` formats:
+- HTTP interfaces default to `json` for backward compatibility
+- MCP Tools default to `toon` compressed format to reduce token consumption
+- Error responses always use JSON format
+
+The `x-account-id` and `x-account-type` parameter conventions across Context Loader tools have also been unified to simplify caller integration.
+
+---
+
+### [Execution Factory]
+
+0.6.0 adds a Skill execution endpoint, bringing Skill execution under unified Execution Factory management with support for dual Dataset writes of execution results.
+
+**1. Skill Execution Endpoint and Dataset Dual-Write**
+
+The Execution Factory adds a dedicated Skill execution endpoint, supporting invocation of registered Skills through a unified interface and synchronous writes of execution results to Dataset, enabling persistent storage of Skill output data. Dataset data can subsequently be queried by BKN object type bindings, forming a complete data loop of "execute → store → retrieve".
+
+**2. Stability Fixes**
+
+Fixed a failure in composite operator creation; fixed a nil pointer dereference panic when streaming forwarding is missing a ResponseWriter; optimized service startup logic to avoid index initialization blocking startup, switching to a background retry mechanism to improve service availability.
+
+---
+
+### [Decision Agent]
+
+0.6.0 completes Decision Agent's full integration with Execution Factory Skill capabilities, giving the agent the complete ability to perceive, load, and invoke Skills from the knowledge network.
+
+**1. Native Skill Loading in Agents**
+
+`agent-factory` adds Skill type support, with full Skill configuration support across agent create, detail view, update handlers, and run services. Agents can now read and load available Skills from the Execution Factory at runtime, enabling native Skill perception and invocation.
+
+Related database migrations are complete (v0.6.0 Skill-related tables and `agent-memory` history tables, covering DM8 and MariaDB).
+
+**2. TraceAI Evidence Chain Support**
+
+`agent-executor` adds TraceAI Evidence request header support, introducing an `enable_traceai_evidence` feature flag (configured in `FeaturesConfig`). When enabled, `X-TraceAi-Enable-Evidence` is automatically injected into API tool proxy requests, enabling Evidence data collection across all call chains beyond Decision Agent for unified full-chain evidence extraction.
+
+**3. Publish Request Validation Improvement**
+
+Refactored `agent-factory` publish request validation to use constructor semantics for field validation and sanitization. Validation failures now return clear 400 errors instead of 500, improving API error diagnosability.
+
+---
+
+### [Sandbox Runtime]
+
+0.6.0 corresponds to Sandbox 0.3.2, adding archive upload and Shell execution capabilities that significantly expand agent flexibility and applicability in code execution scenarios.
+
+**1. Archive Upload and Auto-Extraction**
+
+Adds Session Workspace archive upload capability, supporting ZIP archives uploaded to specified Workspace paths with automatic extraction:
+
+- **Overwrite Control**: configurable conflict behavior; upload responses include overwrite statistics and extraction result metadata
+- **Path Safety**: built-in path safety validation rejects illegal entries and path traversal content (Path Traversal protection)
+- **Skill Package Deployment**: combined with Skill execution capabilities, supports one-shot upload and deployment of entire Skill dependency packages to the Sandbox environment
+
+**2. Shell Script Execution**
+
+Adds `language=shell` execution mode in `execute` and `execute-sync` endpoints:
+
+- **Working Directory Control**: optional `working_directory` parameter specifies the script execution working directory
+- **Command Normalization**: automatically normalizes incorrectly prefixed `bash/sh` commands
+- **Scenario Coverage**: supports chained commands, relative path execution, and other complex Shell script scenarios with complete end-to-end test coverage
+
+**3. Helm Chart Image Configuration**
+
+Unified Sandbox Helm Chart image configuration to the top-level `image` values structure, enabling offline packaging tools to fully extract all images from Chart values, simplifying offline installation for private deployments.
+
+---
+
+### [KWeaver SDK]
+
+0.6.0 completes KWeaver SDK integration with the Execution Factory Skill management module, and adds `kweaver explore` interactive exploration and multi-account management capabilities to further enhance developer experience.
+
+**1. Skill Management Commands**
+
+SDK CLI adds the `kweaver skill` command family, covering the complete Skill lifecycle from registration to execution:
+
+- `skill list`: list currently available Skills
+- `skill market`: browse the Skill marketplace
+- `skill get`: retrieve configuration details, input/output parameter definitions for a specified Skill
+- `skill register`: register a Skill to the Execution Factory under unified execution management
+- `skill install`: trigger Skill dependency installation and runtime environment initialization
+- `skill status`: query Skill installation/runtime status
+- `skill content` / `read-file`: read Skill content and associated files
+- `skill download`: download the Skill package
+
+**2. kweaver explore: Local Visual Platform Exploration**
+
+The new `kweaver explore` command launches a local browser SPA with four interactive views: platform status aggregation overview, BKN knowledge network browser (object types / relation types / instances / subgraphs), Decision Agent streaming chat (with real-time execution Trace), and VEGA Catalog and data preview. Developers can quickly validate platform data and agent behavior without opening the full platform UI.
+
+**3. Dataflow CLI — End-to-End Unstructured Data Pipeline**
+
+The new `kweaver dataflow` command family supports operating Dataflow document processing pipelines directly from the SDK:
+
+- `dataflow list`: list all Dataflow DAGs
+- `dataflow run <dagId> --file <path>`: upload a local file (PDF, Word, etc.) to directly trigger unstructured data processing
+- `dataflow run <dagId> --url <url> --name <filename>`: trigger via remote URL without local upload
+- `dataflow runs <dagId>`: view run history for a specified DAG, with `--since` time filtering
+- `dataflow logs <dagId> <instanceId>`: view step-by-step execution logs; `--detail` expands full input/output payloads per step
+
+Combined with Dataflow document parsing nodes, Execution Factory Skill dual-write to Dataset, BKN object type binding, and Context Loader semantic retrieval, the SDK now covers the complete end-to-end pipeline of "file upload → document parsing → knowledge network construction → agent Q&A".
+
+**4. Multi-Account Management and Auth Enhancements**
+
+Multi-account profile management support is added, allowing developers to manage login sessions for multiple KWeaver instances on a single machine:
+
+- `--alias` parameter names login accounts; `auth use` switches between accounts quickly
+- Global `--user` flag enables per-command credential override without changing the global account
+- `--port` and `--redirect-uri` support custom OAuth2 callback addresses for complex network environments
+- Stale client auto-recovery reduces re-authentication frequency
+
+---
+
+### [TraceAI]
+
+0.6.0 corresponds to TraceAI 0.2.2, completing Helm Chart image version management optimization to ensure packaged Charts inherit the version numbers resolved by the release pipeline, keeping image tags strongly consistent with actual release images.
+
+---
+
+### [kweaver-eval]
+
+0.6.0 ships the first version of the `kweaver-eval` Acceptance module, providing independent acceptance testing for the full KWeaver Core stack. Coverage spans **6 core modules** — **Agent, BKN, VEGA, Data Sources (DS), Dataview, and Context Loader** — with **104 test cases**, of which **79 pass (76%)**.
+
+**1. Test Case Coverage Overview**
+
+| Module | Cases | Passed | Known Issues |
+|--------|-------|--------|--------------|
+| Agent (Decision Agent) | 33 | 33 | 0 |
+| BKN Engine | 26 | 23 | 3 |
+| VEGA + DS + Dataview | 27 | 19 | 6 |
+| Context Loader | 3 | 3 | 0 |
+| Dataflow | 14 | TBD | — |
+| Token Refresh | 1 | 1 | 0 |
+
+The Agent module covers CRUD lifecycle, single-turn/multi-turn/streaming conversations, conversational robustness (concurrent sessions, special character input, long messages, cross-turn context retention), and error paths — 33 cases, all passing. The Dataflow module's 14 test cases were activated on the 0.6.0 release date with the `kweaver dataflow` CLI.
+
+**2. Dual-Scoring Framework**
+
+Each test case produces two scoring dimensions:
+
+- **Deterministic Assertions**: validates exit codes, JSON structure, and field values; applied to all cases
+- **Agent Judge Semantic Evaluation**: uses the Claude API to score semantic correctness of outputs, supporting CRITICAL / HIGH / MEDIUM / LOW severity classification; selectively enabled per case
+
+**3. Cross-Run Issue Tracking and Upstream Defect Feedback**
+
+A built-in cross-run issue tracking mechanism (`feedback.json` persistence) automatically identifies defects that appear across consecutive runs and escalates them for human follow-up. Acceptance testing has already surfaced and tracked **20+ upstream defects** (including adp#427, adp#428, adp#442, adp#445, adp#447, adp#448, and others), establishing an engineering quality feedback loop between kweaver-eval and upstream repositories.
+
+---
+
+## Release Resources
+
+### GitHub Repositories
+
+**KWeaver Core**
+- GitHub Release: https://github.com/kweaver-ai/kweaver-core/tree/release/0.6.0
+
+**KWeaver SDK**
+- GitHub: https://github.com/kweaver-ai/kweaver-sdk
+
+**kweaver-eval**
+- GitHub: https://github.com/kweaver-ai/kweaver-eval
+
+---

--- a/release-notes/0.6.0/KWeaver Core 0.6.0 版本发布通知.md
+++ b/release-notes/0.6.0/KWeaver Core 0.6.0 版本发布通知.md
@@ -1,0 +1,267 @@
+# KWeaver Core 0.6.0 版本发布通知
+
+---
+
+## 版本概述
+
+### KWeaver Core 0.6.0 版本正式发布
+
+**企业决策智能生态，Skill 能力全链路贯通**
+
+KWeaver Core 0.6.0 以 **Skill 全链路打通**为核心主题，将Skill能力从业务知识网络建模、Context Loader 语义召回、执行工厂统一执行，到 Decision Agent 智能体感知与调用，形成端到端完整闭环。本版本同步完成 VEGA 对 AnyShare 企业知识库的无缝接入，将主流企业非结构化数据源纳入业务知识网络统一管理体系；沙箱运行时新增压缩包上传自动解压与 Shell 脚本执行能力，大幅提升智能体代码执行的灵活性；整体部署内存压缩至 24G，显著降低企业落地门槛。与此同时，`kweaver-eval` 首版 Acceptance 模块正式建成，覆盖 6 大核心模块 104 个用例，以"确定性断言 + Agent Judge 语义评估"双维度体系对平台全栈进行独立验收，标志着 KWeaver Core 的工程质量治理能力进入系统化阶段。
+
+---
+
+## KWeaver Core 0.6.0 版本核心亮点速览
+
+**1. Skill 全链路打通，技能能力贯穿平台各层**
+
+0.6.0 版本完成 Skill 在 KWeaver 核心平台的全链路打通：BKN 支持在知识网络中建模 Skill 对象类；Context Loader 新增 `find_skills` 工具，支持在知识网络边界内语义召回 Skill 候选；执行工厂新增 Skill 执行接口并支持双写 Dataset；Decision Agent 完成对执行工厂 Skill 的读取与加载；KWeaver SDK 同步对接执行工厂 Skill 管理模块。技能不再是孤立的功能单元，而是与业务知识网络深度融合的可治理、可召回、可执行的智能体能力。
+
+**2. AnyShare 企业知识库接入，非结构化数据源统一纳管**
+
+VEGA 完成对 AnyShare 企业知识库的 Catalog 对接，支持通过 Discover 命令扫描发现 AnyShare 知识库（单页上限 1000 条），并通过 BKN 对象类建模将 AnyShare 文档数据纳入业务知识网络统一管理。支持应用账号、永久 Token 及 SSO 一键登录三种认证方式，实现企业级权限穿透查询。Resource 层同步新增实时流式增量构建与自定义视图能力，数据虚拟化构建能力持续完善。
+
+**3. Sandbox 沙箱运行时升级，智能体执行边界大幅拓展**
+
+沙箱运行时 0.3.2 版本新增压缩包上传与自动解压能力，支持将 ZIP 包整体上传至 Session Workspace 并自动解压到指定路径，内置路径安全校验防止路径穿越；新增 Shell 脚本执行支持，提供 `working_directory` 工作目录参数，覆盖链式命令、相对路径执行等复杂场景。两项能力联合，使智能体在代码执行场景下具备完整的 Skill 包部署与脚本执行能力。
+
+**4. KWeaver SDK Skill 管理与 Dataflow CLI 全面上线，开发者体验大幅升级**
+
+KWeaver SDK 本版完成对执行工厂 Skill 管理模块的全面对接，新增 `kweaver skill` 命令族，覆盖 Skill 注册、安装、查找、读取、状态查询及内容下载全生命周期。新增 `kweaver dataflow` 命令族，支持直接上传本地文件或通过远程 URL 触发 Dataflow 非结构化数据处理流程，SDK 现可端到端覆盖「文件上传 → 文档解析 → 知识网络构建 → 智能体问答」全链路。新增 `kweaver explore` 命令，在本地启动浏览器 SPA，提供平台状态概览、BKN 浏览器、Decision Agent 流式对话（含 Trace）与 VEGA 数据预览四个视图；同步引入多账号 Profile 管理，支持 `--alias` 命名、`--user` 单命令级凭证覆盖与过期客户端自动恢复，显著提升 CI/容器环境下的开发者体验。
+
+**5. 部署内存降至 24G，企业落地门槛大幅降低**
+
+0.6.0 版本完成整体部署优化，ADP + ISF + Core 全量部署内存降低至 24G 以内，相比此前版本显著降低。配合 `kweaver-eval` 首版 Acceptance 模块建成，覆盖 6 大核心模块 104 个用例，采用"确定性断言 + Agent Judge"双维度评测体系，为平台质量持续治理提供工程基础。
+
+---
+
+## 详细功能说明
+
+### 【VEGA 数据虚拟化】
+
+0.6.0 版本在数据源接入与 Resource 构建两个方向均完成重要能力扩展，AnyShare 企业知识库接入是本版本 VEGA 最核心的能力突破。
+
+**1. AnyShare 知识库接入（Catalog 对接）**
+
+VEGA Catalog 完成对 AnyShare 企业知识库的接入支持，通过 Discover 命令自动扫描当前账号下可访问的知识库列表（单页检索上限 1000 条），并获取每个知识库的完整 Resource 元数据（名称、ID、类型、创建者、修改者、DNS 地址、字段定义等）。
+
+支持三种认证方式以适配不同企业部署场景：
+- **应用账号**：提供 AppID + Secret，适合集成部署
+- **永久 Token**：适合高权限运维场景
+- **SSO 一键登录**：与 KWeaver 账号体系打通，当前登录者权限透传至 AnyShare，实现用户级数据权限隔离
+
+当前版本优先支持 AnyShare 知识库类型接入，文档库等其他类型将在后续迭代中逐步覆盖。
+
+**2. Resource 实时流式增量构建**
+
+Resource 新增实时流式增量构建模式，在全量构建的基础上支持基于增量字段的实时数据同步。相比全量构建，增量构建仅处理自上次构建以来新增或变更的数据，大幅降低数据更新成本，满足对数据时效性要求较高的场景。
+
+**3. Resource 自定义视图**
+
+支持对 Resource 定义自定义视图，用户可灵活配置字段映射与向量索引结构，满足不同业务场景的检索需求，进一步提升 VEGA 在数据虚拟化层的灵活性。
+
+**4. 大数据量查询稳定性优化**
+
+针对 Catalog 和 Resource 列表接口在大数据量场景下的查询性能问题进行专项优化，提升大规模知识库接入场景下的系统稳定性。
+
+---
+
+### 【BKN 引擎】
+
+0.6.0 版本完成 BKN 与 VEGA Resource 的对接，使业务知识网络中的对象类可直接绑定到 VEGA 数据资源，打通了业务语义建模与数据虚拟化层的连接通路。
+
+**1. BKN 对接 VEGA Resource**
+
+BKN 对象类现可绑定至 VEGA Resource 数据源（支持 AnyShare 知识库、MySQL、Dataset 等类型），实现通过业务知识网络统一查询和召回来自多个异构数据源的数据。绑定完成后，通过 BKN 的 `ontology_query` 接口即可检索对应 Resource 中的真实数据，语义建模与数据访问在同一知识网络中完成闭合。
+
+支持两种对象创建模式：
+- **严格模式（strict_mode=true）**：创建对象类时校验关联 Resource 的存在性，不存在则报错拦截
+- **非严格模式（strict_mode=false）**：忽略依赖资源存在性检查，直接创建对象类，适合分步建模场景
+
+**2. 稳定性修复**
+
+修复对象类、行动类在无 Branch 状态下更新时报错的问题；修复对象类绑定 Resource 后列表排序异常的问题，提升业务知识网络编辑操作的稳定性。
+
+---
+
+### 【Context Loader】
+
+0.6.0 版本新增 `find_skills` 工具，将 Skill 候选发现能力引入 Context Loader 工具体系，完成技能在语义召回层的闭环。
+
+**1. find_skills：知识网络边界内的 Skill 候选发现**
+
+新增 `find_skills` 工具，支持在指定 `kn_id` 和业务上下文边界内发现 Skill 候选，补全 Context Loader `find_*` 语义工具族的能力覆盖。
+
+核心特性：
+- **双召回模式**：支持对象类级召回（在指定对象类下查找 Skill）和实例级召回（在特定实例关联的 Skill 中查找），网络级召回后续开放
+- **最小化元数据返回**：返回 `skill_id`、`name`、`description` 三项核心信息，降低 Token 消耗
+- **基础契约校验**：入口自动校验知识网络中 `skills` ObjectType 是否存在且至少包含 `skill_id`、`name` 数据属性，不满足时直接返回明确错误，避免无效召回
+
+> 注意：`find_skills` 属于候选资源发现工具，不替代 `kn_search` / `query_object_instance`；`object_type_id` 为必填参数；网络中须已完成 Skill 承接和绑定，召回结果才能稳定可用。
+
+**2. 统一响应格式支持**
+
+新增 `response_format` 参数，支持 `json` 和 `toon` 两种格式：
+- HTTP 接口默认返回 `json`，向后兼容
+- MCP Tool 默认返回 `toon` 压缩格式，降低 Token 消耗
+- 错误响应统一保持 JSON 格式
+
+同步统一了 Context Loader 各工具的 `x-account-id`、`x-account-type` 参数口径，简化调用方接入配置。
+
+---
+
+### 【执行工厂】
+
+0.6.0 版本新增 Skill 执行接口，将技能执行能力纳入执行工厂统一管理，并支持执行结果双写 Dataset。
+
+**1. Skill 执行接口与 Dataset 双写**
+
+执行工厂新增专用 Skill 执行接口，支持通过统一接口调用已注册的 Skill，并将执行结果同步写入 Dataset，实现技能产出数据的持久化沉淀。Dataset 数据可供后续 BKN 对象类绑定查询，形成"执行→存储→召回"的完整数据闭环。
+
+**2. 稳定性修复**
+
+修复组合算子创建失败的问题；修复流式转发在缺少 ResponseWriter 时 nil 指针解引用导致 panic 的问题；优化服务启动逻辑，避免索引初始化阻塞启动，改为后台重试机制，提升服务可用性。
+
+---
+
+### 【Decision Agent】
+
+0.6.0 版本完成 Decision Agent 对执行工厂 Skill 能力的全面接入，智能体具备了从知识网络中感知、读取并调用 Skill 的完整能力。
+
+**1. Agent 内置 Skill 读取与加载能力**
+
+`agent-factory` 新增 Skill 类型支持，在 Agent 创建、详情查看、更新处理器及运行服务中全面支持 Skill 配置，智能体可在运行时从执行工厂读取并加载可用 Skill，实现对 Skill 的原生感知与调用。
+
+相关数据库迁移已完成（v0.6.0 Skill 相关表及 `agent-memory` 历史表，覆盖 DM8 和 MariaDB）。
+
+**2. TraceAI Evidence 链路补充**
+
+`agent-executor` 新增 TraceAI Evidence 请求头支持，引入 `enable_traceai_evidence` 功能开关（在 `FeaturesConfig` 中配置），开启后在 API 工具代理请求中自动注入 `X-TraceAi-Enable-Evidence` 请求头，打通 Decision Agent 以外其他调用链的 Evidence 数据采集通路，实现全链路证据提取的统一覆盖。
+
+**3. 发布请求校验优化**
+
+重构 `agent-factory` 发布请求校验逻辑，采用构造函数语义对请求字段进行校验和清洗，校验失败时返回明确的 400 错误信息而非 500，提升接口错误的可诊断性。
+
+---
+
+### 【沙箱运行时】
+
+0.6.0 版本对应 Sandbox 0.3.2，新增压缩包上传与 Shell 执行两项能力，显著提升智能体在代码执行场景下的灵活性与适用范围。
+
+**1. 压缩包上传与自动解压**
+
+新增 Session Workspace 压缩包上传能力，支持将 ZIP 格式压缩包上传至指定 Workspace 路径并自动解压：
+
+- **覆盖控制**：支持配置冲突时的覆盖行为，上传响应中包含覆盖统计和解压结果元数据
+- **路径安全**：内置路径安全校验，拒绝非法条目与路径穿越内容（Path Traversal 防护）
+- **Skill 包部署**：配合 Skill 执行能力，支持将整个 Skill 依赖包一次性上传部署到 Sandbox 环境
+
+**2. Shell 脚本执行支持**
+
+新增 `language=shell` 执行模式，在 `execute` 与 `execute-sync` 接口中支持 Shell 脚本直接执行：
+
+- **工作目录控制**：支持通过可选 `working_directory` 参数指定脚本执行的工作目录
+- **命令规范化**：对误写 `bash/sh` 前缀命令进行自动规范化处理
+- **场景覆盖**：支持链式命令、相对路径执行等复杂 Shell 脚本场景，端到端测试覆盖完整
+
+**3. Helm Chart 镜像配置优化**
+
+将 Sandbox Helm Chart 镜像配置统一规范至顶层 `image` values 结构，支持离线打包工具从 Chart values 中完整提取所有镜像，简化私有化部署的离线安装流程。
+
+---
+
+### 【KWeaver SDK】
+
+0.6.0 版本完成 KWeaver SDK 与执行工厂 Skill 管理模块的对接，并新增 `kweaver explore` 交互式探索命令与多账号管理能力，进一步提升开发者与智能体在平台上的操作体验。
+
+**1. Skill 管理命令全面上线**
+
+SDK CLI 新增 `kweaver skill` 命令族，覆盖 Skill 从注册到执行的完整生命周期：
+
+- `skill list`：列出当前可用的 Skill
+- `skill market`：浏览 Skill 市场
+- `skill get`：获取指定 Skill 的配置详情、输入输出参数定义
+- `skill register`：将 Skill 注册到执行工厂，纳入统一执行能力管理体系
+- `skill install`：触发 Skill 依赖安装与运行环境初始化
+- `skill status`：查询 Skill 安装/运行状态
+- `skill content` / `read-file`：读取 Skill 内容与附属文件
+- `skill download`：下载 Skill 包
+
+**2. kweaver explore：本地可视化平台探索**
+
+新增 `kweaver explore` 命令，在本地启动一个浏览器 SPA，提供四个交互式探索视图：平台状态聚合概览、BKN 知识网络浏览器（对象类/关系类/实例/子图）、Decision Agent 流式对话（含实时执行 Trace 展示）、VEGA Catalog 与数据预览。开发者无需打开完整平台 UI，即可快速验证平台数据与智能体效果。
+
+**3. Dataflow CLI 上线，非结构化数据构建 KN 全链路打通**
+
+新增 `kweaver dataflow` 命令族，支持通过 SDK 直接操作 Dataflow 文档处理流程：
+
+- `dataflow list`：列举当前所有 Dataflow DAG
+- `dataflow run <dagId> --file <path>`：上传本地文件（PDF、Word 等）直接触发非结构化数据处理流程
+- `dataflow run <dagId> --url <url> --name <filename>`：通过远程 URL 触发，无需本地上传
+- `dataflow runs <dagId>`：查看指定 DAG 的运行记录，支持 `--since` 按时间过滤
+- `dataflow logs <dagId> <instanceId>`：查看逐步骤执行日志，`--detail` 可展开每步 input/output 完整载荷
+
+结合 Dataflow 文档解析节点、执行工厂 Skill 双写 Dataset、BKN 对象类绑定与 Context Loader 语义召回，SDK 现可端到端覆盖「文件上传 → 文档解析 → 知识网络构建 → 智能体问答」全链路，并可通过 OpenClaw 完整演示效果。
+
+**4. 多账号管理与认证增强**
+
+新增多账号 Profile 管理支持，开发者可在同一机器上管理多个 KWeaver 实例的登录态：
+
+- `--alias` 参数支持为登录账号命名，`auth use` 在多账号间快速切换
+- 全局 `--user` 标志支持单条命令级别的凭证覆盖，无需切换全局账号
+- 支持通过 `--port` 和 `--redirect-uri` 自定义 OAuth2 回调地址，适配复杂网络环境
+- 过期客户端自动恢复（stale client auto-recovery），减少重新登录频率
+
+---
+
+### 【TraceAI】
+
+0.6.0 对应 TraceAI 0.2.2，完成 Helm Chart 镜像版本管理优化，确保打包出的 Chart 可以继承发布流程解析出的版本号，镜像标签与实际发布镜像保持强一致。
+
+---
+
+### 【kweaver-eval】
+
+0.6.0 版本完成 `kweaver-eval` 模块初版建设，对 KWeaver Core 全栈进行独立验收，覆盖 **Agent、BKN、VEGA、数据源（DS）、数据视图（Dataview）、Context Loader** 6 大核心模块，共 **104 个用例**，当前 **79 个用例通过（76%）**。
+
+**1. 用例覆盖概览**
+
+| 模块 | 用例数 | 通过 | 已知缺陷 |
+|------|--------|------|----------|
+| Agent（Decision Agent） | 33 | 33 | 0 |
+| BKN 引擎 | 26 | 23 | 3 |
+| VEGA + DS + Dataview | 27 | 19 | 6 |
+| Context Loader | 3 | 3 | 0 |
+| Dataflow | 14 | 待统计 | — |
+| Token 刷新 | 1 | 1 | 0 |
+
+Agent 模块覆盖了 CRUD 生命周期、单轮/多轮/流式对话、对话健壮性（并发会话、特殊字符输入、长消息、上下文跨轮保持）及错误路径共 33 个用例，全部通过。Dataflow 模块 14 个测试用例已随 `kweaver dataflow` CLI 于 0.6.0 发布当日正式激活。
+
+**2. 双维度评测体系**
+
+每个测试用例均产出两个评分维度：
+
+- **确定性断言**：验证退出码、JSON 结构、字段值，覆盖所有用例
+- **Agent Judge 语义评估**：通过 Claude API 对输出结果进行语义正确性评分，支持 CRITICAL / HIGH / MEDIUM / LOW 四级严重度定级，按用例选启
+
+**3. 跨运行 Issue 追踪与上游缺陷反馈**
+
+内置跨运行 Issue 追踪机制（`feedback.json` 持久化），自动识别连续出现的缺陷并升级为需人工跟进状态。已通过验收测试发现并跟踪反馈 **20+ 个上游缺陷**（含 adp#427、adp#428、adp#442、adp#445、adp#447、adp#448 等），形成 kweaver-eval 与上游仓库之间的工程质量反馈闭环。
+
+---
+
+## 版本发布
+
+### 1. GitHub 安装包和技术文档
+
+**KWeaver Core**
+- GitHub Release: https://github.com/kweaver-ai/kweaver-core/tree/release/0.6.0
+
+**KWeaver SDK**
+- GitHub: https://github.com/kweaver-ai/kweaver-sdk
+
+**kweaver-eval**
+- GitHub: https://github.com/kweaver-ai/kweaver-eval
+
+---


### PR DESCRIPTION
## Summary

- Add `release-notes/0.6.0/KWeaver Core 0.6.0 版本发布通知.md` — Chinese release announcement
- Add `release-notes/0.6.0/KWeaver Core 0.6.0 Release Notes.md` — English release announcement

Both documents cover: Skill end-to-end pipeline, AnyShare integration, Sandbox 0.3.2, KWeaver SDK (skill commands + dataflow CLI + explore), TraceAI 0.2.2, and kweaver-eval first Acceptance module (104 cases, 6 modules).