### PR TITLE
fix(bkn): action-type execute 缺参时返回 400 而非静默丢弃 (#285)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ env/
 *.swp
 *.swo
 .claude
+.cursor
 *~
 
 # Testing

--- a/adp/bkn/ontology-query/server/interfaces/action_type.go
+++ b/adp/bkn/ontology-query/server/interfaces/action_type.go
@@ -10,6 +10,7 @@ import cond "ontology-query/common/condition"
 // 行动查询请求体
 type ActionQuery struct {
 	InstanceIdentities []map[string]any `json:"_instance_identities,omitempty"`
+	DynamicParams      map[string]any   `json:"dynamic_params,omitempty"`
 
 	KNID         string `json:"-"`
 	Branch       string `json:"-"`

--- a/adp/bkn/ontology-query/server/logics/action_scheduler/action_scheduler_service.go
+++ b/adp/bkn/ontology-query/server/logics/action_scheduler/action_scheduler_service.go
@@ -101,6 +101,11 @@ func (s *actionSchedulerService) ExecuteAction(ctx context.Context, req *interfa
 			WithErrorDetails(fmt.Sprintf("Action type not found: %s", req.ActionTypeID))
 	}
 
+	if missing := logics.MissingActionInputDynamicParamNames(&actionType, req.DynamicParams); len(missing) > 0 {
+		return nil, rest.NewHTTPError(ctx, http.StatusBadRequest, oerrors.OntologyQuery_ActionExecution_InvalidParameter).
+			WithErrorDetails(fmt.Sprintf("当前请求执行的行动类[%s]所需的动态参数未完整传入，缺少参数 %v，请在请求的 dynamic_params 中填充", actionType.ATName, missing))
+	}
+
 	// Get instances based on action type configuration and request parameters
 	instances, objDatas, err := s.getInstancesForAction(ctx, &actionType, req.KNID, req.Branch, req.InstanceIdentities)
 	if err != nil {
@@ -678,7 +683,7 @@ func (s *actionSchedulerService) buildExecutionParams(actionType *interfaces.Act
 		case interfaces.LOGIC_PARAMS_VALUE_FROM_CONST:
 			setNestedValue(params, param.Name, param.Value)
 		case interfaces.LOGIC_PARAMS_VALUE_FROM_INPUT:
-			if val := getNestedValue(dynamicParams, param.Name); val != nil {
+			if val := logics.ActionDynamicParamGetValue(dynamicParams, param.Name); val != nil {
 				setNestedValue(params, param.Name, val)
 			}
 		}

--- a/adp/bkn/ontology-query/server/logics/action_scheduler/action_scheduler_service_test.go
+++ b/adp/bkn/ontology-query/server/logics/action_scheduler/action_scheduler_service_test.go
@@ -499,6 +499,99 @@ func Test_ActionExecution_Snapshot(t *testing.T) {
 	})
 }
 
+func Test_ExecuteAction_InputDynamicParamsValidation(t *testing.T) {
+	Convey("行动执行：行动类含 input 参数时，dynamic_params 未给齐则返回 400", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		appSetting := &common.AppSetting{}
+		omAccess := omock.NewMockOntologyManagerAccess(mockCtrl)
+
+		logics.OMA = omAccess
+
+		service := &actionSchedulerService{
+			appSetting: appSetting,
+			omAccess:   omAccess,
+		}
+
+		ctx := context.Background()
+		baseActionType := func(extraParams ...interfaces.Parameter) interfaces.ActionType {
+			p := []interfaces.Parameter{{Name: "token", ValueFrom: interfaces.LOGIC_PARAMS_VALUE_FROM_INPUT}}
+			p = append(p, extraParams...)
+			return interfaces.ActionType{
+				ATID:       "at_001",
+				ATName:     "needs_input",
+				Parameters: p,
+			}
+		}
+
+		Convey("未提供 dynamic_params", func() {
+			actionType := baseActionType()
+			omAccess.EXPECT().GetActionType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(actionType, map[string]any{}, true, nil)
+
+			req := &interfaces.ActionExecutionRequest{
+				KNID:               "kn_001",
+				ActionTypeID:       "at_001",
+				InstanceIdentities: []map[string]any{{"id": "1"}},
+			}
+
+			_, err := service.ExecuteAction(ctx, req)
+			So(err, ShouldNotBeNil)
+			httpErr, ok := err.(*rest.HTTPError)
+			So(ok, ShouldBeTrue)
+			So(httpErr.HTTPCode, ShouldEqual, http.StatusBadRequest)
+			So(httpErr.BaseError.ErrorCode, ShouldEqual, oerrors.OntologyQuery_ActionExecution_InvalidParameter)
+		})
+
+		Convey("仅提供部分 input（缺少另一个参数）", func() {
+			actionType := baseActionType(interfaces.Parameter{
+				Name: "other", ValueFrom: interfaces.LOGIC_PARAMS_VALUE_FROM_INPUT,
+			})
+			omAccess.EXPECT().GetActionType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(actionType, map[string]any{}, true, nil)
+
+			req := &interfaces.ActionExecutionRequest{
+				KNID:               "kn_001",
+				ActionTypeID:       "at_001",
+				InstanceIdentities: []map[string]any{{"id": "1"}},
+				DynamicParams: map[string]any{
+					"token": "ok",
+				},
+			}
+
+			_, err := service.ExecuteAction(ctx, req)
+			So(err, ShouldNotBeNil)
+			httpErr, ok := err.(*rest.HTTPError)
+			So(ok, ShouldBeTrue)
+			So(httpErr.HTTPCode, ShouldEqual, http.StatusBadRequest)
+			So(httpErr.BaseError.ErrorCode, ShouldEqual, oerrors.OntologyQuery_ActionExecution_InvalidParameter)
+		})
+
+		Convey("dynamic_params 中某 key 为 null，视为未提供", func() {
+			actionType := baseActionType()
+			omAccess.EXPECT().GetActionType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(actionType, map[string]any{}, true, nil)
+
+			req := &interfaces.ActionExecutionRequest{
+				KNID:               "kn_001",
+				ActionTypeID:       "at_001",
+				InstanceIdentities: []map[string]any{{"id": "1"}},
+				DynamicParams: map[string]any{
+					"token": nil,
+				},
+			}
+
+			_, err := service.ExecuteAction(ctx, req)
+			So(err, ShouldNotBeNil)
+			httpErr, ok := err.(*rest.HTTPError)
+			So(ok, ShouldBeTrue)
+			So(httpErr.HTTPCode, ShouldEqual, http.StatusBadRequest)
+			So(httpErr.BaseError.ErrorCode, ShouldEqual, oerrors.OntologyQuery_ActionExecution_InvalidParameter)
+		})
+	})
+}
+
 func Test_ExecuteAction_ScanMode(t *testing.T) {
 	Convey("Test ExecuteAction with scan mode (empty _instance_identities)", t, func() {
 		mockCtrl := gomock.NewController(t)

--- a/adp/bkn/ontology-query/server/logics/action_type/action_type_service.go
+++ b/adp/bkn/ontology-query/server/logics/action_type/action_type_service.go
@@ -89,6 +89,12 @@ func (ats *actionTypeService) GetActionsByActionTypeID(ctx context.Context,
 		return resps, rest.NewHTTPError(ctx, http.StatusNotFound, oerrors.OntologyQuery_ObjectType_ObjectTypeNotFound)
 	}
 
+	if missing := logics.MissingActionInputDynamicParamNames(&actionType, query.DynamicParams); len(missing) > 0 {
+		return resps, rest.NewHTTPError(ctx, http.StatusBadRequest,
+			oerrors.OntologyQuery_ActionType_InvalidParameter_DynamicParams).
+			WithErrorDetails(fmt.Sprintf("当前请求查询的行动类[%s]所需的动态参数未完整传入，缺少参数 %v，请在请求的 dynamic_params 中填充", actionType.ATName, missing))
+	}
+
 	// 2. 检查是否绑定了对象类
 	isObjectTypeBound := actionType.ObjectTypeID != ""
 	var objectType interfaces.ObjectType
@@ -113,7 +119,7 @@ func (ats *actionTypeService) GetActionsByActionTypeID(ctx context.Context,
 		if len(query.InstanceIdentities) == 0 {
 			// Case 4: 未绑定对象类 + 无 identities → 构造一个临时的虚拟实例
 			logger.Infof("No identities provided, creating virtual instance for action type %s", actionType.ATID)
-			virtualAction, err := buildActionFromInstanceData(map[string]any{}, &actionType)
+			virtualAction, err := buildActionFromInstanceData(map[string]any{}, &actionType, query.DynamicParams)
 			if err != nil {
 				logger.Errorf("Error building virtual action: %v", err)
 				return resps, rest.NewHTTPError(ctx, http.StatusBadRequest, oerrors.OntologyQuery_InternalError_UnMarshalDataFailed).
@@ -136,7 +142,7 @@ func (ats *actionTypeService) GetActionsByActionTypeID(ctx context.Context,
 			logger.Infof("Constructing instances from identities for action type %s", actionType.ATID)
 			actions := []interfaces.ActionParam{}
 			for _, identity := range query.InstanceIdentities {
-				action, err := buildActionFromInstanceData(identity, &actionType)
+				action, err := buildActionFromInstanceData(identity, &actionType, query.DynamicParams)
 				if err != nil {
 					logger.Errorf("Error building action from instance data: %v", err)
 					return resps, rest.NewHTTPError(ctx, http.StatusBadRequest, oerrors.OntologyQuery_InternalError_UnMarshalDataFailed).
@@ -207,7 +213,7 @@ func (ats *actionTypeService) GetActionsByActionTypeID(ctx context.Context,
 				}
 
 				// 满足条件，构造行动数据
-				action, err := buildActionFromInstanceData(instanceIdentity, &actionType)
+				action, err := buildActionFromInstanceData(instanceIdentity, &actionType, query.DynamicParams)
 				if err != nil {
 					logger.Errorf("Error building action from instance data: %v", err)
 					return resps, rest.NewHTTPError(ctx, http.StatusBadRequest, oerrors.OntologyQuery_InternalError_UnMarshalDataFailed).
@@ -285,7 +291,8 @@ func (ats *actionTypeService) GetActionsByActionTypeID(ctx context.Context,
 							actionType.ATName, param.Name, err.Error()))
 				}
 			case interfaces.LOGIC_PARAMS_VALUE_FROM_INPUT:
-				dynamicParamsJson, err = sjson.Set(dynamicParamsJson, param.Name, nil)
+				val := logics.ActionDynamicParamGetValue(query.DynamicParams, param.Name)
+				dynamicParamsJson, err = sjson.Set(dynamicParamsJson, param.Name, val)
 				if err != nil {
 					return resps, rest.NewHTTPError(ctx, http.StatusBadRequest, oerrors.OntologyQuery_InternalError_UnMarshalDataFailed).
 						WithErrorDetails(fmt.Sprintf("Error setting action type[%s]'s dynamic parameter path %s: %v",
@@ -351,7 +358,7 @@ func (ats *actionTypeService) GetActionsByActionTypeID(ctx context.Context,
 
 // buildActionFromInstanceData builds action data from instance data
 func buildActionFromInstanceData(instanceData map[string]any,
-	actionType *interfaces.ActionType) (interfaces.ActionParam, error) {
+	actionType *interfaces.ActionType, requestDynamicParams map[string]any) (interfaces.ActionParam, error) {
 
 	var action interfaces.ActionParam
 
@@ -373,7 +380,8 @@ func buildActionFromInstanceData(instanceData map[string]any,
 					actionType.ATName, param.Name, err)
 			}
 		case interfaces.LOGIC_PARAMS_VALUE_FROM_INPUT:
-			dynamicParamsJson, err = sjson.Set(dynamicParamsJson, param.Name, nil)
+			val := logics.ActionDynamicParamGetValue(requestDynamicParams, param.Name)
+			dynamicParamsJson, err = sjson.Set(dynamicParamsJson, param.Name, val)
 			if err != nil {
 				return action, fmt.Errorf("error setting action type[%s]'s dynamic parameter path %s: %v",
 					actionType.ATName, param.Name, err)

--- a/adp/bkn/ontology-query/server/logics/action_type/action_type_service_test.go
+++ b/adp/bkn/ontology-query/server/logics/action_type/action_type_service_test.go
@@ -270,6 +270,9 @@ func Test_actionTypeService_GetActionsByActionTypeID(t *testing.T) {
 				InstanceIdentities: []map[string]any{
 					{"id": "123"},
 				},
+				DynamicParams: map[string]any{
+					"input_param": "user_supplied",
+				},
 			}
 
 			actionType := interfaces.ActionType{
@@ -310,7 +313,113 @@ func Test_actionTypeService_GetActionsByActionTypeID(t *testing.T) {
 
 			result, err := service.GetActionsByActionTypeID(ctx, query)
 			So(err, ShouldBeNil)
-			So(result.Actions[0].DynamicParams["input_param"], ShouldBeNil)
+			So(result.Actions[0].DynamicParams["input_param"], ShouldEqual, "user_supplied")
+		})
+
+		Convey("失败 - 参数来源为输入但未提供 dynamic_params", func() {
+			query := &interfaces.ActionQuery{
+				KNID:         knID,
+				ActionTypeID: actionTypeID,
+				InstanceIdentities: []map[string]any{
+					{"id": "123"},
+				},
+			}
+
+			actionType := interfaces.ActionType{
+				ATID:         actionTypeID,
+				ATName:       "test_action",
+				ObjectTypeID: objectTypeID,
+				ActionSource: interfaces.ActionSource{
+					Type: "tool",
+				},
+				Parameters: []interfaces.Parameter{
+					{
+						Name:      "input_param",
+						ValueFrom: interfaces.LOGIC_PARAMS_VALUE_FROM_INPUT,
+					},
+				},
+			}
+
+			omAccess.EXPECT().GetActionType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(actionType, map[string]any{"id": actionType.ATID}, true, nil)
+
+			result, err := service.GetActionsByActionTypeID(ctx, query)
+			So(err, ShouldNotBeNil)
+			httpErr, ok := err.(*rest.HTTPError)
+			So(ok, ShouldBeTrue)
+			So(httpErr.HTTPCode, ShouldEqual, http.StatusBadRequest)
+			So(httpErr.BaseError.ErrorCode, ShouldEqual, oerrors.OntologyQuery_ActionType_InvalidParameter_DynamicParams)
+			So(result.TotalCount, ShouldEqual, 0)
+		})
+
+		Convey("失败 - 多个 input 参数但 dynamic_params 只给了部分", func() {
+			query := &interfaces.ActionQuery{
+				KNID:         knID,
+				ActionTypeID: actionTypeID,
+				InstanceIdentities: []map[string]any{
+					{"id": "123"},
+				},
+				DynamicParams: map[string]any{
+					"input_a": "v1",
+				},
+			}
+
+			actionType := interfaces.ActionType{
+				ATID:         actionTypeID,
+				ATName:       "test_action",
+				ObjectTypeID: objectTypeID,
+				ActionSource: interfaces.ActionSource{
+					Type: "tool",
+				},
+				Parameters: []interfaces.Parameter{
+					{Name: "input_a", ValueFrom: interfaces.LOGIC_PARAMS_VALUE_FROM_INPUT},
+					{Name: "input_b", ValueFrom: interfaces.LOGIC_PARAMS_VALUE_FROM_INPUT},
+				},
+			}
+
+			omAccess.EXPECT().GetActionType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(actionType, map[string]any{"id": actionType.ATID}, true, nil)
+
+			result, err := service.GetActionsByActionTypeID(ctx, query)
+			So(err, ShouldNotBeNil)
+			httpErr, ok := err.(*rest.HTTPError)
+			So(ok, ShouldBeTrue)
+			So(httpErr.HTTPCode, ShouldEqual, http.StatusBadRequest)
+			So(httpErr.BaseError.ErrorCode, ShouldEqual, oerrors.OntologyQuery_ActionType_InvalidParameter_DynamicParams)
+			So(result.TotalCount, ShouldEqual, 0)
+		})
+
+		Convey("失败 - dynamic_params 中某 input 为 null", func() {
+			query := &interfaces.ActionQuery{
+				KNID:         knID,
+				ActionTypeID: actionTypeID,
+				InstanceIdentities: []map[string]any{
+					{"id": "123"},
+				},
+				DynamicParams: map[string]any{
+					"input_param": nil,
+				},
+			}
+
+			actionType := interfaces.ActionType{
+				ATID:         actionTypeID,
+				ATName:       "test_action",
+				ObjectTypeID: objectTypeID,
+				ActionSource: interfaces.ActionSource{
+					Type: "tool",
+				},
+				Parameters: []interfaces.Parameter{
+					{Name: "input_param", ValueFrom: interfaces.LOGIC_PARAMS_VALUE_FROM_INPUT},
+				},
+			}
+
+			omAccess.EXPECT().GetActionType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(actionType, map[string]any{"id": actionType.ATID}, true, nil)
+
+			result, err := service.GetActionsByActionTypeID(ctx, query)
+			So(err, ShouldNotBeNil)
+			httpErr, ok := err.(*rest.HTTPError)
+			So(ok, ShouldBeTrue)
+			So(httpErr.HTTPCode, ShouldEqual, http.StatusBadRequest)
+			So(httpErr.BaseError.ErrorCode, ShouldEqual, oerrors.OntologyQuery_ActionType_InvalidParameter_DynamicParams)
+			So(result.TotalCount, ShouldEqual, 0)
 		})
 
 		Convey("成功 - 包含类型信息", func() {

--- a/adp/bkn/ontology-query/server/logics/common.go
+++ b/adp/bkn/ontology-query/server/logics/common.go
@@ -1312,3 +1312,44 @@ func CondCfgToFilterMap(c *cond.CondCfg) map[string]any {
 	}
 	return m
 }
+
+// ActionDynamicParamGetValue returns a value from a dynamic-params map using dot-separated keys for nested access.
+// Same semantics as action_scheduler.getNestedValue.
+func ActionDynamicParamGetValue(data map[string]any, key string) any {
+	if data == nil {
+		return nil
+	}
+
+	if strings.Contains(key, ".") {
+		parts := strings.Split(key, ".")
+		current := data
+
+		for i, part := range parts {
+			if i == len(parts)-1 {
+				return current[part]
+			}
+			next, ok := current[part].(map[string]any)
+			if !ok {
+				return nil
+			}
+			current = next
+		}
+	}
+
+	return data[key]
+}
+
+// MissingActionInputDynamicParamNames lists action-type parameter names with value_from=input
+// that are missing from dynamicParams (nil map or absent/nil value per ActionDynamicParamGetValue).
+func MissingActionInputDynamicParamNames(actionType *interfaces.ActionType, dynamicParams map[string]any) []string {
+	var missing []string
+	for _, param := range actionType.Parameters {
+		if param.ValueFrom != interfaces.LOGIC_PARAMS_VALUE_FROM_INPUT {
+			continue
+		}
+		if ActionDynamicParamGetValue(dynamicParams, param.Name) == nil {
+			missing = append(missing, param.Name)
+		}
+	}
+	return missing
+}

--- a/adp/docs/api/bkn/ontology-query-ai/ontology-query.yaml
+++ b/adp/docs/api/bkn/ontology-query-ai/ontology-query.yaml
@@ -801,6 +801,8 @@ paths:
                   _instance_identities:
                   - c_commentid: "32485"
                   - c_commentid: "32696"
+                  dynamic_params:
+                    Authorization: "Bearer xxx"
         required: true
       parameters:
       - name: kn_id
@@ -815,6 +817,12 @@ paths:
           type: string
         in: path
         required: true
+      - name: branch
+        description: 分支名称，默认 main
+        schema:
+          type: string
+        in: query
+        required: false
       - name: include_type_info
         description: "是否包含行动类信息, 默认false，不包含"
         schema:
@@ -895,6 +903,12 @@ paths:
                     total_count: 1
                     overall_ms: 1163
           description: ok
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+          description: 请求参数错误。例如行动类存在 value_from 为 input 的参数时，须在请求体 dynamic_params 中传入全部对应取值，否则返回 400（如 OntologyQuery.ActionType.InvalidParameter.DynamicParams）。
       summary: 行动查询
     parameters:
     - name: kn_id
@@ -909,6 +923,12 @@ paths:
         type: string
       in: path
       required: true
+    - name: branch
+      description: 分支名称，默认 main
+      schema:
+        type: string
+      in: query
+      required: false
     - name: include_type_info
       description: "是否包含行动类信息, 默认false，不包含"
       schema:
@@ -993,8 +1013,17 @@ paths:
         required: true
       parameters:
       - name: kn_id
+        description: 业务知识网络ID
         in: path
         required: true
+        schema:
+          type: string
+      - name: branch
+        description: 分支名称，默认 main（与实现 DefaultQuery branch 一致）
+        schema:
+          type: string
+        in: query
+        required: false
       - name: include_logic_params
         description: 包含逻辑属性的计算参数，默认false，返回结果不包含逻辑属性的字段和值
         schema:
@@ -1026,6 +1055,14 @@ paths:
           type: boolean
         in: query
         required: false
+      - name: x-http-method-override
+        description: 重载 POST，须为 GET（与对象实例查询等接口一致，实现中强制校验）
+        schema:
+          enum:
+          - GET
+          type: string
+        in: header
+        required: true
       responses:
         "200":
           content:
@@ -2191,7 +2228,8 @@ paths:
                       length: 1
                     overall_ms: 150
       summary: 基于一组对象实例组织关系子图
-      description: 给定一组对象实例，按概念定义的关系，组织这些对象实例的关系子图
+      description: |
+        给定一组对象实例，按概念定义的关系，组织这些对象实例的关系子图。
   /api/ontology-query/v1/knowledge-networks/{kn_id}/object-types/{ot_id}/properties:
     post:
       requestBody:
@@ -2253,6 +2291,18 @@ paths:
           type: string
         in: path
         required: true
+      - name: branch
+        description: 分支名称，默认 main
+        schema:
+          type: string
+        in: query
+        required: false
+      - name: include_type_info
+        description: 是否包含对象类信息，默认 false
+        schema:
+          type: boolean
+        in: query
+        required: false
       - name: exclude_system_properties
         description: 需要排除的系统字段列表。可选值：_instance_id（实例ID）、_instance_identity（实例唯一标识）、_display（显示值）。如果指定了某个字段，则在返回的对象数据中不包含该字段。可以传递多个值，例如：?exclude_system_properties=_instance_id&exclude_system_properties=_display
         schema:
@@ -2440,6 +2490,12 @@ paths:
             type: string
           in: path
           required: true
+        - name: branch
+          description: 分支名称，默认 main
+          schema:
+            type: string
+          in: query
+          required: false
       responses:
         "202":
           content:
@@ -4033,11 +4089,11 @@ components:
       description: 属性查询请求体
       required:
       - properties
-      - __instance_identities
+      - _instance_identities
       type: object
       properties:
-        __instance_identities:
-          description: 对象主键的数组，代表多个对象。map，key为主键属性名，value为对应的属性值
+        _instance_identities:
+          description: 对象主键的数组，代表多个对象。每项为 map，key 为主键属性名，value 为对应的属性值
           type: array
           items:
             $ref: '#/components/schemas/InstanceIdentity'
@@ -4048,11 +4104,10 @@ components:
             type: string
         dynamic_params:
           description: |
-            各个逻辑属性所需的动态参数。是个map，key为属性名称，value为map，其key为参数名，值为赋予的参数值。
-            当属性是指标属性时，dynamic_params 的结构应遵循 MetricPropertyDynamicParams schema，包含：
-            - 时间参数：start（开始时间戳，毫秒）、end（结束时间戳，毫秒）、instant（是否即时查询）、step（步长，如"1m"、"1h"等）
-            - 分析参数：analysis_dimensions（分析维度数组）、order_by_fields（排序字段数组）、having_condition（having值过滤条件）、metrics（同环比、占比分析配置）
-            - 配置的动态参数：指标属性配置中定义的其他动态参数（如 pod_ip、pod_name 等）
+            各逻辑属性所需的动态参数：外层 key 为**逻辑属性名**，内层为参数名到取值的 map。
+            当属性是指标属性时，内层结构可遵循 MetricPropertyDynamicParams（时间、分析维度等）；
+            算子属性则为参数名到标量或嵌套对象的映射。未传或某属性无动态需求时可省略该 key。
+          type: object
           additionalProperties:
             oneOf:
             - type: string
@@ -4986,18 +5041,35 @@ components:
         - type: string
         - type: integer
     InstanceIdentities:
-      description: 对象唯一标识
+      description: 行动查询请求体。除实例唯一标识外，当行动类 parameters 中存在 value_from 为 input 的项时，须在本对象的 dynamic_params 中按参数名传入非空取值；缺失或值为 null 时返回 400。
       required:
-      - __instance_identities
+      - _instance_identities
       type: object
       properties:
-        __instance_identities:
-          description: 对象主键的数组，代表多个对象。map，key为主键属性名，value为对应的属性值
+        _instance_identities:
+          description: 对象主键的数组，代表多个对象。每项为 map，key 为主键属性名，value 为对应的属性值
           type: array
           items:
             $ref: '#/components/schemas/InstanceIdentity'
         dynamic_params:
-          description: 动态参数，用于填充行动参数
+          description: |
+            行动类「动态输入」参数取值（与行动类 parameters 中 value_from=input 的 name 对应，支持点分路径表示嵌套键）。
+            当行动类定义了此类参数时必填且取值不能为 null；否则接口返回 400（错误码 OntologyQuery.ActionType.InvalidParameter.DynamicParams）。
+          type: object
+          additionalProperties: true
+
+    ActionExecutionRequest:
+      description: |
+        行动执行请求体。当行动类 parameters 中存在 value_from 为 input 的项时，须在 dynamic_params 中传入全部对应非空取值，否则返回 400（错误码 OntologyQuery.ActionExecution.InvalidParameter）。
+      type: object
+      properties:
+        _instance_identities:
+          description: 目标对象唯一标识列表；扫描模式下可传空数组，由服务端按行动条件拉取实例
+          type: array
+          items:
+            $ref: '#/components/schemas/InstanceIdentity'
+        dynamic_params:
+          description: 与行动类 input 参数名对应的取值（支持点分路径）。有 input 参数时必填且不能为 null。
           type: object
           additionalProperties: true
 


### PR DESCRIPTION
# Pull Request

## What Changed

`action-type execute` 在请求中 **缺少 `input` 里已声明的某个参数** 时，由原先 **静默丢弃** 改为返回 **HTTP 400**，错误信息可定位缺失字段。

主要改动范围：

- [x] BKN `action_type` 接口与 `action_scheduler` 调度层校验与行为调整
- [x] `ontology-query` 中 `action_type_service` 与 `common` 辅助逻辑
- [x] OpenAPI：`ontology-query-ai/ontology-query.yaml` 中相关说明/响应
- [x] 单元测试：`action_scheduler_service_test`、`action_type_service_test` 等
- [x] `.gitignore` 小幅更新

**提交说明：** [bug] 285-issue 【BKN】action-type execute 存在缺失的 input 参数时由静默丢弃改为报 400 错误

---

## Why

- Related Issue: #285
- Background: 缺参时静默成功容易导致线上问题难排查；与「声明了必填入参却未传」的契约不符，应显式失败并返回 400。

---

## How

- 在 `common` 中集中/复用对 **声明的 input 与实参** 的校验，缺失时返回 400 及明确错误
- `action_type` / `action_scheduler` 在 execute 路径上应用该校验
- `ontology-query.yaml` 同步行为与错误说明（如适用）

- Breaking changes: 依赖「少传参数仍 200 且静默忽略」的客户端将收到 **400**；需按契约补齐参数。

---

## Testing

- [x] 单元测试已更新/新增（本地逻辑覆盖缺参 400 场景）
- [ ] 集成测试（如仓库 CI 有则跟进）
- [x] 在测试环境完整走查 execute（按需）

Test notes: 以 `action_scheduler_service_test`、`action_type_service_test` 中新增用例为准。

---

## Risk & Rollback

- **风险：** 对错误容忍的旧调用方可能从「误成功」变为 400
- **回滚：** revert 本 PR 对应提交即可恢复旧行为

---

## Additional Notes

- Base: `main`；分支已 rebase 完成。

**本 PR 涉及文件（与 `gh pr diff` 一致）：**

- `.gitignore`
- `adp/bkn/ontology-query/server/interfaces/action_type.go`
- `adp/bkn/ontology-query/server/logics/action_scheduler/action_scheduler_service.go`
- `adp/bkn/ontology-query/server/logics/action_scheduler/action_scheduler_service_test.go`
- `adp/bkn/ontology-query/server/logics/action_type/action_type_service.go`
- `adp/bkn/ontology-query/server/logics/action_type/action_type_service_test.go`
- `adp/bkn/ontology-query/server/logics/common.go`
- `adp/docs/api/bkn/ontology-query-ai/ontology-query.yaml`
