### PR TITLE
feat(deploy): add --force-upgrade to bypass chart-version skip

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -5,6 +5,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONF_DIR="${CONF_DIR:-${HOME}/.kweaver-ai}"
 CONFIG_YAML_PATH="${CONFIG_YAML_PATH:-${CONF_DIR}/config.yaml}"
 
+# Global flag: bypass "skip when chart version unchanged" optimization so that
+# helm upgrade re-renders templates with the latest values.yaml. Use this after
+# editing config.yaml on a previously-installed cluster.
+FORCE_UPGRADE="${FORCE_UPGRADE:-false}"
+
 # Fix paths to use script's conf directory, not user home
 FLANNEL_MANIFEST_PATH="${SCRIPT_DIR}/conf/kube-flannel.yml"
 LOCALPV_MANIFEST_PATH="${SCRIPT_DIR}/conf/local-path-storage.yaml"
@@ -108,6 +113,8 @@ usage() {
     echo "  $0 all install                # Full initialization with all components"
     echo ""
     echo "Global Options:"
+    echo "  --force-upgrade               Always run helm upgrade even if installed chart version equals target."
+    echo "                                Use this after editing config.yaml on a previously-installed cluster."
     echo "  --config=<path>               Specify config.yaml path (values file for helm installs)"
     echo "                                (default: ~/.kweaver-ai/config.yaml or \$CONFIG_YAML_PATH env var)"
     echo "  --charts_dir=<path>           Use a specific local chart directory for download/install"
@@ -330,6 +337,14 @@ confirm_access_address_before_install() {
 
 # Main function
 main() {
+    # Parse global flags before module/action
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --force-upgrade) FORCE_UPGRADE="true"; shift ;;
+            *) break ;;
+        esac
+    done
+
     local module="${1:-}"
     local action="${2:-}"
     shift 2 2>/dev/null || true
@@ -377,6 +392,7 @@ main() {
             case "$1" in
                 --api_server_address=*) API_SERVER_ADVERTISE_ADDRESS="${1#*=}"; shift ;;
                 --api_server_address)   API_SERVER_ADVERTISE_ADDRESS="$2"; shift 2 ;;
+                --force-upgrade)        FORCE_UPGRADE="true"; shift ;;
                 --access_address=*)     KWEAVER_ACCESS_ADDRESS="${1#*=}"; shift ;;
                 --access_address)       KWEAVER_ACCESS_ADDRESS="$2"; shift 2 ;;
                 *) shift ;;

--- a/deploy/scripts/lib/common.sh
+++ b/deploy/scripts/lib/common.sh
@@ -711,6 +711,11 @@ should_skip_upgrade_same_chart_version() {
     local chart_name="$3"
     local target_version="$4"
 
+    # Honor explicit override: never skip when caller asked to force re-render.
+    if [[ "${FORCE_UPGRADE:-false}" == "true" ]]; then
+        return 1
+    fi
+
     if [[ -z "${target_version}" ]]; then
         return 1
     fi
@@ -725,7 +730,7 @@ should_skip_upgrade_same_chart_version() {
     local installed_version
     installed_version=$(get_installed_chart_version "${release_name}" "${namespace}" "${chart_name}")
     if [[ -n "${installed_version}" && "${installed_version}" == "${target_version}" ]]; then
-        log_info "Skip ${release_name}: installed chart version ${installed_version} equals target ${target_version}."
+        log_info "Skip ${release_name}: installed chart version ${installed_version} equals target ${target_version}. (Pass --force-upgrade to re-render with updated values.)"
         return 0
     fi
 

--- a/deploy/scripts/services/core.sh
+++ b/deploy/scripts/services/core.sh
@@ -117,6 +117,10 @@ parse_core_args() {
                 CORE_SET_VALUES+=("businessDomain.enabled=false")
                 shift
                 ;;
+            --force-upgrade)
+                FORCE_UPGRADE="true"
+                shift
+                ;;
             *)
                 log_error "Unknown argument: $1"
                 return 1

--- a/deploy/scripts/services/dip.sh
+++ b/deploy/scripts/services/dip.sh
@@ -79,6 +79,10 @@ parse_dip_args() {
                 DIP_CONFIRM_MISSING_OPENCLAW_PATHS="true"
                 shift
                 ;;
+            --force-upgrade)
+                FORCE_UPGRADE="true"
+                shift
+                ;;
             *)
                 log_error "Unknown argument: $1"
                 return 1

--- a/deploy/scripts/services/isf.sh
+++ b/deploy/scripts/services/isf.sh
@@ -82,6 +82,10 @@ parse_isf_args() {
                 FORCE_REFRESH_CHARTS="true"
                 shift
                 ;;
+            --force-upgrade)
+                FORCE_UPGRADE="true"
+                shift
+                ;;
             *)
                 log_error "Unknown argument: $1"
                 return 1


### PR DESCRIPTION
## Summary

- 新增全局 `--force-upgrade`（也支持 `FORCE_UPGRADE=true` 环境变量），让 `should_skip_upgrade_same_chart_version()` 强制返回"继续 upgrade"，即便本地 chart 版本与已安装版本相同也会重新 render values。
- 在原有 skip 日志末尾追加可操作 hint：`(Pass --force-upgrade to re-render with updated values.)`，让用户在第一次撞墙时就知道怎么修复。
- **修复用户场景**：编辑 `~/.kweaver-ai/config.yaml`（如改 `accessAddress`、密码、副本数）后重跑 `deploy.sh kweaver-core install`，之前会被 "Skip ... equals target" 全部静默吞掉，必须手动 `helm uninstall <release>` 才能让新配置生效。

## Changes

- `deploy/scripts/lib/common.sh`：`should_skip_upgrade_same_chart_version` 顶部加 `FORCE_UPGRADE` 检查 + skip 日志追加 hint
- `deploy/deploy.sh`：global flag 预解析 + k8s 子参数循环 + `usage()`
- `deploy/scripts/services/{core,isf,dip}.sh`：各自 `parse_*_args` 加 `--force-upgrade` case

## Test plan

在 `ubuntu@43.129.210.161` 真实 K8s 集群验证：

- [x] 默认 `install`：仍 skip，新增 hint `(Pass --force-upgrade to re-render with updated values.)` 出现
- [x] `install --force-upgrade`：0 个 skip，72 处 helm `STATUS: deployed`（每个 release 重新 render）
- [x] 集群最终 36 Running / 2 Completed / 0 Failed，`/api/v1/health` HTTP 200
- [x] `bash -n` 语法检查全部通过

## 影响范围

- 仅 deploy 脚本，未触及业务代码与 chart
- 默认行为完全兼容（不传 `--force-upgrade` 时与 main 一致）

Made with [Cursor](https://cursor.com)