### PR TITLE
[fix] 调整统一查询中 ResourceType 检查方式

### DIFF
--- a/adp/vega/vega-backend/server/driveradapters/query_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/query_handler.go
@@ -123,24 +123,18 @@ func (r *restHandler) sqlQuery(c *gin.Context, ctx context.Context, span trace.S
 		return
 	}
 
-	// 校验resource_type参数，必填，可以是mysql、mariadb、postgresql或opensearch
+	// 校验resource_type参数，必填，必须是当前统一查询接口支持的连接器类型
 	if req.ResourceType == "" {
 		httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, errors.VegaBackend_InvalidParameter_ResourceType).
-			WithErrorDetails("resource_type is required and must be one of: mysql, mariadb, postgresql, opensearch")
+			WithErrorDetails(fmt.Sprintf("resource_type is required and must be one of: %v", interfaces.GetSupportedConnectorTypesForQuery()))
 		o11y.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
 		return
 	}
 
-	validResourceTypes := map[string]bool{
-		"mysql":      true,
-		"mariadb":    true,
-		"postgresql": true,
-		"opensearch": true,
-	}
-	if !validResourceTypes[req.ResourceType] {
+	if !interfaces.IsConnectorTypeSupportedForQuery(req.ResourceType) {
 		httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, errors.VegaBackend_InvalidParameter_ResourceType).
-			WithErrorDetails(fmt.Sprintf("resource_type must be one of: mysql, mariadb, postgresql, opensearch, got: %s", req.ResourceType))
+			WithErrorDetails(fmt.Sprintf("resource_type must be one of: %v, got: %s", interfaces.GetSupportedConnectorTypesForQuery(), req.ResourceType))
 		o11y.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
 		return

--- a/adp/vega/vega-backend/server/interfaces/connector_type.go
+++ b/adp/vega/vega-backend/server/interfaces/connector_type.go
@@ -26,6 +26,42 @@ var (
 	}
 )
 
+// 连接器类型常量定义
+const (
+	ConnectorTypeMySQL      string = "mysql"
+	ConnectorTypeMariaDB    string = "mariadb"
+	ConnectorTypePostgreSQL string = "postgresql"
+	ConnectorTypeOpenSearch string = "opensearch"
+	ConnectorTypeOracle     string = "oracle"
+	ConnectorTypeAnyShare   string = "anyshare"
+)
+
+// 当前统一查询接口支持的连接器类型列表
+// 注意：系统支持更多连接器类型，但当前统一查询接口仅支持以下类型
+var SupportedConnectorTypesForQuery = map[string]bool{
+	ConnectorTypeMySQL:      true,
+	ConnectorTypeMariaDB:    true,
+	ConnectorTypePostgreSQL: true,
+	ConnectorTypeOpenSearch: true,
+}
+
+// GetSupportedConnectorTypesForQuery 返回当前统一查询接口支持的连接器类型列表
+// 注意：系统支持更多连接器类型，但当前统一查询接口仅支持以下类型
+func GetSupportedConnectorTypesForQuery() []string {
+	return []string{
+		ConnectorTypeMySQL,
+		ConnectorTypeMariaDB,
+		ConnectorTypePostgreSQL,
+		ConnectorTypeOpenSearch,
+	}
+}
+
+// IsConnectorTypeSupportedForQuery 检查给定的连接器类型是否被当前统一查询接口支持
+// 注意：系统支持更多连接器类型，但当前统一查询接口仅支持部分类型
+func IsConnectorTypeSupportedForQuery(connectorType string) bool {
+	return SupportedConnectorTypesForQuery[connectorType]
+}
+
 // ConnectorFieldConfig 定义连接器配置字段的元数据（兼容 JSON Schema properties）
 type ConnectorFieldConfig struct {
 	Name        string `json:"name"`        // 字段显示名

--- a/adp/vega/vega-backend/server/logics/connectors/factory/init.go
+++ b/adp/vega/vega-backend/server/logics/connectors/factory/init.go
@@ -6,6 +6,7 @@
 package factory
 
 import (
+	"vega-backend/interfaces"
 	"vega-backend/logics/connectors/local/fileset/anyshare"
 	"vega-backend/logics/connectors/local/index/opensearch"
 	"vega-backend/logics/connectors/local/table/mariadb"
@@ -14,10 +15,10 @@ import (
 
 // InitLocalConnectors 初始化本地 connector
 func (cf *ConnectorFactory) InitLocalConnectors() {
-	cf.connectors["mysql"] = mariadb.NewMariaDBConnector()
-	cf.connectors["opensearch"] = opensearch.NewOpenSearchConnector()
-	//cf.connectors["oracle"] = oracle.NewOracleConnector()
-	cf.connectors["mariadb"] = mariadb.NewMariaDBConnector()
-	cf.connectors["postgresql"] = postgresql.NewPostgresqlConnector()
-	cf.connectors["anyshare"] = anyshare.NewAnyShareConnector()
+	cf.connectors[interfaces.ConnectorTypeMySQL] = mariadb.NewMariaDBConnector()
+	cf.connectors[interfaces.ConnectorTypeOpenSearch] = opensearch.NewOpenSearchConnector()
+	//cf.connectors[interfaces.ConnectorTypeOracle] = oracle.NewOracleConnector()
+	cf.connectors[interfaces.ConnectorTypeMariaDB] = mariadb.NewMariaDBConnector()
+	cf.connectors[interfaces.ConnectorTypePostgreSQL] = postgresql.NewPostgresqlConnector()
+	cf.connectors[interfaces.ConnectorTypeAnyShare] = anyshare.NewAnyShareConnector()
 }

--- a/adp/vega/vega-backend/server/logics/connectors/local/fileset/anyshare/anyshare.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/fileset/anyshare/anyshare.go
@@ -133,12 +133,12 @@ func NewAnyShareConnector() connectors.FilesetConnector {
 
 // GetType returns the data source type.
 func (c *AnyShareConnector) GetType() string {
-	return "anyshare"
+	return interfaces.ConnectorTypeAnyShare
 }
 
 // GetName returns the connector name.
 func (c *AnyShareConnector) GetName() string {
-	return "anyshare"
+	return interfaces.ConnectorTypeAnyShare
 }
 
 // GetMode returns the connector mode.
@@ -405,7 +405,7 @@ func (c *AnyShareConnector) GetMetadata(ctx context.Context) (map[string]any, er
 		return nil, err
 	}
 	return map[string]any{
-		"connector":        "anyshare",
+		"connector":        interfaces.ConnectorTypeAnyShare,
 		"host":             c.config.Host,
 		"port":             c.config.Port,
 		"doc_lib_type":     c.config.DocLibType,

--- a/adp/vega/vega-backend/server/logics/connectors/local/index/opensearch/opensearch.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/index/opensearch/opensearch.go
@@ -141,12 +141,12 @@ func NewOpenSearchConnector() connectors.IndexConnector {
 
 // GetType returns the data source type.
 func (c *OpenSearchConnector) GetType() string {
-	return "opensearch"
+	return interfaces.ConnectorTypeOpenSearch
 }
 
 // GetName returns the data source name.
 func (c *OpenSearchConnector) GetName() string {
-	return "opensearch"
+	return interfaces.ConnectorTypeOpenSearch
 }
 
 // GetMode returns the connector mode.

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb.go
@@ -71,12 +71,12 @@ func NewMariaDBConnector() connectors.TableConnector {
 
 // GetType returns the data source type.
 func (c *MariaDBConnector) GetType() string {
-	return "mariadb"
+	return interfaces.ConnectorTypeMariaDB
 }
 
 // GetName returns the connector name.
 func (c *MariaDBConnector) GetName() string {
-	return "mariadb"
+	return interfaces.ConnectorTypeMariaDB
 }
 
 // GetMode returns the connector mode.

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/oracle/oracle.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/oracle/oracle.go
@@ -98,12 +98,12 @@ func NewOracleConnector() connectors.TableConnector {
 
 // GetType returns the data source type.
 func (c *OracleConnector) GetType() string {
-	return "oracle"
+	return interfaces.ConnectorTypeOracle
 }
 
 // GetName returns the connector name.
 func (c *OracleConnector) GetName() string {
-	return "oracle"
+	return interfaces.ConnectorTypeOracle
 }
 
 // GetMode returns the connector mode.

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql.go
@@ -53,12 +53,12 @@ func NewPostgresqlConnector() connectors.TableConnector {
 
 // GetType 返回数据源类型键（与 t_connector_type.f_type、factory 注册键一致）。
 func (c *PostgresqlConnector) GetType() string {
-	return "postgresql"
+	return interfaces.ConnectorTypePostgreSQL
 }
 
 // GetName 返回连接器名称。
 func (c *PostgresqlConnector) GetName() string {
-	return "postgresql"
+	return interfaces.ConnectorTypePostgreSQL
 }
 
 // GetMode 返回连接器模式。

--- a/adp/vega/vega-backend/server/logics/dataset/dataset_service.go
+++ b/adp/vega/vega-backend/server/logics/dataset/dataset_service.go
@@ -322,7 +322,7 @@ func (ds *datasetService) CreateBuildTask(ctx context.Context, id string, req *i
 	}
 
 	// Check if catalog connector type is mysql
-	if catalog.ConnectorType != "mysql" {
+	if catalog.ConnectorType != interfaces.ConnectorTypeMySQL {
 		span.SetStatus(codes.Error, "Catalog connector type is not mysql")
 		return "", rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Catalog_InvalidParameter_ConnectorType).
 			WithErrorDetails("Catalog connector type must be mysql")

--- a/adp/vega/vega-backend/server/logics/query/sql_query_service.go
+++ b/adp/vega/vega-backend/server/logics/query/sql_query_service.go
@@ -73,7 +73,7 @@ func (s *sqlQueryService) Execute(ctx context.Context, req *interfaces.SQLQueryR
 	// 如果是流式查询，调用executeStreamQuery方法
 	if req.QueryType == "stream" {
 		// OpenSearch流式查询直接调用executeOpenSearchQuery
-		if req.ResourceType == "opensearch" {
+		if req.ResourceType == interfaces.ConnectorTypeOpenSearch {
 			// 从query中获取resource_id
 			queryMap, ok := req.Query.(map[string]any)
 			if !ok {
@@ -120,7 +120,7 @@ func (s *sqlQueryService) Execute(ctx context.Context, req *interfaces.SQLQueryR
 	}
 
 	// 优先检查resource_type，因为OpenSearch查询的query是JSON对象，不包含resource_id占位符
-	if req.ResourceType == "opensearch" {
+	if req.ResourceType == interfaces.ConnectorTypeOpenSearch {
 		// OpenSearch查询，跳过resource_id提取
 		// 从query中获取resource_id
 		queryMap, ok := req.Query.(map[string]any)
@@ -210,12 +210,12 @@ func (s *sqlQueryService) Execute(ctx context.Context, req *interfaces.SQLQueryR
 		}
 
 		// 根据catalog的ConnectorType来决定调用哪个方法
-		if catalog.ConnectorType == "opensearch" {
+		if catalog.ConnectorType == interfaces.ConnectorTypeOpenSearch {
 			return s.executeOpenSearchQuery(ctx, req, resourceIds, catalog)
 		}
 
 		// 如果指定了resource_type为mysql/mariadb/postgresql，则不进行SQL转换，直接执行
-		if req.ResourceType == "mysql" || req.ResourceType == "mariadb" || req.ResourceType == "postgresql" {
+		if req.ResourceType == interfaces.ConnectorTypeMySQL || req.ResourceType == interfaces.ConnectorTypeMariaDB || req.ResourceType == interfaces.ConnectorTypePostgreSQL {
 			// 将resource_id替换为catalog.schema.table格式
 			replacedSQL, err := s.replaceResourceIdWithSchemaTable(ctx, req.Query, resourceIds, catalog)
 			if err != nil {
@@ -263,9 +263,9 @@ func (s *sqlQueryService) Execute(ctx context.Context, req *interfaces.SQLQueryR
 	// 8. 根据catalog的ConnectorType决定目标SQL方言
 	var targetDialect string
 	switch dataSource.ConnectorType {
-	case "mariadb", "mysql":
+	case interfaces.ConnectorTypeMariaDB, interfaces.ConnectorTypeMySQL:
 		targetDialect = "mysql"
-	case "postgresql":
+	case interfaces.ConnectorTypePostgreSQL:
 		targetDialect = "postgres"
 	default:
 		span.SetStatus(codes.Error, "unsupported connector type")
@@ -330,7 +330,7 @@ func (s *sqlQueryService) validateRequest(ctx context.Context, req *interfaces.S
 	// 如果提供了query参数，需要进行类型校验
 	if req.Query != nil {
 		// 如果是OpenSearch查询，query应该是map类型
-		if req.ResourceType == "opensearch" {
+		if req.ResourceType == interfaces.ConnectorTypeOpenSearch {
 			if _, ok := req.Query.(map[string]any); !ok {
 				return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Query_InvalidParameter).
 					WithErrorDetails("query must be a JSON object for opensearch queries")
@@ -365,7 +365,7 @@ func (s *sqlQueryService) validateRequest(ctx context.Context, req *interfaces.S
 	}
 
 	// 流式查询时，stream_size必填（OpenSearch流式查询除外，使用size参数）
-	if req.QueryType == "stream" && req.ResourceType != "opensearch" && req.StreamSize <= 0 {
+	if req.QueryType == "stream" && req.ResourceType != interfaces.ConnectorTypeOpenSearch && req.StreamSize <= 0 {
 		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Query_InvalidParameter).
 			WithErrorDetails("stream_size is required for stream query and must be greater than 0")
 	}
@@ -501,10 +501,10 @@ func (s *sqlQueryService) executeSQLWithQueryType(ctx context.Context, catalog *
 	// 根据connector类型执行SQL
 	var result *interfaces.SQLQueryResponse
 	switch catalog.ConnectorType {
-	case "mariadb", "mysql":
+	case interfaces.ConnectorTypeMariaDB, interfaces.ConnectorTypeMySQL:
 		mariadbConnector := connector.(*mariadb.MariaDBConnector)
 		result, err = mariadbConnector.ExecuteRawSQL(ctx, sql)
-	case "postgresql":
+	case interfaces.ConnectorTypePostgreSQL:
 		postgresqlConnector := connector.(*postgresql.PostgresqlConnector)
 		result, err = postgresqlConnector.ExecuteRawSQL(ctx, sql)
 	default:
@@ -534,10 +534,10 @@ func (s *sqlQueryService) executeNativeSQL(ctx context.Context, req *interfaces.
 	// 根据resource_type确定connector类型
 	var connectorType string
 	switch req.ResourceType {
-	case "mysql", "mariadb":
-		connectorType = "mariadb"
-	case "postgresql":
-		connectorType = "postgresql"
+	case interfaces.ConnectorTypeMySQL, interfaces.ConnectorTypeMariaDB:
+		connectorType = interfaces.ConnectorTypeMariaDB
+	case interfaces.ConnectorTypePostgreSQL:
+		connectorType = interfaces.ConnectorTypePostgreSQL
 	default:
 		return nil, rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Query_InvalidParameter).
 			WithErrorDetails(fmt.Sprintf("unsupported resource_type: %s", req.ResourceType))
@@ -720,7 +720,7 @@ func (s *sqlQueryService) executeStreamQueryNewSession(ctx context.Context, req 
 	}
 
 	// 4. 检查是否支持流式查询
-	if catalog.ConnectorType != "mariadb" && catalog.ConnectorType != "mysql" && catalog.ConnectorType != "postgresql" {
+	if catalog.ConnectorType != interfaces.ConnectorTypeMariaDB && catalog.ConnectorType != interfaces.ConnectorTypeMySQL && catalog.ConnectorType != interfaces.ConnectorTypePostgreSQL {
 		return nil, rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Query_InvalidParameter).
 			WithErrorDetails(fmt.Sprintf("stream query is not supported for connector type: %s", catalog.ConnectorType))
 	}
@@ -810,9 +810,9 @@ func (s *sqlQueryService) executeSQLWithSession(ctx context.Context, req *interf
 	// 3. 根据catalog的ConnectorType决定目标SQL方言
 	var targetDialect string
 	switch catalog.ConnectorType {
-	case "mariadb", "mysql":
+	case interfaces.ConnectorTypeMariaDB, interfaces.ConnectorTypeMySQL:
 		targetDialect = "mysql"
-	case "postgresql":
+	case interfaces.ConnectorTypePostgreSQL:
 		targetDialect = "postgres"
 	default:
 		return nil, rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Query_InvalidParameter).

--- a/adp/vega/vega-backend/server/logics/query/sqlglot/sqlglot.go
+++ b/adp/vega/vega-backend/server/logics/query/sqlglot/sqlglot.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"vega-backend/interfaces"
 
 	"github.com/kweaver-ai/kweaver-go-lib/logger"
 )
@@ -94,11 +95,11 @@ except Exception as e:
 // MapDataSourceTypeToDialect 将数据源类型映射到sqlglot方言
 func MapDataSourceTypeToDialect(dataSourceType string) (string, error) {
 	switch strings.ToLower(dataSourceType) {
-	case "mysql":
+	case interfaces.ConnectorTypeMySQL:
 		return "mysql", nil
 	case "postgres":
 		return "postgres", nil
-	case "maria", "mariadb":
+	case "maria", interfaces.ConnectorTypeMariaDB:
 		return "mysql", nil // MariaDB使用mysql方言
 	default:
 		logger.Errorf("unsupported dataSourceType: %s", dataSourceType)


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [√] 添加了完整的连接器类型常量定义（MySQL, MariaDB, PostgreSQL, OpenSearch, AnyShare）
- [√] 将代码中硬编码的连接器类型字符串替换为常量引用


---

## Why

- Related Issue: [Issue #251 ](link-to-issue)
- Background:
  - 之前代码中存在大量硬编码的连接器类型字符串，导致代码可维护性差，容易出错
  - 需要统一连接器类型的定义和使用方式，提高代码质量，增加可扩展性
  - 明确区分系统支持的连接器类型和当前统一查询接口支持的连接器类型
---

## How

- Key implementation points:
  - 在 `connector_type.go` 中连接器类型的常量定义
  - 更新了硬编码的引用方式
- Breaking changes (API, config, database, etc.):
  - 无破坏性变更，仅内部实现优化
  - API 接口保持不变，仅代码实现方式改变

---

## Testing

- [√] 代码审查通过
- [√] 确保所有连接器类型常量定义正确
- [√] 确保统一查询硬编码连接器类型字符串已替换为常量引用

Test notes:
  - 这是一个代码重构任务，主要是替换硬编码字符串为常量引用
  - 不涉及功能变更，不需要额外的测试用例

---

## Risk & Rollback

- Potential risks:
  - 风险较低，仅涉及代码重构
  - 可能的风险：如果遗漏了某些硬编码字符串，可能导致部分功能异常
- Rollback plan:
  - 可以通过 git revert 快速回滚
  - 如果发现问题，可以逐个文件回滚修改

---

## Additional Notes
- 本次改动提高了代码的可维护性和可扩展性
- 明确了系统支持的连接器类型和统一查询接口支持的连接器类型的区别
- 为未来添加新的连接器类型提供了清晰的扩展点

- Screenshots, logs, documentation links, etc.:
