### PR TITLE
logic view 查询接口支持limit参数 + 补充logic view 参数校验

### DIFF
--- a/adp/docs/design/vega/features/vega-backend/VEGA_Part8_LogicView_SQLnodeUsage.md
+++ b/adp/docs/design/vega/features/vega-backend/VEGA_Part8_LogicView_SQLnodeUsage.md
@@ -1,0 +1,169 @@
+# SQL 节点模板使用指南
+
+## 概述
+
+SQL 节点支持使用 Go 模板语法编写自定义 SQL，可以引用输入节点的 SQL 并为其添加别名。
+
+## 模板上下文
+
+在 SQL 模板中，可以通过以下两种方式引用输入节点：
+
+### 1. 直接引用（向后兼容）
+
+使用 `.节点ID` 直接获取带别名的子查询 SQL：
+
+```sql
+SELECT * FROM .node1
+WHERE .node1.some_field = 'value'
+```
+
+展开后：
+```sql
+SELECT * FROM (SELECT ... FROM table1) AS node1
+WHERE (SELECT ... FROM table1) AS node1.some_field = 'value'
+```
+
+### 2. 使用模板函数（推荐）
+
+提供三个模板函数，灵活性更高：
+
+#### `node(nodeID)` - 返回带别名的完整 SQL
+
+```sql
+SELECT a.field1, b.field2
+FROM {{ node "node1" }} a
+JOIN {{ node "node2" }} b ON a.id = b.ref_id
+```
+
+展开后：
+```sql
+SELECT a.field1, b.field2
+FROM (SELECT ... FROM table1) AS node1_alias a
+JOIN (SELECT ... FROM table2) AS node2_alias b ON a.id = b.ref_id
+```
+
+#### `nodeSQL(nodeID)` - 仅返回子查询 SQL
+
+```sql
+WITH base AS ({{ nodeSQL "node1" }})
+SELECT * FROM base
+```
+
+展开后：
+```sql
+WITH base AS (SELECT ... FROM table1)
+SELECT * FROM base
+```
+
+#### `nodeAlias(nodeID)` - 返回节点别名
+
+```sql
+SELECT {{ nodeAlias "node1" }}.field1
+FROM {{ node "node1" }}
+```
+
+展开后：
+```sql
+SELECT node1_alias.field1
+FROM (SELECT ... FROM table1) AS node1_alias
+```
+
+## 别名生成规则
+
+节点别名通过 `sanitizeAlias()` 函数自动生成：
+
+1. **替换特殊字符**：所有非字母数字字符替换为下划线
+   - `node-1` → `node_1`
+   - `node.1` → `node_1`
+   - `my-node_1` → `my_node_1`
+
+2. **数字开头处理**：如果以数字开头，添加 `n_` 前缀
+   - `123node` → `n_123node`
+
+3. **长度限制**：最大 60 个字符（MySQL 标识符最大 64 字符）
+
+## 完整示例
+
+### 示例 1：简单查询
+
+**节点配置：**
+- node1: 资源节点，查询 users 表
+- node2: 资源节点，查询 orders 表
+- sql_node: 自定义 SQL 节点，输入 [node1, node2]
+
+**模板 SQL：**
+```sql
+SELECT 
+    u.name,
+    o.order_no,
+    o.amount
+FROM {{ node "node1" }} u
+JOIN {{ node "node2" }} o ON u.id = o.user_id
+WHERE o.amount > {{ .threshold }}
+```
+
+**生成 SQL：**
+```sql
+SELECT 
+    u.name,
+    o.order_no,
+    o.amount
+FROM (SELECT id, name, email FROM users) AS node1 u
+JOIN (SELECT id, user_id, order_no, amount FROM orders) AS node2 o 
+    ON u.id = o.user_id
+WHERE o.amount > 100
+```
+
+### 示例 2：多层嵌套
+
+**模板 SQL：**
+```sql
+WITH base_data AS (
+    SELECT * FROM {{ node "node1" }}
+    WHERE status = 'active'
+)
+SELECT 
+    bd.*,
+    derived.calculated_field
+FROM base_data bd
+CROSS JOIN (
+    SELECT COUNT(*) as calculated_field 
+    FROM {{ node "node2" }}
+) derived
+```
+
+### 示例 3：动态字段引用
+
+**模板 SQL：**
+```sql
+SELECT 
+    {{ nodeAlias "node1" }}.id,
+    {{ nodeAlias "node1" }}.name,
+    {{ nodeAlias "node2" }}.related_info
+FROM {{ node "node1" }}
+LEFT JOIN {{ node "node2" }} 
+    ON {{ nodeAlias "node1" }}.id = {{ nodeAlias "node2" }}.ref_id
+```
+
+## 注意事项
+
+1. **节点 ID 必须存在**：如果模板中引用了不存在的节点 ID，会返回错误
+2. **别名唯一性**：同一 SQL 节点内，不同输入节点的别名保证唯一
+3. **向后兼容**：原有的 `.nodeID` 引用方式仍然可用，会自动展开为带别名的 SQL
+4. **参数化查询**：所有参数使用 `?` 或 `$1, $2` 占位符，由 Squirrel 库处理
+
+## 错误处理
+
+| 错误场景 | 错误信息 |
+|---------|---------|
+| 节点 ID 不存在 | `unknown node ID in template: xxx` |
+| 模板语法错误 | `failed to parse SQL template for node xxx: ...` |
+| 模板执行错误 | `failed to execute SQL template for node xxx: ...` |
+| 输入节点构建失败 | `failed to build sql node input xxx: ...` |
+
+## 最佳实践
+
+1. **使用模板函数而非直接引用**：`{{ node "node1" }}` 比 `.node1` 更清晰
+2. **为子查询添加别名**：便于在 SELECT/WHERE/JOIN 中引用
+3. **避免过深嵌套**：递归深度受 `MaxRecursionDepth` 限制
+4. **测试复杂模板**：使用单元测试验证生成的 SQL 是否正确

--- a/adp/vega/vega-backend/server/driveradapters/validate.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate.go
@@ -25,7 +25,7 @@ func validateID(ctx context.Context, ID string) error {
 		return nil
 	}
 
-	// 非内置视图校验数据视图 id，只包含小写英文字母和数字和下划线(_)和连字符(-)，且不能以下划线开头，不能超过40个字符
+	// 非内置视图校验逻辑视图 id，只包含小写英文字母和数字和下划线(_)和连字符(-)，且不能以下划线开头，不能超过40个字符
 	re := regexp2.MustCompile(interfaces.RegexPattern_NonBuiltin_ViewID, regexp2.RE2)
 	match, err := re.MatchString(ID)
 	if err != nil || !match {

--- a/adp/vega/vega-backend/server/driveradapters/validate_resource.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_resource.go
@@ -128,7 +128,7 @@ func validateViewFields(ctx context.Context, viewFields []*interfaces.ViewProper
 		if _, ok := nameMap[field.Name]; !ok {
 			nameMap[field.Name] = struct{}{}
 		} else {
-			errDetails := fmt.Sprintf("Data view field '%s' name '%s' already exists", field.Name, field.Name)
+			errDetails := fmt.Sprintf("Logic view field '%s' name '%s' already exists", field.Name, field.Name)
 			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_Duplicated_FieldName).
 				WithDescription(map[string]any{"FieldName": field.Name}).
 				WithErrorDetails(errDetails)
@@ -137,7 +137,7 @@ func validateViewFields(ctx context.Context, viewFields []*interfaces.ViewProper
 		if _, ok := displayNameMap[field.DisplayName]; !ok {
 			displayNameMap[field.DisplayName] = struct{}{}
 		} else {
-			errDetails := fmt.Sprintf("Data view field '%s' display name '%s' already exists", field.Name, field.DisplayName)
+			errDetails := fmt.Sprintf("Logic view field '%s' display name '%s' already exists", field.Name, field.DisplayName)
 			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_Duplicated_FieldDisplayName).
 				WithDescription(map[string]any{"FieldName": field.Name, "DisplayName": field.DisplayName}).
 				WithErrorDetails(errDetails)
@@ -174,7 +174,7 @@ func validateFeatures(ctx context.Context, fieldsMap map[string]*interfaces.View
 		if _, ok := featureNameMap[f.FeatureName]; !ok {
 			featureNameMap[f.FeatureName] = struct{}{}
 		} else {
-			errDetails := fmt.Sprintf("Data view field feature '%s' name '%s' already exists", f.FeatureName, f.FeatureName)
+			errDetails := fmt.Sprintf("Logic view field feature '%s' name '%s' already exists", f.FeatureName, f.FeatureName)
 			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_Duplicated_FieldFeatureName).
 				WithDescription(map[string]any{"FieldFeatureName": f.FeatureName}).
 				WithErrorDetails(errDetails)

--- a/adp/vega/vega-backend/server/errors/logic_view.go
+++ b/adp/vega/vega-backend/server/errors/logic_view.go
@@ -9,6 +9,7 @@ package errors
 // Resource 错误码
 const (
 	// LogicView 校验相关
+	VegaBackend_LogicView_InvalidParameter_JoinType          = "VegaBackend.LogicView.InvalidParameter.JoinType"
 	VegaBackend_LogicView_InvalidParameter_LogicDefinition   = "VegaBackend.LogicView.InvalidParameter.LogicDefinition"
 	VegaBackend_LogicView_InvalidParameter_FieldName         = "VegaBackend.LogicView.InvalidParameter.FieldName"
 	VegaBackend_LogicView_LengthExceeded_FieldName           = "VegaBackend.LogicView.LengthExceeded.FieldName"
@@ -23,6 +24,7 @@ const (
 )
 
 var LogicViewErrCodeList = []string{
+	VegaBackend_LogicView_InvalidParameter_JoinType,
 	VegaBackend_LogicView_InvalidParameter_LogicDefinition,
 	VegaBackend_LogicView_InvalidParameter_FieldName,
 	VegaBackend_LogicView_LengthExceeded_FieldName,

--- a/adp/vega/vega-backend/server/errors/logic_view.go
+++ b/adp/vega/vega-backend/server/errors/logic_view.go
@@ -11,6 +11,7 @@ const (
 	// LogicView 校验相关
 	VegaBackend_LogicView_InvalidParameter_JoinType          = "VegaBackend.LogicView.InvalidParameter.JoinType"
 	VegaBackend_LogicView_InvalidParameter_LogicDefinition   = "VegaBackend.LogicView.InvalidParameter.LogicDefinition"
+	VegaBackend_LogicView_Duplicated_NodeID                  = "VegaBackend.LogicView.Duplicated.NodeID"
 	VegaBackend_LogicView_InvalidParameter_FieldName         = "VegaBackend.LogicView.InvalidParameter.FieldName"
 	VegaBackend_LogicView_LengthExceeded_FieldName           = "VegaBackend.LogicView.LengthExceeded.FieldName"
 	VegaBackend_LogicView_LengthExceeded_FieldDisplayName    = "VegaBackend.LogicView.LengthExceeded.FieldDisplayName"
@@ -26,6 +27,7 @@ const (
 var LogicViewErrCodeList = []string{
 	VegaBackend_LogicView_InvalidParameter_JoinType,
 	VegaBackend_LogicView_InvalidParameter_LogicDefinition,
+	VegaBackend_LogicView_Duplicated_NodeID,
 	VegaBackend_LogicView_InvalidParameter_FieldName,
 	VegaBackend_LogicView_LengthExceeded_FieldName,
 	VegaBackend_LogicView_LengthExceeded_FieldDisplayName,

--- a/adp/vega/vega-backend/server/interfaces/logic_view_service.go
+++ b/adp/vega/vega-backend/server/interfaces/logic_view_service.go
@@ -29,10 +29,10 @@ const (
 	LogicDefinitionNodeType_Output   = "output"
 
 	// join的类型
-	JoinType_Inner     = "inner"
-	JoinType_Left      = "left"
-	JoinType_Right     = "right"
-	JoinType_FullOuter = "full outer"
+	JoinType_Inner = "inner"
+	JoinType_Left  = "left"
+	JoinType_Right = "right"
+	// JoinType_FullOuter = "full outer"
 
 	// union的类型
 	UnionType_All      = "all"
@@ -63,10 +63,9 @@ var (
 	}
 
 	JoinTypeMap = map[string]struct{}{
-		JoinType_Inner:     {},
-		JoinType_Left:      {},
-		JoinType_Right:     {},
-		JoinType_FullOuter: {},
+		JoinType_Inner: {},
+		JoinType_Left:  {},
+		JoinType_Right: {},
 	}
 
 	UnionTypeMap = map[string]struct{}{

--- a/adp/vega/vega-backend/server/interfaces/query.go
+++ b/adp/vega/vega-backend/server/interfaces/query.go
@@ -7,6 +7,11 @@ package interfaces
 
 import "context"
 
+const (
+	QueryType_Standard = "standard" // 标准查询
+	QueryType_Stream   = "stream"   // 流式查询
+)
+
 // QueryExecuteRequest 统一查询请求；query_id 必填，用于游标 session
 type QueryExecuteRequest struct {
 	QueryID         string         `json:"query_id"`                   // 必填，同一轮查询一致

--- a/adp/vega/vega-backend/server/locale/logic_view.en-US.toml
+++ b/adp/vega/vega-backend/server/locale/logic_view.en-US.toml
@@ -1,3 +1,8 @@
+[VegaBackend.LogicView.InvalidParameter.JoinType]
+Description = "Invalid logic view join type"
+Solution = "Please check the join type of the logic view definition"
+ErrorLink = "None"
+
 [VegaBackend.LogicView.InvalidParameter.LogicDefinition]
 Description = "Invalid logic view definition"
 Solution = "Please check the logic view definition"

--- a/adp/vega/vega-backend/server/locale/logic_view.en-US.toml
+++ b/adp/vega/vega-backend/server/locale/logic_view.en-US.toml
@@ -28,13 +28,18 @@ Description = "Field comment length exceeded"
 Solution = "Please shorten the field comment"
 ErrorLink = "None"
 
+[VegaBackend.LogicView.Duplicated.NodeID]
+Description = "Logic view logic definition node id duplicated"
+Solution = "Please use different logic definition node id"
+ErrorLink = "None"
+
 [VegaBackend.LogicView.Duplicated.FieldName]
-Description = "Data view field name already exists"
+Description = "Logic view field name already exists"
 Solution = "Please use a different field name"
 ErrorLink = "None"
 
 [VegaBackend.LogicView.Duplicated.FieldDisplayName]
-Description = "Data view field display name already exists"
+Description = "Logic view field display name already exists"
 Solution = "Please use a different display name"
 ErrorLink = "None"
 

--- a/adp/vega/vega-backend/server/locale/logic_view.zh-CN.toml
+++ b/adp/vega/vega-backend/server/locale/logic_view.zh-CN.toml
@@ -1,3 +1,8 @@
+[VegaBackend.LogicView.InvalidParameter.JoinType]
+Description = "不支持的逻辑视图关联类型"
+Solution = "请检查逻辑视图join节点join_type配置"
+ErrorLink = "暂无"
+
 [VegaBackend.LogicView.InvalidParameter.LogicDefinition]
 Description = "无效的逻辑视图定义"
 Solution = "请检查逻辑视图定义"

--- a/adp/vega/vega-backend/server/locale/logic_view.zh-CN.toml
+++ b/adp/vega/vega-backend/server/locale/logic_view.zh-CN.toml
@@ -28,13 +28,18 @@ Description = "字段备注长度超限"
 Solution = "请缩短备注内容"
 ErrorLink = "暂无"
 
+[VegaBackend.LogicView.Duplicated.NodeID]
+Description = "逻辑视图逻辑定义里节点ID重复"
+Solution = "请使用不同的节点ID"
+ErrorLink = "暂无"
+
 [VegaBackend.LogicView.Duplicated.FieldName]
-Description = "数据视图字段名称已存在"
+Description = "逻辑视图字段名称已存在"
 Solution = "请使用不同的字段名称"
 ErrorLink = "暂无"
 
 [VegaBackend.LogicView.Duplicated.FieldDisplayName]
-Description = "数据视图字段显示名称已存在"
+Description = "逻辑视图字段显示名称已存在"
 Solution = "请使用不同的显示名称"
 ErrorLink = "暂无"
 

--- a/adp/vega/vega-backend/server/logics/resource/logic_view.go
+++ b/adp/vega/vega-backend/server/logics/resource/logic_view.go
@@ -214,10 +214,10 @@ func validateJoinNode(ctx context.Context, node *interfaces.LogicDefinitionNode,
 			WithErrorDetails("The logic definition join config is invalid")
 	}
 
-	// join_type 只能为 inner, left, right, full outer
+	// join_type 只能为 inner, left, right
 	if _, ok := interfaces.JoinTypeMap[cfg.JoinType]; !ok {
-		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
-			WithErrorDetails("The logic definition join config is invalid, join_type must be inner, left, right, full outer")
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_JoinType).
+			WithErrorDetails("The logic definition join config is invalid, join_type must be inner, left, right")
 	}
 
 	// join_on 校验

--- a/adp/vega/vega-backend/server/logics/resource/logic_view.go
+++ b/adp/vega/vega-backend/server/logics/resource/logic_view.go
@@ -32,9 +32,18 @@ func (rs *resourceService) validateLogicDefinition(ctx context.Context, view *in
 			WithErrorDetails("Logic definition is empty")
 	}
 
+	// 校验节点ID的唯一性
 	nodeMap := make(map[string]struct{})
-	for _, ds := range view.LogicDefinition {
-		nodeMap[ds.ID] = struct{}{}
+	for _, node := range view.LogicDefinition {
+		if node.ID == "" {
+			return "", rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+				WithErrorDetails("Node ID cannot be empty")
+		}
+		if _, exists := nodeMap[node.ID]; exists {
+			return "", rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_Duplicated_NodeID).
+				WithErrorDetails(fmt.Sprintf("Duplicate node ID found: %s", node.ID))
+		}
+		nodeMap[node.ID] = struct{}{}
 	}
 
 	resourceNodeCount := 0

--- a/adp/vega/vega-backend/server/logics/resource_data/logic_view/dsl/dsl.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/logic_view/dsl/dsl.go
@@ -42,20 +42,6 @@ func NewlogicViewDSLGenerator(nodes []*interfaces.LogicDefinitionNode) *logicVie
 	}
 }
 
-// func marshalDSL(dsl interfaces.DSLCfg) (bytes.Buffer, error) {
-// 	// 序列化为JSON
-// 	dslBytes, err := sonic.Marshal(dsl)
-// 	if err != nil {
-// 		return bytes.Buffer{}, fmt.Errorf("data view marshal interfaces.DSLCfg error: %s", err.Error())
-// 	}
-
-// 	var queryBuffer bytes.Buffer
-// 	queryBuffer.Write(dslBytes)
-
-// 	// fmt.Println(queryBuffer.String())
-// 	return queryBuffer, nil
-// }
-
 // DSL生成器
 func (g *logicViewDSLGenerator) BuildDSL(ctx context.Context, query interfaces.ResourceDataQueryParams, view *interfaces.LogicView,
 	viewIndicesMap map[string][]string) (interfaces.DSLCfg, error) {

--- a/adp/vega/vega-backend/server/logics/resource_data/logic_view/logic_view.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/logic_view/logic_view.go
@@ -350,24 +350,23 @@ func (lvs *logicViewService) executeCompositeViewBySQL(ctx context.Context, view
 	logger.Infof("executeCompositeViewBySQL Final SQL: [%s]", finalSql)
 
 	if view.IsSingleSource {
-		var resourceType string
-		for _, ref := range view.RefResources {
-			catalog, err := lvs.cs.GetByID(ctx, ref.CatalogID, true)
-			if err != nil {
-				return nil, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_Resource_InternalError).
-					WithErrorDetails(fmt.Sprintf("failed to get catalog: %v", err))
-			}
-			if catalog == nil {
-				return nil, 0, rest.NewHTTPError(ctx, http.StatusNotFound, verrors.VegaBackend_Resource_CatalogNotFound).
-					WithErrorDetails(fmt.Sprintf("catalog %s not found", ref.CatalogID))
-			}
-			resourceType = catalog.ConnectorType
-			break
-		}
+		// var resourceType string
+		// for _, ref := range view.RefResources {
+		// 	catalog, err := lvs.cs.GetByID(ctx, ref.CatalogID, true)
+		// 	if err != nil {
+		// 		return nil, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_Resource_InternalError).
+		// 			WithErrorDetails(fmt.Sprintf("failed to get catalog: %v", err))
+		// 	}
+		// 	if catalog == nil {
+		// 		return nil, 0, rest.NewHTTPError(ctx, http.StatusNotFound, verrors.VegaBackend_Resource_CatalogNotFound).
+		// 			WithErrorDetails(fmt.Sprintf("catalog %s not found", ref.CatalogID))
+		// 	}
+		// 	resourceType = catalog.ConnectorType
+		// 	break
+		// }
 
 		req := interfaces.SQLQueryRequest{
 			Query:        finalSql,
-			ResourceType: resourceType,
 			QueryType:    params.QueryType,
 			StreamSize:   params.Limit,
 			QueryTimeout: int(params.Timeout),

--- a/adp/vega/vega-backend/server/logics/resource_data/logic_view/sql/sql.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/logic_view/sql/sql.go
@@ -436,16 +436,66 @@ func (g *logicViewSQLGenerator) buildSqlNodeSQL(ctx context.Context, node *inter
 	g.nodeFieldsMap[node.ID] = outputFieldsMap
 
 	var allArgs []any
+
+	// 预构建所有输入节点的 SQL 并生成别名
+	type nodeContext struct {
+		SQL     string
+		Alias   string
+		WithSQL string // 带别名的完整 SQL: (subquery) AS alias
+	}
+	nodeContexts := make(map[string]*nodeContext)
+
+	for _, inputID := range node.Inputs {
+		subSQL, subArgs, err := g.buildNodeSQL(ctx, inputID, depth)
+		if err != nil {
+			return "", nil, fmt.Errorf("failed to build sql node input %s: %w", inputID, err)
+		}
+		allArgs = append(allArgs, subArgs...)
+
+		// 生成唯一别名：将节点 ID 中的特殊字符替换为下划线
+		alias := sanitizeAlias(inputID)
+
+		nodeContexts[inputID] = &nodeContext{
+			SQL:     subSQL,
+			Alias:   alias,
+			WithSQL: fmt.Sprintf("(%s) AS %s", subSQL, alias),
+		}
+	}
+
 	// 创建模板函数映射
 	funcMap := template.FuncMap{
+		// node 函数：返回带别名的子查询 SQL
 		"node": func(nodeID string) (string, error) {
-			subSQL, subArgs, err := g.buildNodeSQL(ctx, nodeID, depth)
-			if err != nil {
-				return "", err
+			ctx, ok := nodeContexts[nodeID]
+			if !ok {
+				return "", fmt.Errorf("unknown node ID in template: %s", nodeID)
 			}
-			allArgs = append(allArgs, subArgs...)
-			return "(" + subSQL + ")", nil
+			return ctx.WithSQL, nil
 		},
+		// nodeSQL 函数：仅返回子查询 SQL（不带别名和括号）
+		"nodeSQL": func(nodeID string) (string, error) {
+			ctx, ok := nodeContexts[nodeID]
+			if !ok {
+				return "", fmt.Errorf("unknown node ID in template: %s", nodeID)
+			}
+			return ctx.SQL, nil
+		},
+		// nodeAlias 函数：返回节点别名
+		"nodeAlias": func(nodeID string) (string, error) {
+			ctx, ok := nodeContexts[nodeID]
+			if !ok {
+				return "", fmt.Errorf("unknown node ID in template: %s", nodeID)
+			}
+			return ctx.Alias, nil
+		},
+	}
+
+	// 准备模板上下文：提供两种引用方式
+	// 1. 直接使用 .node1 会获取带别名的 SQL（向后兼容）
+	// 2. 使用模板函数 node()/nodeSQL()/nodeAlias() 获取不同形式
+	contextMap := make(map[string]string)
+	for inputID, ctx := range nodeContexts {
+		contextMap[inputID] = ctx.WithSQL
 	}
 
 	// 解析模板
@@ -454,23 +504,27 @@ func (g *logicViewSQLGenerator) buildSqlNodeSQL(ctx context.Context, node *inter
 		return "", nil, fmt.Errorf("failed to parse SQL template for node %s: %w", node.ID, err)
 	}
 
-	// 准备上下文
-	contextMap := make(map[string]string)
-	for _, inputID := range node.Inputs {
-		subSQL, subArgs, err := g.buildNodeSQL(ctx, inputID, depth)
-		if err != nil {
-			return "", nil, fmt.Errorf("failed to build sql node input %s: %w", inputID, err)
-		}
-		contextMap[inputID] = "(" + subSQL + ")"
-		allArgs = append(allArgs, subArgs...)
-	}
-
 	var result strings.Builder
 	if err := tmpl.Execute(&result, contextMap); err != nil {
 		return "", nil, fmt.Errorf("failed to execute SQL template for node %s: %w", node.ID, err)
 	}
 
 	return result.String(), allArgs, nil
+}
+
+// sanitizeAlias 清理节点 ID 生成合法的 SQL 别名
+func sanitizeAlias(nodeID string) string {
+	// 替换所有非字母数字字符为下划线
+	alias := regexp.MustCompile(`[^a-zA-Z0-9_]`).ReplaceAllString(nodeID, "_")
+	// 如果以数字开头，添加前缀
+	if len(alias) > 0 && alias[0] >= '0' && alias[0] <= '9' {
+		alias = "n_" + alias
+	}
+	// 限制长度（MySQL 标识符最大 64 字符）
+	if len(alias) > 60 {
+		alias = alias[:60]
+	}
+	return alias
 }
 
 // GetNodeFieldsMap 获取节点的输出字段map

--- a/adp/vega/vega-backend/server/logics/resource_data/logic_view/sql/sql.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/logic_view/sql/sql.go
@@ -678,7 +678,7 @@ func (b *SQLBuilder) ApplyParams(ctx context.Context, params *interfaces.Resourc
 	}
 
 	// 3. 处理分页/限制
-	if params.QueryType == "standard" && params.Limit > 0 {
+	if (params.QueryType == "" || params.QueryType == interfaces.QueryType_Standard) && params.Limit > 0 {
 		b.Limit(params.Limit)
 	}
 

--- a/adp/vega/vega-backend/server/logics/resource_data/logic_view/sql/sql.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/logic_view/sql/sql.go
@@ -248,11 +248,6 @@ func (g *logicViewSQLGenerator) buildJoinNodeSQL(ctx context.Context, node *inte
 		return "", nil, fmt.Errorf("join node must have exactly 2 inputs, got %d", len(node.Inputs))
 	}
 
-	// MariaDB 不支持 FULL OUTER JOIN
-	if strings.EqualFold(cfg.JoinType, interfaces.JoinType_FullOuter) {
-		return "", nil, fmt.Errorf("MariaDB does not support FULL OUTER JOIN, please use LEFT JOIN + UNION instead")
-	}
-
 	leftID := node.Inputs[0]
 	rightID := node.Inputs[1]
 


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] 逻辑视图（Logic View）handler / service 校验与 SQL 生成增强
- [x] 同步更新文档 `adp/docs/design/vega/features/vega-backend/VEGA_Part8_LogicView_SQLnodeUsage.md`

---

## Why

- Related Issue: https://github.com/kweaver-ai/kweaver-core/issues/235
- Background:
  - issue #235：`/resources/{id}/data` 查询接口中 `limit` 参数传入后未真正生效，后台执行 SQL 未附加 limit，导致结果集不受控
  - 逻辑视图节点校验不完备：`logic_definition` 中节点 ID 允许重复、`join_type` 错误仅能归入通用参数错误码、错误文案仍残留 "Data view"
  - SQL 节点缺少以模板方式引用其他输入节点的能力，表达力不足
  - MariaDB 不支持 `FULL OUTER JOIN`，原实现既声明支持又在底层报错，容易误导

---

## How

### 关键实现点

1. **SQL 节点模板支持**（`logics/resource_data/logic_view/sql/sql.go`）
   - 预构建所有输入节点的子查询 SQL 并生成唯一别名
   - 新增模板函数 `node / nodeSQL / nodeAlias`，支持 `{{ node "id" }}` 形式的引用
   - 保留 `.nodeID` 直接引用方式，向后兼容
   - 别名生成规则：非字母数字替换为 `_`、数字开头加 `n_` 前缀、长度限制 60 字符
2. **Logic View 参数校验补强**（`logics/resource/logic_view.go`）
   - 校验 `LogicDefinition` 中节点 ID 非空且唯一，新增错误码 `VegaBackend.LogicView.Duplicated.NodeID`
   - `join_type` 单独走 `VegaBackend.LogicView.InvalidParameter.JoinType` 错误码，便于前端区分提示
3. **去除 FULL OUTER JOIN 支持**（`interfaces/logic_view_service.go`、`sql/sql.go`）
   - `JoinTypeMap` 移除 `full outer`，上层在校验阶段即拦截，`buildJoinNodeSQL` 中移除 MariaDB 兜底报错
4. **Query 常量提取**（`interfaces/query.go`）
   - 新增 `QueryType_Standard / QueryType_Stream` 常量
5. **SQL 查询不再传 ResourceType**（`logic_view.go`）
   - 注释/去除通过 `catalog.ConnectorType` 推导 `resourceType` 的逻辑，交由下游处理
6. **文案与校验注释**
   - validate.go / validate_resource.go / locale toml 中 "Data view" 改为 "Logic view"
7. **文档新增**：`VEGA_Part8_LogicView_SQLnodeUsage.md` 说明 SQL 节点模板用法、别名规则、完整示例、错误处理与最佳实践

### Breaking Changes

- `JoinType_FullOuter` 不再被接受；若有请求使用 `full outer` 将返回 `VegaBackend.LogicView.InvalidParameter.JoinType`
- `LogicDefinition` 中重复节点 ID 原先会被静默覆盖，现直接报 `Duplicated.NodeID`
- 错误码枚举新增两项：`InvalidParameter.JoinType`、`Duplicated.NodeID`（locale 同步更新 zh-CN / en-US）

---

## Testing

- [ ] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:
- 本地验证 logic view 查询接口 `limit` 参数透传生效
- 构造重复节点 ID 的 logic_definition 请求，返回 `VegaBackend.LogicView.Duplicated.NodeID`
- 构造 `join_type=full outer` 请求，返回 `VegaBackend.LogicView.InvalidParameter.JoinType`
- SQL 节点使用 `{{ node "x" }}` / `{{ nodeSQL "x" }}` / `{{ nodeAlias "x" }}` 展开均符合文档示例

---

## Risk & Rollback

- 潜在风险：
  - 已有调用方若仍在使用 `full outer` join 或重复节点 ID，会收到新错误码
  - SQL 模板新函数若被误用（未定义节点 ID）会直接返回错误而非静默展开
- 回滚计划：revert 本 PR 的 6 个 commit 即可恢复此前行为（`JoinTypeMap` 恢复 FullOuter、去除新校验与模板函数）

---

## Additional Notes

- 新增文档路径：`adp/docs/design/vega/features/vega-backend/VEGA_Part8_LogicView_SQLnodeUsage.md`
- 相关 commits：
  - `refactor(interfaces): add query type constants for clarity`
  - `feat(sql): 增加 SQL 节点模板自定义支持与别名生成机制`
  - `[fix] sql 查询不传 resource type`
  - `refactor(sql): 移除 MariaDB 不支持的 FULL OUTER JOIN 限制和相关提示`
  - `[fix] logic view 不支持 full outer`
  - `[fix] logic definition node id 不能重复`
