### PR TITLE
fix(examples): 修复 02-csv-to-kn run.sh 实例解析与 agent 提示词问题

### DIFF
--- a/examples/02-csv-to-kn/README.md
+++ b/examples/02-csv-to-kn/README.md
@@ -1,0 +1,127 @@
+# 02 - From CSV Files to Knowledge Graph
+
+End-to-end example: import local CSV files, build a Knowledge Network, explore
+the graph, run semantic search, and chat with an Agent.
+
+**No SQL knowledge required** — bring your own CSV files and let KWeaver
+discover the schema and relationships automatically.
+
+## What This Example Does
+
+```
+CSV Files (local)
+     │
+     ▼
+┌─────────────────────┐     ┌──────────────┐
+│  bkn create-from-csv │────▶│  Knowledge   │
+│  (import + build)    │     │   Network    │
+└─────────────────────┘     └──────┬───────┘
+                                   │
+              ┌────────────────────┼───────────────────┐
+              ▼                    ▼                   ▼
+       ┌────────────┐     ┌──────────────┐    ┌───────────────┐
+       │   Schema   │     │   Subgraph   │    │  Agent Q&A    │
+       │  Explore   │     │  Traversal   │    │ (with context)│
+       └────────────┘     └──────────────┘    └───────────────┘
+```
+
+0. **Connect** a MySQL datasource (backing store for the imported tables)
+1. **Import** CSV files and build a Knowledge Network — one command
+2. **Explore** auto-discovered object types and their properties
+3. **Query** object instances
+4. **Traverse** the graph with subgraph queries (depth 2)
+5. **Search** the knowledge schema semantically via context-loader
+6. **Export** the KN definition to a portable file
+7. **Chat** with an Agent to answer business questions
+
+### Sample Data
+
+The `data/` directory contains a fictional HR dataset:
+
+| File | Contents |
+|------|----------|
+| `departments.csv` | 5 departments with budget and headcount |
+| `employees.csv` | 16 employees with role, level, salary, manager |
+| `projects.csv` | 8 projects with status, budget, owner |
+
+## Prerequisites
+
+```bash
+# 1. Install the KWeaver CLI
+npm install -g @kweaver-ai/kweaver-sdk
+
+# 2. Authenticate to a KWeaver platform
+kweaver auth login https://<platform-url>
+
+# 3. MySQL database reachable from the platform
+#    (used as backing store — the script creates the tables automatically)
+```
+
+## Quick Start
+
+```bash
+cd examples/02-csv-to-kn
+cp env.sample .env
+vim .env          # set DB_HOST, DB_NAME, DB_USER, DB_PASS
+./run.sh
+```
+
+### Using Your Own CSV Files
+
+Replace the files in `data/` with your own CSVs — KWeaver will discover the
+schema automatically. Requirements:
+
+- First row must be a header
+- File name becomes the table (and object type) name
+- All columns are imported; numeric columns are detected automatically
+
+## What You'll See
+
+```
+=== Step 1: Connect datasource ===
+  Datasource: d7abc...
+
+=== Step 2: Import CSVs and build Knowledge Network ===
+  Files: departments.csv employees.csv projects.csv
+  Knowledge Network: d7def...
+  Auto-discovered object types (3):
+    - departments
+    - employees
+    - projects
+
+=== Step 3: Explore schema ===
+  Object types (3):
+    - departments  (5 properties)  id=...
+    - employees    (9 properties)  id=...
+    - projects     (8 properties)  id=...
+
+=== Step 5: Subgraph traversal ===
+  Starting from instance: emp_001
+  Graph: 12 nodes, 8 edges
+
+=== Step 7: Export Knowledge Network ===
+  Exported: 3 object types, 0 relation types
+```
+
+## Key CLI Commands Used
+
+| Command | What it does |
+|---------|-------------|
+| `kweaver ds connect mysql ...` | Register MySQL as backing datasource |
+| `kweaver bkn create-from-csv <ds-id> --files data/*.csv --build` | Import CSVs and build KN in one step |
+| `kweaver bkn object-type list <kn-id>` | List auto-discovered object types |
+| `kweaver bkn object-type query <kn-id> <ot-id> --limit 5` | Query instances |
+| `kweaver bkn subgraph <kn-id> <instance-id> --depth 2` | Graph traversal |
+| `kweaver context-loader kn-search "..." --kn-id <kn-id> --only-schema` | Semantic search |
+| `kweaver bkn export <kn-id>` | Export KN definition |
+| `kweaver agent chat <agent-id> -m "..."` | Chat with schema context |
+
+## Differences from Example 01
+
+| | 01-db-to-qa | 02-csv-to-kn |
+|---|---|---|
+| Data source | Existing MySQL database | Local CSV files |
+| Ingestion | `ds connect` + `create-from-ds` | `create-from-csv` (one step) |
+| Schema setup | Write SQL seed file | Just bring CSVs |
+| Graph feature | Semantic search + Q&A | Subgraph traversal + export |
+| Data domain | Supply chain (BOM, orders) | HR (employees, projects) |

--- a/examples/02-csv-to-kn/README.zh.md
+++ b/examples/02-csv-to-kn/README.zh.md
@@ -1,0 +1,94 @@
+# 02 - 从 CSV 文件到知识图谱
+
+端到端示例：导入本地 CSV 文件 → 构建知识网络 → 图谱探索 → 语义搜索 → Agent 问答。
+
+**无需了解 SQL** —— 只要带上 CSV 文件，KWeaver 自动识别 schema 和关系。
+
+## 示例流程
+
+```
+本地 CSV 文件
+     │
+     ▼
+┌─────────────────────┐     ┌──────────────┐
+│  bkn create-from-csv │────▶│   知识网络    │
+│  （导入 + 构建）     │     └──────┬───────┘
+└─────────────────────┘            │
+              ┌────────────────────┼───────────────────┐
+              ▼                    ▼                   ▼
+       ┌────────────┐     ┌──────────────┐    ┌───────────────┐
+       │  Schema 探索 │     │   子图遍历   │    │  Agent 问答   │
+       └────────────┘     └──────────────┘    └───────────────┘
+```
+
+0. **连接** MySQL 数据源（用于存放导入的表）
+1. **一条命令**导入 CSV 并构建知识网络
+2. **探索**自动发现的对象类型和属性
+3. **查询**对象实例
+4. **子图遍历**（depth=2，多跳图查询）
+5. **语义搜索**（通过 context-loader）
+6. **导出** KN 定义文件
+7. **Agent 对话**（注入 schema 上下文）
+
+### 示例数据
+
+`data/` 目录包含一份虚构的 HR 数据集：
+
+| 文件 | 内容 |
+|------|------|
+| `departments.csv` | 5 个部门，含预算和人数 |
+| `employees.csv` | 16 名员工，含职级、薪资、汇报关系 |
+| `projects.csv` | 8 个项目，含状态、预算、负责人 |
+
+## 前置条件
+
+```bash
+# 1. 安装 KWeaver CLI
+npm install -g @kweaver-ai/kweaver-sdk
+
+# 2. 登录平台
+kweaver auth login https://<platform-url>
+
+# 3. 准备一个平台可访问的 MySQL 数据库
+#    （脚本会自动在其中创建表，无需手动建表）
+```
+
+## 快速开始
+
+```bash
+cd examples/02-csv-to-kn
+cp env.sample .env
+vim .env   # 填写 DB_HOST、DB_NAME、DB_USER、DB_PASS
+./run.sh
+```
+
+### 使用自己的 CSV 文件
+
+将 `data/` 目录中的文件替换为你自己的 CSV 即可。要求：
+
+- 第一行为列名（header）
+- 文件名会成为表名和对象类型名
+- 所有列自动导入，数值列自动识别类型
+
+## 与示例 01 的区别
+
+| | 01-db-to-qa | 02-csv-to-kn |
+|---|---|---|
+| 数据来源 | 已有 MySQL 数据库 | 本地 CSV 文件 |
+| 数据导入 | `ds connect` + `create-from-ds` | `create-from-csv`（一步完成） |
+| Schema 准备 | 编写 SQL seed 文件 | 直接带 CSV |
+| 图谱特性展示 | 语义搜索 + 问答 | **子图遍历** + 导出 |
+| 数据领域 | 供应链（BOM、采购订单） | **HR（员工、部门、项目）** |
+
+## 涉及的 CLI 命令
+
+| 命令 | 作用 |
+|------|------|
+| `kweaver ds connect mysql ...` | 注册 MySQL 数据源 |
+| `kweaver bkn create-from-csv <ds-id> --files data/*.csv --build` | 导入 CSV 并构建 KN |
+| `kweaver bkn object-type list <kn-id>` | 列出自动发现的对象类型 |
+| `kweaver bkn object-type query <kn-id> <ot-id> --limit 5` | 查询实例 |
+| `kweaver bkn subgraph <kn-id> <instance-id> --depth 2` | 子图遍历 |
+| `kweaver context-loader kn-search "..." --kn-id <kn-id> --only-schema` | 语义搜索 |
+| `kweaver bkn export <kn-id>` | 导出 KN 定义 |
+| `kweaver agent chat <agent-id> -m "..."` | 对话（含 schema 上下文） |

--- a/examples/02-csv-to-kn/data/departments.csv
+++ b/examples/02-csv-to-kn/data/departments.csv
@@ -1,0 +1,6 @@
+id,name,location,budget_cny,head_count
+dept_01,Engineering,Shanghai,12000000,42
+dept_02,Product,Shanghai,6000000,18
+dept_03,Sales,Beijing,8000000,35
+dept_04,Operations,Shanghai,5000000,22
+dept_05,Finance,Shanghai,3000000,12

--- a/examples/02-csv-to-kn/data/employees.csv
+++ b/examples/02-csv-to-kn/data/employees.csv
@@ -1,0 +1,17 @@
+id,name,department_id,role,level,hire_date,manager_id,salary_cny
+emp_001,Zhang Wei,dept_01,Engineering Manager,M2,2018-03-15,,380000
+emp_002,Li Na,dept_01,Senior Engineer,P6,2019-07-22,emp_001,280000
+emp_003,Wang Fang,dept_01,Engineer,P5,2021-04-10,emp_001,200000
+emp_004,Chen Jian,dept_01,Engineer,P5,2022-01-18,emp_001,195000
+emp_005,Liu Yang,dept_01,Senior Engineer,P6,2020-09-01,emp_001,265000
+emp_006,Zhao Min,dept_02,Product Director,M3,2017-06-20,,420000
+emp_007,Sun Hua,dept_02,Senior Product Manager,P6,2019-11-05,emp_006,300000
+emp_008,Zhou Xin,dept_02,Product Manager,P5,2021-08-30,emp_006,220000
+emp_009,Wu Lei,dept_03,Sales Director,M3,2016-04-12,,450000
+emp_010,Zheng Yan,dept_03,Senior Account Manager,P6,2018-10-28,emp_009,310000
+emp_011,Ma Tao,dept_03,Account Manager,P5,2020-03-17,emp_009,240000
+emp_012,He Jing,dept_03,Account Manager,P5,2021-12-06,emp_009,230000
+emp_013,Gao Peng,dept_04,Operations Manager,M2,2019-02-25,,360000
+emp_014,Lin Mei,dept_04,Senior Operations Specialist,P5,2020-07-14,emp_013,210000
+emp_015,Xu Bo,dept_05,Finance Manager,M2,2018-08-08,,340000
+emp_016,Song Qian,dept_05,Senior Accountant,P5,2020-05-19,emp_015,205000

--- a/examples/02-csv-to-kn/data/projects.csv
+++ b/examples/02-csv-to-kn/data/projects.csv
@@ -1,0 +1,9 @@
+id,name,department_id,status,start_date,end_date,budget_cny,owner_id
+proj_01,AI Platform v2,dept_01,active,2024-01-10,2024-12-31,2000000,emp_001
+proj_02,Data Pipeline Refactor,dept_01,active,2024-03-01,2024-09-30,800000,emp_002
+proj_03,Mobile App Redesign,dept_02,active,2024-02-15,2024-08-31,1200000,emp_007
+proj_04,CRM Integration,dept_03,completed,2023-06-01,2024-03-31,600000,emp_010
+proj_05,Supply Chain Dashboard,dept_04,active,2024-04-01,2024-11-30,900000,emp_013
+proj_06,Annual Budget Planning,dept_05,completed,2023-10-01,2024-01-31,200000,emp_015
+proj_07,Search Engine Upgrade,dept_01,planning,2024-07-01,2025-02-28,1500000,emp_005
+proj_08,Enterprise Sales Expansion,dept_03,active,2024-05-01,2024-12-31,1800000,emp_009

--- a/examples/02-csv-to-kn/env.sample
+++ b/examples/02-csv-to-kn/env.sample
@@ -1,0 +1,12 @@
+# Database connection — used as backing store for CSV import (same config as 01-db-to-qa if you ran it)
+DB_HOST=192.168.40.105
+DB_PORT=3306
+DB_NAME=supply_chain
+DB_USER=root
+DB_PASS=changeme
+
+# Agent ID to chat with (from `kweaver agent list`). Optional — chat step is skipped if unset.
+AGENT_ID=
+
+# Set to 1 for verbose output (API request/response bodies; passwords never printed)
+# DEBUG=1

--- a/examples/02-csv-to-kn/run.sh
+++ b/examples/02-csv-to-kn/run.sh
@@ -1,0 +1,329 @@
+#!/usr/bin/env bash
+# =============================================================================
+# 02-csv-to-kn: From CSV Files to Knowledge Graph
+#
+# Import local CSV files → Knowledge Network → Graph Exploration → Agent Q&A
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# ── CLI flags ────────────────────────────────────────────────────────────────
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [options]
+
+Options:
+  -h, --help   Show this help.
+
+Environment variables are read from .env (see env.sample).
+EOF
+}
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
+    esac
+    shift
+done
+
+# ── Debug helpers ─────────────────────────────────────────────────────────────
+DEBUG="${DEBUG:-0}"
+debug() {
+    [ "$DEBUG" = "1" ] || [ "$DEBUG" = "true" ] && echo "[debug] $*" >&2 || true
+}
+debug_json() {
+    local label="$1" payload="$2"
+    if [ "$DEBUG" = "1" ] || [ "$DEBUG" = "true" ]; then
+        echo "[debug] --- ${label} ---" >&2
+        echo "$payload" >&2
+        echo "[debug] --- end ${label} ---" >&2
+    fi
+}
+
+# ── Load config ──────────────────────────────────────────────────────────────
+[ -f "$SCRIPT_DIR/.env" ] && source "$SCRIPT_DIR/.env"
+
+DB_HOST="${DB_HOST:?Set DB_HOST in .env}"
+DB_PORT="${DB_PORT:-3306}"
+DB_NAME="${DB_NAME:?Set DB_NAME in .env}"
+DB_USER="${DB_USER:?Set DB_USER in .env}"
+DB_PASS="${DB_PASS:?Set DB_PASS in .env}"
+
+TIMESTAMP=$(date +%s)
+DS_NAME="csv_example_ds_${TIMESTAMP}"
+KN_NAME="csv_example_kn_${TIMESTAMP}"
+
+DS_ID=""
+KN_ID=""
+
+cleanup() {
+    [ -z "$KN_ID" ] && [ -z "$DS_ID" ] && return 0
+    echo ""
+    echo "=== Cleanup ==="
+    [ -n "$KN_ID" ] && kweaver bkn delete "$KN_ID" -y 2>/dev/null && echo "  Deleted KN $KN_ID"
+    [ -n "$DS_ID" ] && kweaver ds delete "$DS_ID" -y 2>/dev/null && echo "  Deleted datasource $DS_ID"
+    echo "Done."
+}
+trap cleanup EXIT
+
+# ── Step 1: Connect datasource ────────────────────────────────────────────────
+echo "=== Step 1: Connect datasource ==="
+echo "  Host: $DB_HOST:$DB_PORT  Database: $DB_NAME"
+
+DS_JSON=$(kweaver ds connect mysql "$DB_HOST" "$DB_PORT" "$DB_NAME" \
+    --account "$DB_USER" --password "$DB_PASS" --name "$DS_NAME")
+debug_json "ds connect" "$DS_JSON"
+
+DS_ID=$(echo "$DS_JSON" | python3 -c \
+    "import sys,json; d=json.load(sys.stdin); \
+     r=d[0] if isinstance(d,list) else d; \
+     print(r.get('datasource_id') or r.get('id',''))" 2>/dev/null || true)
+
+[ -z "$DS_ID" ] && { echo "Error: ds connect failed — check credentials." >&2; exit 1; }
+echo "  Datasource: $DS_ID"
+
+# ── Step 2: Import CSVs + build Knowledge Network ─────────────────────────────
+echo ""
+echo "=== Step 2: Import CSVs and build Knowledge Network ==="
+echo "  Files: $(ls "$SCRIPT_DIR/data/"*.csv | xargs -n1 basename | tr '\n' ' ')"
+
+KN_JSON=$(kweaver bkn create-from-csv "$DS_ID" \
+    --files "$SCRIPT_DIR/data/*.csv" \
+    --name "$KN_NAME" \
+    --build \
+    --timeout 300)
+debug_json "create-from-csv" "$KN_JSON"
+
+KN_ID=$(echo "$KN_JSON" | python3 -c \
+    "import sys,json; d=json.load(sys.stdin); \
+     print(d.get('kn_id') or d.get('id',''))" 2>/dev/null || true)
+
+[ -z "$KN_ID" ] && { echo "Error: create-from-csv failed." >&2; exit 1; }
+echo "  Knowledge Network: $KN_ID"
+
+# Show auto-discovered object types
+echo "$KN_JSON" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+ots = d.get('object_types', [])
+if ots:
+    print(f'  Auto-discovered object types ({len(ots)}):')
+    for ot in ots:
+        print(f'    - {ot.get(\"name\",\"?\")}')
+" 2>/dev/null || true
+
+# ── Step 3: Explore schema ────────────────────────────────────────────────────
+echo ""
+echo "=== Step 3: Explore schema ==="
+
+OT_LIST=$(kweaver bkn object-type list "$KN_ID")
+debug_json "object-type list" "$OT_LIST"
+
+OT_IDS=$(echo "$OT_LIST" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+entries = data.get('entries', data) if isinstance(data, dict) else data
+print(f'  Object types ({len(entries)}):')
+ids = []
+for e in entries:
+    name = e.get('name','?')
+    props = e.get('data_properties', [])
+    ot_id = e.get('id') or e.get('ot_id','')
+    print(f'    - {name}  ({len(props)} properties)  id={ot_id}')
+    ids.append(ot_id)
+# Print first two IDs for later steps
+print('__IDS__:' + ','.join(ids[:2]))
+" 2>/dev/null || true)
+
+echo "$OT_IDS" | grep -v "^__IDS__"
+FIRST_OT=$(echo "$OT_IDS" | grep "^__IDS__" | cut -d: -f2 | cut -d, -f1)
+SECOND_OT=$(echo "$OT_IDS" | grep "^__IDS__" | cut -d: -f2 | cut -d, -f2)
+
+if [ -n "$FIRST_OT" ]; then
+    echo ""
+    echo "  Properties of '$(echo "$OT_LIST" | python3 -c \
+        "import sys,json; d=json.load(sys.stdin); \
+         e=d.get('entries',d) if isinstance(d,dict) else d; \
+         print(e[0].get('name','?') if e else '?')" 2>/dev/null)':"
+    kweaver bkn object-type get "$KN_ID" "$FIRST_OT" --pretty 2>/dev/null | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+entry = data
+if isinstance(data, dict) and 'entries' in data:
+    entry = data['entries'][0] if data['entries'] else data
+for p in (entry.get('data_properties') or [])[:8]:
+    print(f'    - {p.get(\"name\",\"?\")}  ({p.get(\"type\",\"?\")})')
+" 2>/dev/null || true
+fi
+
+# ── Step 4: Query instances ───────────────────────────────────────────────────
+echo ""
+echo "=== Step 4: Query instances ==="
+
+if [ -n "$FIRST_OT" ]; then
+    echo "  Querying first 5 records from object type '$FIRST_OT':"
+    kweaver bkn object-type query "$KN_ID" "$FIRST_OT" --limit 5 2>/dev/null | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+instances = data.get('datas') or data.get('instances') or data.get('entries') or (data if isinstance(data, list) else [])
+for inst in instances[:5]:
+    items = [(k,v) for k,v in inst.items() if not k.startswith('_')][:4]
+    print('    ' + '  '.join(f'{k}={v}' for k,v in items))
+" 2>/dev/null || echo "    (no instances returned)"
+fi
+
+# ── Step 5: Subgraph traversal ────────────────────────────────────────────────
+echo ""
+echo "=== Step 5: Subgraph traversal ==="
+
+# Get an instance ID from the first object type
+if [ -n "$FIRST_OT" ]; then
+    INSTANCE_ID=$(kweaver bkn object-type query "$KN_ID" "$FIRST_OT" --limit 1 2>/dev/null | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+instances = data.get('datas') or data.get('instances') or data.get('entries') or (data if isinstance(data,list) else [])
+if instances:
+    print(instances[0].get('_instance_id') or instances[0].get('id') or instances[0].get('rid',''))
+" 2>/dev/null || true)
+fi
+
+if [ -n "${INSTANCE_ID:-}" ]; then
+    echo "  Starting from instance: $INSTANCE_ID"
+    SUBGRAPH=$(kweaver bkn subgraph "$KN_ID" "$INSTANCE_ID" --depth 2 2>/dev/null \
+        || kweaver bkn subgraph "$KN_ID" "$INSTANCE_ID" 2>/dev/null || true)
+    if [ -n "$SUBGRAPH" ]; then
+        echo "$SUBGRAPH" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    nodes = data.get('nodes') or data.get('vertices') or []
+    edges = data.get('edges') or data.get('relations') or []
+    print(f'  Graph: {len(nodes)} nodes, {len(edges)} edges')
+except Exception:
+    pass
+" 2>/dev/null || true
+    fi
+else
+    echo "  (no instances available for subgraph — skipping)"
+fi
+
+# ── Step 6: Semantic search ───────────────────────────────────────────────────
+echo ""
+echo "=== Step 6: Semantic search via context-loader ==="
+
+kweaver context-loader config set --kn-id "$KN_ID" >/dev/null 2>&1 || true
+
+SEARCH_RESULT=$(kweaver context-loader kn-search "部门 预算 人员" \
+    --kn-id "$KN_ID" --only-schema 2>/dev/null || true)
+
+if [ -n "$SEARCH_RESULT" ]; then
+    SCHEMA_RAW=$(echo "$SEARCH_RESULT" | python3 -c \
+        "import sys,json; print(json.load(sys.stdin).get('raw',''))" 2>/dev/null || true)
+    echo "  Schema context (first 8 lines):"
+    echo "$SCHEMA_RAW" | head -8 | sed 's/^/    /'
+    [ "$(echo "$SCHEMA_RAW" | wc -l)" -gt 8 ] && echo "    ..."
+else
+    echo "  (context-loader not available on this deployment)"
+    SCHEMA_RAW=""
+fi
+
+# ── Step 7: Export KN ────────────────────────────────────────────────────────
+echo ""
+echo "=== Step 7: Export Knowledge Network ==="
+
+EXPORT=$(kweaver bkn export "$KN_ID" 2>/dev/null || true)
+if [ -n "$EXPORT" ]; then
+    echo "$EXPORT" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    ots = data.get('object_types', [])
+    rts = data.get('relation_types', [])
+    print(f'  Exported: {len(ots)} object types, {len(rts)} relation types')
+except Exception:
+    pass
+" 2>/dev/null || true
+fi
+
+# ── Step 8: Agent Q&A ─────────────────────────────────────────────────────────
+echo ""
+echo "=== Step 8: Agent Q&A ==="
+
+AGENT_ID="${AGENT_ID:-}"
+if [ -z "$AGENT_ID" ]; then
+    AGENT_ID=$(kweaver agent list --limit 1 2>/dev/null | python3 -c \
+        "import sys,json; d=json.load(sys.stdin); \
+         print(d[0].get('id','') if isinstance(d,list) and d else '')" 2>/dev/null || true)
+fi
+
+if [ -z "$AGENT_ID" ]; then
+    echo "  No agent available — set AGENT_ID in .env or create one with \`kweaver agent create\`."
+    echo "  Skipping Q&A step."
+else
+    QUESTION="这份数据里，哪个部门的预算最高？Engineering 部门有多少员工？"
+
+    # Query actual instance data for departments and employees
+    DEPT_DATA=""
+    EMP_DATA=""
+    if [ -n "$FIRST_OT" ]; then
+        DEPT_DATA=$(kweaver bkn object-type query "$KN_ID" "$FIRST_OT" --limit 20 2>/dev/null | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+rows = data.get('datas') or data.get('instances') or data.get('entries') or []
+lines = []
+for r in rows:
+    lines.append('  ' + ', '.join(f'{k}={v}' for k,v in r.items() if not k.startswith('_')))
+print('\n'.join(lines))
+" 2>/dev/null || true)
+    fi
+    if [ -n "$SECOND_OT" ]; then
+        EMP_DATA=$(kweaver bkn object-type query "$KN_ID" "$SECOND_OT" --limit 20 2>/dev/null | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+rows = data.get('datas') or data.get('instances') or data.get('entries') or []
+lines = []
+for r in rows:
+    lines.append('  ' + ', '.join(f'{k}={v}' for k,v in r.items() if not k.startswith('_')))
+print('\n'.join(lines))
+" 2>/dev/null || true)
+    fi
+
+    PROMPT=""
+    if [ -n "${SCHEMA_RAW:-}" ]; then
+        PROMPT="以下是通过知识网络检索到的 schema 信息：
+
+${SCHEMA_RAW}
+"
+    fi
+    if [ -n "${DEPT_DATA:-}" ]; then
+        PROMPT="${PROMPT}
+departments 表实际数据：
+${DEPT_DATA}
+"
+    fi
+    if [ -n "${EMP_DATA:-}" ]; then
+        PROMPT="${PROMPT}
+employees 表实际数据：
+${EMP_DATA}
+"
+    fi
+    PROMPT="${PROMPT}
+请基于以上数据回答：${QUESTION}"
+
+    echo "  Agent: $AGENT_ID"
+    echo "  Question: $QUESTION"
+    echo ""
+    echo "  Response:"
+    kweaver agent chat "$AGENT_ID" \
+        -m "$PROMPT" \
+        --stream 2>/dev/null | sed 's/^/    /' || \
+    kweaver agent chat "$AGENT_ID" \
+        -m "$PROMPT" \
+        --no-stream 2>/dev/null | sed 's/^/    /' || \
+    echo "    (agent unavailable)"
+fi
+
+echo ""
+echo "=== Example complete ==="
+echo "  KN '$KN_NAME' ($KN_ID) will be deleted on exit."


### PR DESCRIPTION
Closes #226

## 变更内容

### Step 4 / Step 5 — 实例解析字段修正
`object-type query` API 实际返回 `datas` 字段，脚本只查 `instances`/`entries` 导致解析结果为空。
修复：优先取 `datas`，再降级到 `instances`/`entries`。

### Step 5 — instance ID 字段修正
实例 ID 优先取 `_instance_id`（API 标准字段），再降级到 `id`/`rid`。

### Step 8 — Agent 提示词注入实际数据
原 prompt 只含 schema 信息，agent 无法回答具体数值问题。
修复：额外查询 departments / employees 实际实例，注入 prompt，agent 可直接基于真实数据作答。

## 测试结果（117 环境）

修复前：Step 4 输出空，agent 回答"需要实际数据才能回答"
修复后：
- Step 4 正确输出 5 个部门实例
- agent 正确回答：Engineering 预算最高（12,000,000 CNY），Engineering 有 5 名员工

## 关联

kweaver-sdk CLI 修复：kweaver-ai/kweaver-sdk#61