### PR TITLE
docs(examples): improve 01-db-to-qa robustness and add bilingual READMEs

### DIFF
--- a/examples/01-db-to-qa/README.md
+++ b/examples/01-db-to-qa/README.md
@@ -10,10 +10,19 @@ CLI.
 # 1. Install the KWeaver CLI
 npm install -g @kweaver-ai/kweaver-sdk
 
-# 2. Authenticate to a KWeaver platform
+# 2. Install the MySQL **client** on the machine where you run ./run.sh (for Step 0: seed.sql)
+#    macOS:   brew install mysql-client
+#    Ubuntu:  sudo apt install -y mysql-client
+#    On macOS, run.sh also looks for Homebrew mysql-client under /opt/homebrew and /usr/local if mysql is not on PATH.
+#    If it is still not found, set MYSQL_BIN in .env to the full path (see env.sample).
+
+# 3. Authenticate to a KWeaver platform
 kweaver auth login https://<platform-url>
 
-# 3. Ensure a MySQL database is reachable from the platform
+# 4. Ensure a MySQL database is reachable from the platform
+#    Create the database first if needed (e.g. CREATE DATABASE supply_chain …).
+#    The DB user must have rights on that database — `kweaver_rw` is often only for `kweaver_app`,
+#    while `supply_chain` may use a different user (e.g. `kweaver` on that schema).
 #    The script imports seed.sql automatically (a fictional smart-home company).
 ```
 
@@ -53,6 +62,12 @@ vim .env
 ./run.sh
 ```
 
+**`DB_NAME`**: Set this to a database that **already exists** on the server (e.g. `supply_chain_test`). Step 0 imports `seed.sql` into **that** database only. Older versions of this example hardcoded `supply_chain` inside `seed.sql` and ignored `DB_NAME`; current `run.sh` passes `DB_NAME` to the MySQL client so your setting is honored.
+
+**`DB_HOST` vs `DB_HOST_SEED`**: Step 0 runs **`mysql` on your PC**; Step 1 runs **`kweaver ds connect`**, where the **platform** opens the DB connection. If your laptop only reaches the server via **public IP** but pods must use **VPC internal IP**, set **`DB_HOST`** to the internal address (for Step 1) and optionally **`DB_HOST_SEED`** to the public address (for Step 0). If unset, `DB_HOST_SEED` defaults to `DB_HOST`.
+
+**`DEBUG`**: Set `DEBUG=1` (or `true`) in `.env` to print host, `kweaver` version, `kweaver config show`, raw JSON from `ds connect` / `create-from-ds`, and `agent chat --verbose`. Passwords are never printed.
+
 ## Step-by-Step
 
 See `run.sh` for the complete script. Key commands:
@@ -75,6 +90,12 @@ kweaver context-loader kn-search "supply chain"
 # Chat with an agent
 kweaver agent chat <agent-id> -m "What are the main suppliers?"
 ```
+
+## Troubleshooting
+
+### `ERROR 1044 ... Access denied ... to database '<name>'`
+
+The MySQL user in `.env` has no privilege on the database you set as `DB_NAME` (the error shows the real name, e.g. `supply_chain_test`). For example, `kweaver_rw` is often restricted to `kweaver_app` only. User `kweaver` may have `supply_chain.*` but not another database until a DBA runs `GRANT ... ON your_db.*`. Create the database first, then ensure your user can `CREATE TABLE` / `INSERT` there.
 
 ## Cleanup
 

--- a/examples/01-db-to-qa/README.zh.md
+++ b/examples/01-db-to-qa/README.zh.md
@@ -1,0 +1,127 @@
+# 01 - 从数据库到智能问答
+
+端到端示例：连接 MySQL 数据库，构建知识网络，探索 Schema，语义搜索，并通过 Agent 对话回答业务问题 —— 全程 CLI 操作。
+
+## 前置条件
+
+```bash
+# 1. 安装 KWeaver CLI
+npm install -g @kweaver-ai/kweaver-sdk
+
+# 2. 安装 MySQL 客户端（run.sh 的 Step 0 需要在本机执行 mysql 导入 seed.sql）
+#    macOS:   brew install mysql-client
+#    Ubuntu:  sudo apt install -y mysql-client
+#    macOS 下脚本还会自动搜索 Homebrew 的 /opt/homebrew 和 /usr/local 路径。
+#    如果仍找不到，可在 .env 中设置 MYSQL_BIN 指定完整路径（见 env.sample）。
+
+# 3. 登录 KWeaver 平台
+kweaver auth login https://<platform-url>
+
+# 4. 确保 MySQL 数据库可从平台访问
+#    需要提前创建好数据库（例如 CREATE DATABASE supply_chain_test ...）。
+#    DB 用户必须拥有该数据库的权限 —— kweaver_rw 通常只能访问 kweaver_app，
+#    如需其他数据库请 DBA 单独授权。
+#    脚本会自动导入 seed.sql（虚构的智能家居供应链数据）。
+```
+
+## 这个示例做了什么
+
+```
+MySQL 数据库
+     │
+     ▼
+┌─────────────┐     ┌──────────────┐     ┌─────────────────┐
+│  数据源连接   │────▶│   知识网络    │────▶│  上下文加载器     │
+│  (ds connect)│     │   (KN)       │     │  语义搜索        │
+└─────────────┘     └──────────────┘     └─────────────────┘
+                           │
+                           ▼
+                    ┌──────────────┐     ┌─────────────────┐
+                    │  Schema 探索  │     │   Agent 对话     │
+                    │  (对象类/属性) │     │   (智能问答)      │
+                    └──────────────┘     └─────────────────┘
+```
+
+0. **导入数据** — 将示例数据 (`seed.sql`，虚构的智能家居供应链) 导入 MySQL
+1. **连接数据源** — 将 MySQL 数据库注册到平台
+2. **创建知识网络** — 基于数据源自动发现表结构并构建知识网络
+3. **探索 Schema** — 查看自动识别的对象类型和属性
+4. **语义搜索** — 用自然语言检索知识图谱
+5. **Agent 对话** — 向 Agent 提问，基于数据库内容进行智能问答
+
+## 快速开始
+
+```bash
+# 复制配置模板，填写数据库连接信息
+cp env.sample .env
+vim .env
+
+# 运行完整流程
+./run.sh
+```
+
+## 配置说明
+
+### `DB_NAME`
+
+设置为服务器上**已存在**的数据库名（如 `supply_chain_test`）。Step 0 会将 `seed.sql` 导入到该数据库中。
+
+### `DB_HOST` 与 `DB_HOST_SEED`
+
+- `DB_HOST`：**平台内部访问**的数据库地址（Step 1 的 `kweaver ds connect` 使用），通常是云服务器**内网 IP**（如 `172.19.0.9`）
+- `DB_HOST_SEED`：**本机导数据**的地址（Step 0 的 `mysql` 客户端使用），如果本机无法访问内网 IP，可设为**公网 IP**
+
+如果不设 `DB_HOST_SEED`，默认使用 `DB_HOST`。
+
+### `DEBUG`
+
+在 `.env` 中设置 `DEBUG=1`（或 `true`）可打印详细诊断信息：主机地址、`kweaver` 版本、配置、API 原始 JSON 等（不会泄露密码）。
+
+## 关键命令
+
+```bash
+# 连接数据源
+kweaver ds connect mysql $DB_HOST $DB_PORT $DB_NAME \
+  --account $DB_USER --password $DB_PASS --name "my-datasource"
+
+# 从数据源创建知识网络
+kweaver bkn create-from-ds <datasource-id> --name "my-kn" --build
+
+# 探索 Schema
+kweaver bkn object-type list <kn-id>
+
+# 配置上下文加载器并搜索
+kweaver context-loader config set --kn-id <kn-id>
+kweaver context-loader kn-search "供应链"
+
+# 与 Agent 对话
+kweaver agent chat <agent-id> -m "主要供应商有哪些？"
+```
+
+## 常见问题
+
+### `ERROR 1044 ... Access denied ... to database '<name>'`
+
+`.env` 中的 MySQL 用户对 `DB_NAME` 指定的数据库没有权限。例如 `kweaver_rw` 通常只被授权 `kweaver_app` 库。需要 DBA 执行：
+
+```sql
+GRANT ALL PRIVILEGES ON `your_db`.* TO 'your_user'@'%';
+FLUSH PRIVILEGES;
+```
+
+### `504 Gateway Time-out`
+
+Agent 对话超时（Nginx 默认 60 秒）。脚本已使用 `--stream` 流式模式避免此问题。如仍出现，可在 Ingress 上增加超时配置：
+
+```yaml
+nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+```
+
+## 清理
+
+脚本退出时会自动清理创建的资源（知识网络、数据源）。手动清理：
+
+```bash
+kweaver bkn delete <kn-id> -y
+kweaver ds delete <datasource-id> -y
+```

--- a/examples/01-db-to-qa/env.sample
+++ b/examples/01-db-to-qa/env.sample
@@ -1,9 +1,20 @@
 # Database connection (MySQL)
+# Optional: path to mysql client if not on PATH (e.g. Homebrew on macOS)
+# MYSQL_BIN=/opt/homebrew/opt/mysql-client/bin/mysql
+
+# Host for kweaver ds connect — must be reachable from K8s pods (often cloud *internal* IP, e.g. 172.x).
 DB_HOST=192.168.40.105
+# Optional: host for Step 0 only (mysql on your laptop). Use *public* IP if the PC cannot route to DB_HOST.
+# DB_HOST_SEED=203.0.113.10
 DB_PORT=3306
+# Must already exist. User needs CREATE/DROP/INSERT on this database (DDL for tables in seed.sql).
+# Example: user `kweaver` often has access to `supply_chain`; `kweaver_rw` is typically only `kweaver_app`.
 DB_NAME=supply_chain
 DB_USER=root
 DB_PASS=changeme
 
 # Agent ID to chat with (from `kweaver agent list`)
 AGENT_ID=
+
+# Set to 1 or true for extra diagnostics (paths, kweaver config, API JSON bodies; passwords never printed)
+# DEBUG=1

--- a/examples/01-db-to-qa/run.sh
+++ b/examples/01-db-to-qa/run.sh
@@ -8,6 +8,25 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
+# ── Debug helpers (set DEBUG=1 or DEBUG=true in .env) ───────────────────────
+# Never logs DB_PASS.
+DEBUG="${DEBUG:-0}"
+debug() {
+    if [ "$DEBUG" = "1" ] || [ "$DEBUG" = "true" ]; then
+        echo "[debug] $*" >&2
+    fi
+}
+
+debug_dump_json() {
+    local label="$1"
+    local payload="$2"
+    if [ "$DEBUG" = "1" ] || [ "$DEBUG" = "true" ]; then
+        echo "[debug] --- ${label} (raw) ---" >&2
+        echo "$payload" >&2
+        echo "[debug] --- end ${label} ---" >&2
+    fi
+}
+
 # ── Load config ──────────────────────────────────────────────────────────────
 if [ -f "$SCRIPT_DIR/.env" ]; then
     # shellcheck disable=SC1091
@@ -15,10 +34,49 @@ if [ -f "$SCRIPT_DIR/.env" ]; then
 fi
 
 DB_HOST="${DB_HOST:?Set DB_HOST in .env}"
+# Optional: host for Step 0 only (mysql on your PC). Use public IP / VPN-reachable address if your laptop
+# cannot reach DB_HOST (e.g. DB_HOST is a cloud internal IP like 172.x for kweaver ds connect).
+DB_HOST_SEED="${DB_HOST_SEED:-$DB_HOST}"
 DB_PORT="${DB_PORT:-3306}"
 DB_NAME="${DB_NAME:?Set DB_NAME in .env}"
 DB_USER="${DB_USER:?Set DB_USER in .env}"
 DB_PASS="${DB_PASS:?Set DB_PASS in .env}"
+
+# MySQL client binary (must be installed locally; only `kweaver` talks to the platform)
+MYSQL_BIN="${MYSQL_BIN:-mysql}"
+if ! command -v "$MYSQL_BIN" >/dev/null 2>&1; then
+    # Default name not on PATH: common Homebrew layouts (Intel / Apple Silicon) without requiring PATH
+    if [ "$MYSQL_BIN" = "mysql" ]; then
+        _brew_mysql="$(brew --prefix mysql-client 2>/dev/null)/bin/mysql"
+        for _p in "$_brew_mysql" /opt/homebrew/opt/mysql-client/bin/mysql /usr/local/opt/mysql-client/bin/mysql; do
+            if [ -x "$_p" ]; then
+                MYSQL_BIN="$_p"
+                break
+            fi
+        done
+    fi
+fi
+if ! command -v "$MYSQL_BIN" >/dev/null 2>&1; then
+    echo "Error: MySQL client not found (${MYSQL_BIN}). Step 0 runs mysql on your machine to import seed.sql."
+    echo "  macOS:  brew install mysql-client"
+    echo "          export PATH=\"\$(brew --prefix mysql-client)/bin:\$PATH\""
+    echo "  Ubuntu: sudo apt install -y mysql-client"
+    echo "  Or set MYSQL_BIN in .env to the full path of the mysql executable."
+    exit 1
+fi
+
+debug "script: $SCRIPT_DIR/run.sh"
+debug "host: $(hostname 2>/dev/null || true) date: $(date -Iseconds 2>/dev/null || date)"
+debug "MYSQL_BIN=$MYSQL_BIN"
+debug "kweaver=$(command -v kweaver 2>/dev/null || echo 'not found')"
+if command -v kweaver >/dev/null 2>&1; then
+    debug "kweaver version: $(kweaver --version 2>&1 || true)"
+fi
+if [ "$DEBUG" = "1" ] || [ "$DEBUG" = "true" ]; then
+    echo "[debug] DB_HOST=$DB_HOST (kweaver ds connect / platform) DB_HOST_SEED=$DB_HOST_SEED (local mysql Step 0) DB_PORT=$DB_PORT DB_NAME=$DB_NAME DB_USER=$DB_USER DB_PASS=***" >&2
+    echo "[debug] kweaver config (first lines):" >&2
+    kweaver config show 2>&1 | head -25 >&2 || true
+fi
 
 TIMESTAMP=$(date +%s)
 DS_NAME="example_ds_${TIMESTAMP}"
@@ -39,7 +97,14 @@ trap cleanup EXIT
 
 # ── Step 0: Seed the database ───────────────────────────────────────────────
 echo "=== Step 0: Seed sample data into MySQL ==="
-mysql -h "$DB_HOST" -P "$DB_PORT" -u "$DB_USER" -p"$DB_PASS" < "$SCRIPT_DIR/seed.sql"
+if [ "$DB_HOST_SEED" != "$DB_HOST" ]; then
+    echo "  (from this PC: $DB_HOST_SEED:$DB_PORT — platform will use $DB_HOST in Step 1)"
+fi
+debug "Step 0: mysql client imports seed.sql into default database $DB_NAME"
+debug "Step 0: note — this runs on YOUR machine; platform pods use DB_HOST from Step 1."
+debug "Step 0: mysql args (password hidden): -h $DB_HOST_SEED -P $DB_PORT -u $DB_USER -p*** $DB_NAME < seed.sql"
+# Pass DB_NAME as the default database (seed.sql has no USE — works with schema-only users)
+"$MYSQL_BIN" -h "$DB_HOST_SEED" -P "$DB_PORT" -u "$DB_USER" -p"$DB_PASS" "$DB_NAME" < "$SCRIPT_DIR/seed.sql"
 echo "  Imported seed.sql → ${DB_NAME} (erp_material_bom, erp_purchase_order)"
 
 # ── Step 1: Connect datasource ──────────────────────────────────────────────
@@ -47,19 +112,33 @@ echo ""
 echo "=== Step 1: Connect MySQL datasource ==="
 echo "  Host: $DB_HOST:$DB_PORT  Database: $DB_NAME"
 
+debug "Step 1: kweaver ds connect mysql $DB_HOST $DB_PORT $DB_NAME --name $DS_NAME"
 DS_JSON=$(kweaver ds connect mysql "$DB_HOST" "$DB_PORT" "$DB_NAME" \
     --account "$DB_USER" --password "$DB_PASS" --name "$DS_NAME")
+debug_dump_json "ds connect response" "$DS_JSON"
 
-DS_ID=$(echo "$DS_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('datasource_id',''))")
+DS_ID=$(echo "$DS_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('datasource_id',''))" 2>/dev/null || true)
+if [ -z "$DS_ID" ]; then
+    echo "Error: could not parse datasource_id from kweaver ds connect output." >&2
+    debug_dump_json "ds connect (parse failed)" "$DS_JSON"
+    exit 1
+fi
 echo "  Datasource created: $DS_ID"
 
 # ── Step 2: Create Knowledge Network ────────────────────────────────────────
 echo ""
 echo "=== Step 2: Create Knowledge Network from datasource ==="
 
+debug "Step 2: kweaver bkn create-from-ds $DS_ID --name $KN_NAME --build"
 KN_JSON=$(kweaver bkn create-from-ds "$DS_ID" --name "$KN_NAME" --build)
+debug_dump_json "create-from-ds response" "$KN_JSON"
 
-KN_ID=$(echo "$KN_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('kn_id',''))")
+KN_ID=$(echo "$KN_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('kn_id',''))" 2>/dev/null || true)
+if [ -z "$KN_ID" ]; then
+    echo "Error: could not parse kn_id from kweaver bkn create-from-ds output." >&2
+    debug_dump_json "create-from-ds (parse failed)" "$KN_JSON"
+    exit 1
+fi
 echo "  Knowledge Network created: $KN_ID"
 
 # Show auto-discovered object types
@@ -165,12 +244,17 @@ ${SCHEMA_RAW}
     echo "  Question: $QUESTION"
     echo ""
 
-    RESPONSE=$(kweaver agent chat "$AGENT_ID" \
-        -m "$PROMPT" \
-        --no-stream 2>/dev/null)
-
+    debug "Step 5: kweaver agent chat $AGENT_ID --stream"
     echo "  Agent response:"
-    echo "$RESPONSE" | fold -s -w 80 | sed 's/^/    /'
+    if [ "$DEBUG" = "1" ] || [ "$DEBUG" = "true" ]; then
+        kweaver agent chat "$AGENT_ID" \
+            -m "$PROMPT" \
+            --stream --verbose 2>&1 | sed 's/^/    /'
+    else
+        kweaver agent chat "$AGENT_ID" \
+            -m "$PROMPT" \
+            --stream 2>/dev/null | sed 's/^/    /'
+    fi
 fi
 
 echo ""

--- a/examples/01-db-to-qa/seed.sql
+++ b/examples/01-db-to-qa/seed.sql
@@ -1,8 +1,8 @@
 -- supply_chain sample data for KWeaver 01-db-to-qa example
 -- Fictional smart-home company — all names are fabricated
-
-CREATE DATABASE IF NOT EXISTS supply_chain DEFAULT CHARACTER SET utf8mb4;
-USE supply_chain;
+--
+-- The database must already exist. run.sh connects with: mysql ... "$DB_NAME" < seed.sql
+-- (Do not put CREATE DATABASE / USE here — the MySQL user may only have schema rights on that DB.)
 
 DROP TABLE IF EXISTS `erp_material_bom`;
 CREATE TABLE `erp_material_bom` (

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,26 @@
+# KWeaver Examples
+
+[中文版](./README.zh.md)
+
+End-to-end examples that demonstrate core KWeaver capabilities using the CLI.
+
+| Example | Description |
+|---------|-------------|
+| [01-db-to-qa](./01-db-to-qa/) | Connect a MySQL database, build a Knowledge Network, and chat with an Agent — from raw tables to intelligent Q&A in one script. |
+
+## Getting Started
+
+Each example is self-contained. Enter the directory, copy `env.sample` to `.env`, fill in your credentials, and run the script:
+
+```bash
+cd 01-db-to-qa
+cp env.sample .env
+vim .env
+./run.sh
+```
+
+All examples require the KWeaver CLI (`npm install -g @kweaver-ai/kweaver-sdk`) and an authenticated platform (`kweaver auth login`). See the README inside each example for specific prerequisites.
+
+## Cleanup
+
+Scripts clean up resources (datasources, knowledge networks) automatically on exit. See individual READMEs for manual cleanup commands.

--- a/examples/README.zh.md
+++ b/examples/README.zh.md
@@ -1,0 +1,26 @@
+# KWeaver 示例
+
+[English](./README.md)
+
+通过 CLI 演示 KWeaver 核心能力的端到端示例。
+
+| 示例 | 说明 |
+|------|------|
+| [01-db-to-qa](./01-db-to-qa/) | 连接 MySQL 数据库，构建知识网络，与 Agent 对话 —— 一个脚本完成从原始表到智能问答的全流程。 |
+
+## 快速开始
+
+每个示例独立运行。进入目录，复制 `env.sample` 为 `.env`，填写连接信息，执行脚本：
+
+```bash
+cd 01-db-to-qa
+cp env.sample .env
+vim .env
+./run.sh
+```
+
+所有示例需要安装 KWeaver CLI（`npm install -g @kweaver-ai/kweaver-sdk`）并已登录平台（`kweaver auth login`）。各示例的 README 中有详细的前置条件说明。
+
+## 清理
+
+脚本退出时会自动清理创建的资源（数据源、知识网络）。手动清理命令见各示例 README。


### PR DESCRIPTION
## Summary

- **run.sh**: add DEBUG mode, mysql-client auto-detection (macOS Homebrew + Ubuntu), `DB_HOST_SEED` for split public/internal IP access, switch agent chat from `--no-stream` to `--stream` to avoid Nginx 504 timeout
- **seed.sql**: remove hardcoded `CREATE DATABASE` / `USE` so `DB_NAME` from `.env` is respected
- **env.sample**: document `DB_HOST_SEED`, `MYSQL_BIN`, `DEBUG` options with clear comments
- **README.md**: add troubleshooting section (Access denied, 504 timeout), `DB_HOST` vs `DB_HOST_SEED` explanation
- **New**: `01-db-to-qa/README.zh.md` — full Chinese translation of the example README
- **New**: `examples/README.md` + `README.zh.md` — bilingual index for the examples directory

## Test plan

- [ ] Run `./run.sh` with `DEBUG=1` against a MySQL database to verify full flow
- [ ] Verify `DB_HOST_SEED` correctly separates local import IP from platform internal IP
- [ ] Confirm agent chat completes without 504 using stream mode