### PR TITLE
fix: eliminate deadlock in CreateDagVars and refreshDagIndexes (#223)

### DIFF
--- a/adp/dataflow/flow-automation/store/rds/dag/concurrent_test.go
+++ b/adp/dataflow/flow-automation/store/rds/dag/concurrent_test.go
@@ -1,0 +1,54 @@
+package dagmodel
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kweaver-ai/kweaver-core/adp/dataflow/flow-automation/pkg/entity"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConcurrentCreateDag(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping concurrent test in short mode")
+	}
+
+	d := NewDagRepository().(*dag)
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	errors := make([]error, 10)
+	var mu sync.Mutex
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+
+			dag := &entity.Dag{
+				Name: fmt.Sprintf("Concurrent Test DAG %d %d", time.Now().UnixNano(), idx),
+				Vars: entity.DagVars{
+					fmt.Sprintf("var_%d", idx): {DefaultValue: "val"},
+				},
+			}
+			dag.Initial()
+
+			_, err := d.CreateDag(ctx, dag)
+			mu.Lock()
+			errors[idx] = err
+			mu.Unlock()
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i, err := range errors {
+		if err != nil {
+			t.Logf("Goroutine %d error: %v", i, err)
+			assert.NotContains(t, err.Error(), "Deadlock", "Deadlock detected!")
+		}
+	}
+}

--- a/adp/dataflow/flow-automation/store/rds/dag/dag.go
+++ b/adp/dataflow/flow-automation/store/rds/dag/dag.go
@@ -385,12 +385,12 @@ func (d *dag) CreateDag(ctx context.Context, dagEntity *entity.Dag) (string, err
 			return err
 		}
 
-		err = store.CreateDagVars(newCtx, BuildDagVars(dagEntity))
+		err = store.CreateDagVars(newCtx, BuildDagVars(dagEntity), true)
 		if err != nil {
 			return err
 		}
 
-		err = store.refreshDagIndexes(newCtx, dagEntity)
+		err = store.refreshDagIndexes(newCtx, dagEntity, true)
 		if err != nil {
 			return err
 		}
@@ -409,50 +409,127 @@ func (d *dag) CreateDag(ctx context.Context, dagEntity *entity.Dag) (string, err
 	return dagEntity.ID, err
 }
 
-func (d *dag) CreateDagVars(ctx context.Context, dagVars []*DagVarModel) error {
+// getExistingDagVars 查询现有变量
+func (d *dag) getExistingDagVars(ctx context.Context, dagID uint64) ([]existingDagVar, error) {
+	db, _, cancel := d.dbWithContext(ctx)
+	defer cancel()
+
+	var vars []existingDagVar
+	sqlStr := `SELECT f_var_name, f_default_value, f_var_type, f_description FROM t_flow_dag_var WHERE f_dag_id = ?`
+	trace.SetAttributes(ctx, attribute.String(trace.TABLE_NAME, DAGVAR_TABLENAME), attribute.String(trace.DB_SQL, sqlStr))
+	err := db.Raw(sqlStr, dagID).Scan(&vars).Error
+	return vars, err
+}
+
+// getExistingDagSteps 查询现有步骤
+func (d *dag) getExistingDagSteps(ctx context.Context, dagID uint64) ([]existingDagStep, error) {
+	db, _, cancel := d.dbWithContext(ctx)
+	defer cancel()
+
+	var steps []existingDagStep
+	sqlStr := `SELECT f_id, f_operator, f_source_id, f_has_datasource FROM t_flow_dag_step WHERE f_dag_id = ?`
+	trace.SetAttributes(ctx, attribute.String(trace.TABLE_NAME, DAGSTEPINDEX_TABLENAME), attribute.String(trace.DB_SQL, sqlStr))
+	err := db.Raw(sqlStr, dagID).Scan(&steps).Error
+	return steps, err
+}
+
+// getExistingDagAccessors 查询现有访问者
+func (d *dag) getExistingDagAccessors(ctx context.Context, dagID uint64) ([]existingDagAccessor, error) {
+	db, _, cancel := d.dbWithContext(ctx)
+	defer cancel()
+
+	var accessors []existingDagAccessor
+	sqlStr := `SELECT f_id, f_accessor_id FROM t_flow_dag_accessor WHERE f_dag_id = ?`
+	trace.SetAttributes(ctx, attribute.String(trace.TABLE_NAME, DAGACCESSORINDEX_TABLENAME), attribute.String(trace.DB_SQL, sqlStr))
+	err := db.Raw(sqlStr, dagID).Scan(&accessors).Error
+	return accessors, err
+}
+
+// insertDagVars 插入变量
+func (d *dag) insertDagVars(ctx context.Context, dagVars []*DagVarModel) error {
+	if len(dagVars) == 0 {
+		return nil
+	}
+
+	sqlStr := `INSERT INTO t_flow_dag_var (f_id, f_dag_id, f_var_name, f_default_value, f_var_type, f_description) VALUES `
+	values := make([]any, 0, len(dagVars)*6)
+	for _, data := range dagVars {
+		sqlStr += "(?, ?, ?, ?, ?, ?),"
+		values = append(values, data.ID, data.DagID, data.VarName, data.DefaultValue, data.VarType, data.Description)
+	}
+	sqlStr = strings.TrimSuffix(sqlStr, ",")
+
+	return d.db.Exec(sqlStr, values...).Error
+}
+
+func (d *dag) CreateDagVars(ctx context.Context, dagVars []*DagVarModel, isCreate bool) error {
 	var err error
 	newCtx, span := trace.StartInternalSpan(ctx)
-	msgStr, _ := jsoniter.MarshalToString(dagVars)
 	defer func() { trace.TelemetrySpanEnd(span, err) }()
 
-	fn := func(store *dag, dagVars []*DagVarModel) error {
+	fn := func(store *dag, dagVars []*DagVarModel, isCreate bool) error {
 		if len(dagVars) == 0 {
 			return nil
 		}
 
 		dagID := dagVars[0].DagID
-		sqlStr := `DELETE FROM t_flow_dag_var WHERE f_dag_id = ?`
-		trace.SetAttributes(newCtx, attribute.String(trace.TABLE_NAME, DAGVAR_TABLENAME), attribute.String(trace.DB_SQL, sqlStr), attribute.String(trace.DB_QUERY, fmt.Sprintf("%v", dagID)))
-		err = store.db.Exec(sqlStr, dagID).Error
+
+		if isCreate {
+			// 快速路径：直接 INSERT
+			return store.insertDagVars(newCtx, dagVars)
+		}
+
+		// 更新路径：diff + 精确操作
+		existing, err := store.getExistingDagVars(newCtx, dagID)
 		if err != nil {
 			return err
 		}
 
-		sqlStr = `INSERT INTO t_flow_dag_var (f_id, f_dag_id, f_var_name, f_default_value, f_var_type, f_description) VALUES `
-		trace.SetAttributes(newCtx, attribute.String(trace.TABLE_NAME, DAGVAR_TABLENAME), attribute.String(trace.DB_SQL, sqlStr), attribute.String(trace.DB_Values, msgStr))
-		values := make([]any, 0, len(dagVars)*5)
-		for _, data := range dagVars {
-			sqlStr += "(?, ?, ?, ?, ?, ?),"
-			values = append(values, data.ID, data.DagID, data.VarName, data.DefaultValue, data.VarType, data.Description)
+		diff := diffDagVars(existing, dagVars)
+
+		// 执行删除（构建正确的 IN 子句）
+		if len(diff.toDelete) > 0 {
+			placeholders := make([]string, len(diff.toDelete))
+			args := make([]any, len(diff.toDelete)+1)
+			args[0] = dagID
+			for i, name := range diff.toDelete {
+				placeholders[i] = "?"
+				args[i+1] = name
+			}
+			sqlStr := fmt.Sprintf("DELETE FROM t_flow_dag_var WHERE f_dag_id = ? AND f_var_name IN (%s)",
+				strings.Join(placeholders, ","))
+			trace.SetAttributes(newCtx, attribute.String(trace.TABLE_NAME, DAGVAR_TABLENAME), attribute.String(trace.DB_SQL, sqlStr))
+			if err = store.db.Exec(sqlStr, args...).Error; err != nil {
+				return err
+			}
 		}
 
-		sqlStr = sqlStr[:len(sqlStr)-1]
+		// 执行插入
+		if len(diff.toInsert) > 0 {
+			if err = store.insertDagVars(newCtx, diff.toInsert); err != nil {
+				return err
+			}
+		}
 
-		err = store.db.Exec(sqlStr, values...).Error
-		if err != nil {
-			return err
+		// 执行更新（逐行）
+		if len(diff.toUpdate) > 0 {
+			for _, v := range diff.toUpdate {
+				sqlStr := `UPDATE t_flow_dag_var SET f_default_value = ?, f_var_type = ?, f_description = ? WHERE f_dag_id = ? AND f_var_name = ?`
+				if err = store.db.Exec(sqlStr, v.DefaultValue, v.VarType, v.Description, dagID, v.VarName).Error; err != nil {
+					return err
+				}
+			}
 		}
 
 		return nil
-
 	}
 
 	if !d.isTX {
 		err = d.WithTransaction(newCtx, func(_ context.Context, txStore mod.Store) error {
-			return fn(txStore.(*dag), dagVars)
+			return fn(txStore.(*dag), dagVars, isCreate)
 		})
 	} else {
-		err = fn(d, dagVars)
+		err = fn(d, dagVars, isCreate)
 	}
 
 	return err
@@ -544,12 +621,120 @@ func (d *dag) replaceDagInstanceKeywords(ctx context.Context, dagInsID uint64, k
 	return d.insertDagInstanceKeywords(ctx, dagInsID, keywords)
 }
 
-func (d *dag) refreshDagIndexes(ctx context.Context, dag *entity.Dag) error {
+// insertDagSteps 插入 step 索引
+func (d *dag) insertDagSteps(ctx context.Context, steps []*DagStepModel) error {
+	if len(steps) == 0 {
+		return nil
+	}
+
+	sqlStr := `INSERT INTO t_flow_dag_step (f_id, f_dag_id, f_operator, f_source_id, f_has_datasource) VALUES `
+	values := make([]any, 0, len(steps)*5)
+	for _, row := range steps {
+		sqlStr += "(?, ?, ?, ?, ?),"
+		values = append(values, row.ID, row.DagID, row.Operator, row.SourceID, row.HasDatasource)
+	}
+	sqlStr = strings.TrimSuffix(sqlStr, ",")
+
+	return d.db.Exec(sqlStr, values...).Error
+}
+
+// insertDagAccessors 插入 accessor 索引
+func (d *dag) insertDagAccessors(ctx context.Context, accessors []*DagAccessorModel) error {
+	if len(accessors) == 0 {
+		return nil
+	}
+
+	sqlStr := `INSERT INTO t_flow_dag_accessor (f_id, f_dag_id, f_accessor_id) VALUES `
+	values := make([]any, 0, len(accessors)*3)
+	for _, row := range accessors {
+		sqlStr += "(?, ?, ?),"
+		values = append(values, row.ID, row.DagID, row.AccessorID)
+	}
+	sqlStr = strings.TrimSuffix(sqlStr, ",")
+
+	return d.db.Exec(sqlStr, values...).Error
+}
+
+// refreshDagStepsWithDiff 使用 diff 方式刷新 step 索引
+func (d *dag) refreshDagStepsWithDiff(ctx context.Context, dagID uint64, newSteps []*DagStepModel) error {
+	existing, err := d.getExistingDagSteps(ctx, dagID)
+	if err != nil {
+		return err
+	}
+
+	diff := diffDagSteps(existing, newSteps)
+
+	// 删除
+	if len(diff.toDelete) > 0 {
+		placeholders := make([]string, len(diff.toDelete))
+		args := make([]any, len(diff.toDelete))
+		for i, id := range diff.toDelete {
+			placeholders[i] = "?"
+			args[i] = id
+		}
+		sqlStr := fmt.Sprintf("DELETE FROM t_flow_dag_step WHERE f_id IN (%s)", strings.Join(placeholders, ","))
+		if err = d.db.Exec(sqlStr, args...).Error; err != nil {
+			return err
+		}
+	}
+
+	// 插入
+	if len(diff.toInsert) > 0 {
+		if err = d.insertDagSteps(ctx, diff.toInsert); err != nil {
+			return err
+		}
+	}
+
+	// 更新
+	if len(diff.toUpdate) > 0 {
+		for _, s := range diff.toUpdate {
+			sqlStr := `UPDATE t_flow_dag_step SET f_has_datasource = ? WHERE f_id = ?`
+			if err = d.db.Exec(sqlStr, s.HasDatasource, s.ID).Error; err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// refreshDagAccessorsWithDiff 使用 diff 方式刷新 accessor 索引
+func (d *dag) refreshDagAccessorsWithDiff(ctx context.Context, dagID uint64, newAccessors []*DagAccessorModel) error {
+	existing, err := d.getExistingDagAccessors(ctx, dagID)
+	if err != nil {
+		return err
+	}
+
+	diff := diffDagAccessors(existing, newAccessors)
+
+	// 删除
+	if len(diff.toDelete) > 0 {
+		placeholders := make([]string, len(diff.toDelete))
+		args := make([]any, len(diff.toDelete))
+		for i, id := range diff.toDelete {
+			placeholders[i] = "?"
+			args[i] = id
+		}
+		sqlStr := fmt.Sprintf("DELETE FROM t_flow_dag_accessor WHERE f_id IN (%s)", strings.Join(placeholders, ","))
+		if err = d.db.Exec(sqlStr, args...).Error; err != nil {
+			return err
+		}
+	}
+
+	// 插入
+	if len(diff.toInsert) > 0 {
+		if err = d.insertDagAccessors(ctx, diff.toInsert); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (d *dag) refreshDagIndexes(ctx context.Context, dag *entity.Dag, isCreate bool) error {
 	var err error
 	newCtx, span := trace.StartInternalSpan(ctx)
 	defer func() { trace.TelemetrySpanEnd(span, err) }()
-	db, _, cancel := d.dbWithContext(newCtx)
-	defer cancel()
 
 	if dag == nil {
 		return nil
@@ -561,78 +746,32 @@ func (d *dag) refreshDagIndexes(ctx context.Context, dag *entity.Dag) error {
 	}
 
 	stepRows := BuildDagStepIndex(dag)
-	// triggerRows := BuildDagTriggerConfigIndex(dag)
 	accessorRows := BuildDagAccessorIndex(dag)
 
-	deleteIndexes := func(table string) error {
-		sqlStr := fmt.Sprintf("DELETE FROM %s WHERE f_dag_id = ?", table)
-		trace.SetAttributes(newCtx, attribute.String(trace.TABLE_NAME, table), attribute.String(trace.DB_SQL, sqlStr), attribute.String(trace.DB_QUERY, fmt.Sprintf("%v", dagID)))
-		return db.Exec(sqlStr, dagID).Error
-	}
-
-	if err = deleteIndexes(DAGSTEPINDEX_TABLENAME); err != nil {
-		return err
-	}
-	// if err = deleteIndexes(DAGTRIGGERINDEX_TABLENAME); err != nil {
-	// 	return err
-	// }
-	if err = deleteIndexes(DAGACCESSORINDEX_TABLENAME); err != nil {
-		return err
-	}
-
-	insertStepRows := func(rows []*DagStepModel) error {
-		if len(rows) == 0 {
-			return nil
+	// 处理 t_flow_dag_step 表
+	if isCreate {
+		if len(stepRows) > 0 {
+			if err = d.insertDagSteps(newCtx, stepRows); err != nil {
+				return err
+			}
 		}
-		sqlStr := fmt.Sprintf("INSERT INTO %s (f_id, f_dag_id, f_operator, f_source_id, f_has_datasource) VALUES ", DAGSTEPINDEX_TABLENAME)
-		values := make([]any, 0, len(rows)*5)
-		for _, row := range rows {
-			sqlStr += "(?, ?, ?, ?, ?),"
-			values = append(values, row.ID, row.DagID, row.Operator, row.SourceID, row.HasDatasource)
+	} else {
+		if err = d.refreshDagStepsWithDiff(newCtx, dagID, stepRows); err != nil {
+			return err
 		}
-		sqlStr = strings.TrimSuffix(sqlStr, ",")
-		trace.SetAttributes(newCtx, attribute.String(trace.TABLE_NAME, DAGSTEPINDEX_TABLENAME), attribute.String(trace.DB_SQL, sqlStr))
-		return db.Exec(sqlStr, values...).Error
 	}
 
-	// insertTriggerRows := func(rows []*DagTriggerConfigIndex) error {
-	// 	if len(rows) == 0 {
-	// 		return nil
-	// 	}
-	// 	sqlStr := fmt.Sprintf("INSERT INTO %s (f_id, f_dag_id, f_operator, f_source_id) VALUES ", DAGTRIGGERINDEX_TABLENAME)
-	// 	values := make([]any, 0, len(rows)*4)
-	// 	for _, row := range rows {
-	// 		sqlStr += "(?, ?, ?, ?),"
-	// 		values = append(values, row.ID, row.DagID, row.Operator, row.SourceID)
-	// 	}
-	// 	sqlStr = strings.TrimSuffix(sqlStr, ",")
-	// 	trace.SetAttributes(newCtx, attribute.String(trace.TABLE_NAME, DAGTRIGGERINDEX_TABLENAME), attribute.String(trace.DB_SQL, sqlStr))
-	// 	return d.db.Exec(sqlStr, values...).Error
-	// }
-
-	insertAccessorRows := func(rows []*DagAccessorModel) error {
-		if len(rows) == 0 {
-			return nil
+	// 处理 t_flow_dag_accessor 表
+	if isCreate {
+		if len(accessorRows) > 0 {
+			if err = d.insertDagAccessors(newCtx, accessorRows); err != nil {
+				return err
+			}
 		}
-		sqlStr := fmt.Sprintf("INSERT INTO %s (f_id, f_dag_id, f_accessor_id) VALUES ", DAGACCESSORINDEX_TABLENAME)
-		values := make([]any, 0, len(rows)*3)
-		for _, row := range rows {
-			sqlStr += "(?, ?, ?),"
-			values = append(values, row.ID, row.DagID, row.AccessorID)
+	} else {
+		if err = d.refreshDagAccessorsWithDiff(newCtx, dagID, accessorRows); err != nil {
+			return err
 		}
-		sqlStr = strings.TrimSuffix(sqlStr, ",")
-		trace.SetAttributes(newCtx, attribute.String(trace.TABLE_NAME, DAGACCESSORINDEX_TABLENAME), attribute.String(trace.DB_SQL, sqlStr))
-		return db.Exec(sqlStr, values...).Error
-	}
-
-	if err = insertStepRows(stepRows); err != nil {
-		return err
-	}
-	// if err = insertTriggerRows(triggerRows); err != nil {
-	// 	return err
-	// }
-	if err = insertAccessorRows(accessorRows); err != nil {
-		return err
 	}
 
 	return nil
@@ -743,12 +882,12 @@ func (d *dag) UpdateDag(ctx context.Context, dagEntity *entity.Dag) error {
 			return err
 		}
 
-		err = store.CreateDagVars(newCtx, BuildDagVars(dagEntity))
+		err = store.CreateDagVars(newCtx, BuildDagVars(dagEntity), false)
 		if err != nil {
 			return err
 		}
 
-		err = store.refreshDagIndexes(newCtx, dagEntity)
+		err = store.refreshDagIndexes(newCtx, dagEntity, false)
 		if err != nil {
 			return err
 		}

--- a/adp/dataflow/flow-automation/store/rds/dag/diff.go
+++ b/adp/dataflow/flow-automation/store/rds/dag/diff.go
@@ -1,0 +1,153 @@
+package dagmodel
+
+// existingDagVar 现有变量（用于 diff）
+type existingDagVar struct {
+	VarName      string
+	DefaultValue string
+	VarType      string
+	Description  string
+}
+
+// existingDagStep 现有步骤（用于 diff）
+type existingDagStep struct {
+	ID            uint64
+	Operator      string
+	SourceID      string
+	HasDatasource bool
+}
+
+// existingDagAccessor 现有访问者（用于 diff）
+type existingDagAccessor struct {
+	ID         uint64
+	AccessorID string
+}
+
+// dagVarsDiff diff 计算结果
+type dagVarsDiff struct {
+	toInsert []*DagVarModel
+	toUpdate []*DagVarModel
+	toDelete []string // var_name 列表
+}
+
+// dagStepsDiff diff 计算结果
+type dagStepsDiff struct {
+	toInsert []*DagStepModel
+	toUpdate []*DagStepModel
+	toDelete []uint64 // id 列表
+}
+
+// dagAccessorsDiff diff 计算结果
+type dagAccessorsDiff struct {
+	toInsert []*DagAccessorModel
+	toDelete []uint64 // id 列表
+}
+
+// diffDagVars 计算变量差异
+func diffDagVars(existing []existingDagVar, newVars []*DagVarModel) *dagVarsDiff {
+	result := &dagVarsDiff{
+		toInsert: make([]*DagVarModel, 0),
+		toUpdate: make([]*DagVarModel, 0),
+		toDelete: make([]string, 0),
+	}
+
+	existingMap := make(map[string]existingDagVar)
+	for _, v := range existing {
+		existingMap[v.VarName] = v
+	}
+
+	newVarNames := make(map[string]bool)
+	for _, newVar := range newVars {
+		newVarNames[newVar.VarName] = true
+		if existing, ok := existingMap[newVar.VarName]; ok {
+			if existing.DefaultValue != newVar.DefaultValue ||
+				existing.VarType != newVar.VarType ||
+				existing.Description != newVar.Description {
+				result.toUpdate = append(result.toUpdate, newVar)
+			}
+		} else {
+			result.toInsert = append(result.toInsert, newVar)
+		}
+	}
+
+	for _, v := range existing {
+		if !newVarNames[v.VarName] {
+			result.toDelete = append(result.toDelete, v.VarName)
+		}
+	}
+
+	return result
+}
+
+// stepKey 生成步骤的唯一标识
+func stepKey(operator, sourceID string) string {
+	return operator + ":" + sourceID
+}
+
+// diffDagSteps 计算步骤差异
+// 注意：此函数会修改 newSteps 中需要 UPDATE 的元素的 ID 字段
+func diffDagSteps(existing []existingDagStep, newSteps []*DagStepModel) *dagStepsDiff {
+	result := &dagStepsDiff{
+		toInsert: make([]*DagStepModel, 0),
+		toUpdate: make([]*DagStepModel, 0),
+		toDelete: make([]uint64, 0),
+	}
+
+	existingMap := make(map[string]existingDagStep)
+	for _, s := range existing {
+		key := stepKey(s.Operator, s.SourceID)
+		existingMap[key] = s
+	}
+
+	newKeys := make(map[string]bool)
+	for _, newStep := range newSteps {
+		key := stepKey(newStep.Operator, newStep.SourceID)
+		newKeys[key] = true
+
+		if existing, ok := existingMap[key]; ok {
+			if existing.HasDatasource != newStep.HasDatasource {
+				newStep.ID = existing.ID
+				result.toUpdate = append(result.toUpdate, newStep)
+			}
+		} else {
+			result.toInsert = append(result.toInsert, newStep)
+		}
+	}
+
+	for _, s := range existing {
+		key := stepKey(s.Operator, s.SourceID)
+		if !newKeys[key] {
+			result.toDelete = append(result.toDelete, s.ID)
+		}
+	}
+
+	return result
+}
+
+// diffDagAccessors 计算访问者差异
+func diffDagAccessors(existing []existingDagAccessor, newAccessors []*DagAccessorModel) *dagAccessorsDiff {
+	result := &dagAccessorsDiff{
+		toInsert: make([]*DagAccessorModel, 0),
+		toDelete: make([]uint64, 0),
+	}
+
+	existingMap := make(map[string]existingDagAccessor)
+	for _, a := range existing {
+		existingMap[a.AccessorID] = a
+	}
+
+	newAccessorIDs := make(map[string]bool)
+	for _, newAcc := range newAccessors {
+		newAccessorIDs[newAcc.AccessorID] = true
+		if _, ok := existingMap[newAcc.AccessorID]; !ok {
+			result.toInsert = append(result.toInsert, newAcc)
+		}
+	}
+
+	for _, a := range existing {
+		if !newAccessorIDs[a.AccessorID] {
+			result.toDelete = append(result.toDelete, a.ID)
+		}
+	}
+
+	return result
+}

--- a/adp/dataflow/flow-automation/store/rds/dag/diff_test.go
+++ b/adp/dataflow/flow-automation/store/rds/dag/diff_test.go
@@ -1,0 +1,107 @@
+package dagmodel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDiffDagVars(t *testing.T) {
+	t.Run("all insert", func(t *testing.T) {
+		existing := []existingDagVar{}
+		newVars := []*DagVarModel{
+			{VarName: "var1", DefaultValue: "val1", VarType: "string"},
+			{VarName: "var2", DefaultValue: "val2", VarType: "int"},
+		}
+		result := diffDagVars(existing, newVars)
+		assert.Len(t, result.toInsert, 2)
+		assert.Len(t, result.toUpdate, 0)
+		assert.Len(t, result.toDelete, 0)
+	})
+
+	t.Run("all delete", func(t *testing.T) {
+		existing := []existingDagVar{
+			{VarName: "var1", DefaultValue: "val1"},
+			{VarName: "var2", DefaultValue: "val2"},
+		}
+		newVars := []*DagVarModel{}
+		result := diffDagVars(existing, newVars)
+		assert.Len(t, result.toInsert, 0)
+		assert.Len(t, result.toUpdate, 0)
+		assert.Len(t, result.toDelete, 2)
+	})
+
+	t.Run("update needed", func(t *testing.T) {
+		existing := []existingDagVar{
+			{VarName: "var1", DefaultValue: "old_val", VarType: "string"},
+		}
+		newVars := []*DagVarModel{
+			{VarName: "var1", DefaultValue: "new_val", VarType: "string"},
+		}
+		result := diffDagVars(existing, newVars)
+		assert.Len(t, result.toInsert, 0)
+		assert.Len(t, result.toUpdate, 1)
+		assert.Len(t, result.toDelete, 0)
+	})
+
+	t.Run("no change", func(t *testing.T) {
+		existing := []existingDagVar{
+			{VarName: "var1", DefaultValue: "val1", VarType: "string", Description: "desc"},
+		}
+		newVars := []*DagVarModel{
+			{VarName: "var1", DefaultValue: "val1", VarType: "string", Description: "desc"},
+		}
+		result := diffDagVars(existing, newVars)
+		assert.Len(t, result.toInsert, 0)
+		assert.Len(t, result.toUpdate, 0)
+		assert.Len(t, result.toDelete, 0)
+	})
+
+	t.Run("mixed operations", func(t *testing.T) {
+		existing := []existingDagVar{
+			{VarName: "var1", DefaultValue: "val1"},
+			{VarName: "var2", DefaultValue: "old_val"},
+		}
+		newVars := []*DagVarModel{
+			{VarName: "var2", DefaultValue: "new_val"},
+			{VarName: "var3", DefaultValue: "val3"},
+		}
+		result := diffDagVars(existing, newVars)
+		assert.Len(t, result.toInsert, 1)
+		assert.Len(t, result.toUpdate, 1)
+		assert.Len(t, result.toDelete, 1)
+	})
+}
+
+func TestDiffDagSteps(t *testing.T) {
+	t.Run("mixed operations", func(t *testing.T) {
+		existing := []existingDagStep{
+			{ID: 1, Operator: "op1", SourceID: "src1", HasDatasource: false},
+			{ID: 2, Operator: "op2", SourceID: "src2", HasDatasource: false},
+		}
+		newSteps := []*DagStepModel{
+			{Operator: "op2", SourceID: "src2", HasDatasource: true},
+			{Operator: "op3", SourceID: "src3", HasDatasource: false},
+		}
+		result := diffDagSteps(existing, newSteps)
+		assert.Len(t, result.toInsert, 1)
+		assert.Len(t, result.toUpdate, 1)
+		assert.Len(t, result.toDelete, 1)
+	})
+}
+
+func TestDiffDagAccessors(t *testing.T) {
+	t.Run("insert and delete", func(t *testing.T) {
+		existing := []existingDagAccessor{
+			{ID: 1, AccessorID: "acc1"},
+			{ID: 2, AccessorID: "acc2"},
+		}
+		newAccessors := []*DagAccessorModel{
+			{AccessorID: "acc2"},
+			{AccessorID: "acc3"},
+		}
+		result := diffDagAccessors(existing, newAccessors)
+		assert.Len(t, result.toInsert, 1)
+		assert.Len(t, result.toDelete, 1)
+	})
+}


### PR DESCRIPTION
## Background
`CreateDagVars` and `refreshDagIndexes` previously relied on delete-and-rebuild behavior, and could trigger deadlocks when invoked inside outer DAG create/update transactions under concurrent access.

## Changes
- add `isCreate` flag to `CreateDagVars` and `refreshDagIndexes`
- use direct insert path for create flow
- use diff-based incremental update for update flow
- add diff helpers for dag vars / steps / accessors
- add unit tests for diff logic
- add concurrent test to verify no deadlock during DAG creation

## Result
- eliminate deadlock risk in nested transaction scenarios
- reduce unnecessary full-table delete/insert operations
- improve stability and efficiency for DAG create/update flows