### PR TITLE
fix(deploy): silence toolset-import 401 + split businessDomain defaults (core=false, dip=true)

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -313,7 +313,7 @@ confirm_access_address_before_install() {
     echo "  Current detected values:"
     echo "    Host     : ${host}"
     echo "    Port     : ${port}"
-    echo "    Path     : ${path}"
+    echo "    URL Root : ${path}"
     echo "    Protocol : ${scheme}  (http or https)"
     echo "    URL      : ${url}"
     echo "============================================"
@@ -327,7 +327,7 @@ confirm_access_address_before_install() {
         local input_host input_port input_path input_scheme
         read -r -p "  Host     [${host}]: " input_host
         read -r -p "  Port     [${port}]: " input_port
-        read -r -p "  Path     [${path}]: " input_path
+        read -r -p "  URL Root [${path}]: " input_path
         read -r -p "  Protocol [${scheme}]: " input_scheme
 
         host="${input_host:-${host}}"

--- a/deploy/scripts/lib/context_loader_toolset_import.sh
+++ b/deploy/scripts/lib/context_loader_toolset_import.sh
@@ -1,6 +1,34 @@
 # Post-install: import Context Loader toolset (agent-retrieval ADP) via operator-integration impex.
 # Sourced from deploy.sh after common.sh. Requires deploy.sh's _read_access_address_field for ingress import.
 
+_context_loader_log_manual_import_instructions() {
+    log_info "  Please import manually after install:"
+    log_info "    kweaver auth login"
+    log_info "    kweaver toolbox import --file <repo>/adp/context-loader/agent-retrieval/docs/release/toolset/context_loader_toolset.adp --mode upsert"
+}
+
+# v1 impex 在开启 OAuth / Hydra 或 auth.enabled=true 时需要管理员 Bearer；不要走无 Token 的 port-forward（必然 401）。
+_context_loader_impex_requires_bearer() {
+    local namespace="$1"
+    local auth_env
+    if kubectl get deploy agent-operator-integration -n "${namespace}" &>/dev/null; then
+        auth_env="$(kubectl get deploy agent-operator-integration -n "${namespace}" -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="AUTH_ENABLED")].value}' 2>/dev/null || true)"
+        if [[ "${auth_env}" == "true" ]]; then
+            return 0
+        fi
+    fi
+    if kubectl get deploy hydra -n "${namespace}" &>/dev/null; then
+        return 0
+    fi
+    if kubectl get deploy -n "${namespace}" --no-headers 2>/dev/null | awk '{print tolower($1)}' | grep -qE '^hydra'; then
+        return 0
+    fi
+    if helm status hydra -n "${namespace}" &>/dev/null; then
+        return 0
+    fi
+    return 1
+}
+
 _import_context_loader_toolset_via_port_forward() {
     local namespace="$1"
     local adp="$2"
@@ -91,16 +119,17 @@ maybe_import_context_loader_toolset_post_core() {
         return 0
     fi
 
-    # ISF (Hydra/EACP) 在场时，impex API 会强校验 Bearer + admin 权限。
-    # 当前部署脚本无法自动获取 admin token（参见 README / TODO config 子命令），
-    # 强行调用必然 401/403。改为提示用户手工导入，避免误导。
-    if kubectl get deploy hydra -n "${namespace}" &>/dev/null; then
-        log_info "Context Loader toolset auto-import skipped: ISF (Hydra) detected in namespace ${namespace}."
-        log_info "  In auth-enabled environments the impex API requires an admin Bearer token."
-        log_info "  Please import manually after install:"
-        log_info "    kweaver auth login"
-        log_info "    kweaver toolbox import --file <repo>/adp/context-loader/agent-retrieval/docs/release/toolset/context_loader_toolset.adp --mode upsert"
-        return 0
+    # ISF（Hydra）或 Core auth.enabled=true 时，impex 会强校验 Bearer + admin 权限。
+    # 仅匹配 deploy/hydra 会漏掉 chart 生成的 hydra-* 等名称；以集群内 AUTH_ENABLED + Hydra 迹象为准。
+    if _context_loader_impex_requires_bearer "${namespace}"; then
+        if [[ -n "${DEPLOY_PLATFORM_ACCESS_TOKEN:-}" ]]; then
+            log_info "Context Loader toolset: authenticated cluster detected; will use DEPLOY_PLATFORM_ACCESS_TOKEN for impex."
+        else
+            log_info "Context Loader toolset auto-import skipped: authenticated API (Hydra/ISF or auth.enabled=true) in namespace ${namespace}."
+            log_info "  Set DEPLOY_PLATFORM_ACCESS_TOKEN for automated import, or import manually:"
+            _context_loader_log_manual_import_instructions
+            return 0
+        fi
     fi
 
     local _lib_dir
@@ -156,6 +185,11 @@ maybe_import_context_loader_toolset_post_core() {
         fi
 
         log_warn "Context Loader toolset import via access address failed (HTTP ${http_code}). Response: ${body:0:500}"
+        if _context_loader_impex_requires_bearer "${namespace}"; then
+            log_info "Context Loader toolset: not retrying port-forward (impex requires Bearer in this cluster)."
+            _context_loader_log_manual_import_instructions
+            return 0
+        fi
         log_info "Context Loader toolset: retrying via kubectl port-forward..."
     else
         log_info "Context Loader toolset: no DEPLOY_PLATFORM_ACCESS_TOKEN; trying kubectl port-forward (typical for auth.enabled=false / --minimum)."

--- a/deploy/scripts/services/core.sh
+++ b/deploy/scripts/services/core.sh
@@ -417,10 +417,20 @@ _install_core_release_repo() {
     fi
 }
 
+# Inject default --set values for kweaver-core if user did not override them.
+# Currently: businessDomain.enabled defaults to false at install time.
+_core_apply_default_set_values() {
+    if ! get_set_value "businessDomain.enabled" "${CORE_SET_VALUES[@]}" >/dev/null 2>&1; then
+        CORE_SET_VALUES+=("businessDomain.enabled=false")
+        log_info "Default applied: --set businessDomain.enabled=false (override with --set businessDomain.enabled=true)"
+    fi
+}
+
 # Install KWeaver Core services via Helm
 install_core() {
     log_info "Installing KWeaver Core services via Helm..."
     _core_require_version_manifest || return 1
+    _core_apply_default_set_values
 
     if ! ensure_platform_prerequisites; then
         log_error "Failed to ensure platform prerequisites for KWeaver Core"

--- a/deploy/scripts/services/dip.sh
+++ b/deploy/scripts/services/dip.sh
@@ -7,6 +7,10 @@ DIP_LOCAL_CHARTS_DIR="${DIP_LOCAL_CHARTS_DIR:-}"
 DIP_VERSION_MANIFEST_FILE="${DIP_VERSION_MANIFEST_FILE:-}"
 DIP_CONFIRM_MISSING_OPENCLAW_PATHS="${DIP_CONFIRM_MISSING_OPENCLAW_PATHS:-false}"
 
+# --set values forwarded to DIP helm releases (and used to seed core defaults
+# when dip auto-installs missing core releases).
+declare -a DIP_SET_VALUES=()
+
 # Parse dip command arguments
 parse_dip_args() {
     local action="$1"
@@ -78,6 +82,14 @@ parse_dip_args() {
             --confirm-missing-openclaw-paths)
                 DIP_CONFIRM_MISSING_OPENCLAW_PATHS="true"
                 shift
+                ;;
+            --set=*)
+                DIP_SET_VALUES+=("${1#*=}")
+                shift
+                ;;
+            --set)
+                DIP_SET_VALUES+=("$2")
+                shift 2
                 ;;
             -y|--yes)
                 ASSUME_YES="true"
@@ -736,10 +748,28 @@ init_dip_database() {
     init_module_database_if_present "kweaver-dip" "${sql_dir}" "KWeaver DIP"
 }
 
+# Inject DIP-side defaults: businessDomain.enabled=true unless overridden by user.
+# Also propagate the same default into core (CORE_SET_VALUES) so that when DIP
+# triggers install_core for missing releases, core gets businessDomain.enabled=true
+# instead of core's own default (false).
+_dip_apply_default_set_values() {
+    if ! get_set_value "businessDomain.enabled" "${DIP_SET_VALUES[@]}" >/dev/null 2>&1; then
+        DIP_SET_VALUES+=("businessDomain.enabled=true")
+        log_info "Default applied for DIP: --set businessDomain.enabled=true (override with --set businessDomain.enabled=false)"
+    fi
+    if ! get_set_value "businessDomain.enabled" "${CORE_SET_VALUES[@]}" >/dev/null 2>&1; then
+        local dip_bd
+        dip_bd="$(get_set_value "businessDomain.enabled" "${DIP_SET_VALUES[@]}")"
+        CORE_SET_VALUES+=("businessDomain.enabled=${dip_bd}")
+        log_info "Propagated to core for DIP install: --set businessDomain.enabled=${dip_bd}"
+    fi
+}
+
 # Install DIP services via Helm
 install_dip() {
     log_info "Installing KWeaver DIP services via Helm..."
     _dip_require_version_manifest || return 1
+    _dip_apply_default_set_values
 
     local charts_dir
     charts_dir="$(_dip_resolve_charts_dir)"
@@ -909,6 +939,11 @@ _install_dip_release_local() {
         "--wait" "--timeout=600s"
     )
 
+    local set_value
+    for set_value in "${DIP_SET_VALUES[@]}"; do
+        helm_args+=("--set" "${set_value}")
+    done
+
     _dip_append_release_extra_helm_args "${release_name}" helm_args || return 1
 
     if helm "${helm_args[@]}"; then
@@ -954,6 +989,11 @@ _install_dip_release_repo() {
         "--namespace" "${namespace}"
         "-f" "${CONFIG_YAML_PATH}"
     )
+
+    local set_value
+    for set_value in "${DIP_SET_VALUES[@]}"; do
+        helm_args+=("--set" "${set_value}")
+    done
 
     _dip_append_release_extra_helm_args "${release_name}" helm_args || return 1
 


### PR DESCRIPTION
## Summary

Two related deploy-script fixes plus a small UX tweak that was already on local main:

1. **`context_loader_toolset_import.sh` — stop the misleading 401 WARN under ISF/OAuth**
   - Detect that impex requires Bearer via:
     - `agent-operator-integration` Pod env `AUTH_ENABLED=true` (mirrors chart `auth.enabled`)
     - `deploy/hydra` (or any `hydra*` Deployment) in the namespace
     - `helm status hydra` as a fallback
   - When Bearer is required and `DEPLOY_PLATFORM_ACCESS_TOKEN` is unset (or the access-address impex itself returns non-2xx), do **not** retry via no-token `kubectl port-forward`. Print the manual-import hint instead. This removes the misleading `Public.Unauthorized / token is invalid` WARN that always appeared after a successful ISF install.

2. **`core.sh` — default `businessDomain.enabled=false` for `kweaver-core install`**
   - `_core_apply_default_set_values` injects `--set businessDomain.enabled=false` only when the user did not pass it explicitly. Logged so it's discoverable and overridable.

3. **`dip.sh` — propagate `businessDomain.enabled=true` into core when DIP installs**
   - DIP triggers `install_core` for missing core releases via `_dip_ensure_kweaver_core`. Without this, core would inherit the new core-side default (`false`) and end up out of sync with DIP releases (which keep the chart default `true`). New `_dip_apply_default_set_values` ensures both DIP and any DIP-triggered core installs see `true` unless the user overrides via `--set`.
   - Also adds `--set` parsing on the dip subcommand for parity with core.

Includes the previously local-only `fix(deploy): label access URL path prompt as URL Root` commit (already merged into local main, was unpushed).

## Behavior matrix (after this PR)

| Command | `businessDomain.enabled` default |
| --- | --- |
| `kweaver-core install` | `false` |
| `kweaver-dip install` (own releases + auto-installed core) | `true` |
| Any command with explicit `--set businessDomain.enabled=...` | user value wins |

## Notes

- Existing releases will only see the new value when `helm upgrade` actually runs. Use `--force-upgrade` if the target chart version already matches the installed one (otherwise the script prints `Skip <release>: installed chart version ... equals target ...` and the new `--set` is not applied).
- Helm continues to remember the last `--set` values across upgrades; users who previously installed with explicit `businessDomain.enabled=true` will keep that value for core unless they re-`--set false`.

## Test plan

- [ ] `./deploy/deploy.sh kweaver-core install` on a cluster without auth → expect `BUSINESS_DOMAIN_ENABLED=false` on `bkn-backend` / `agent-operator-integration` / `agent-backend`.
- [ ] `./deploy/deploy.sh kweaver-dip install` on a cluster without core → expect `BUSINESS_DOMAIN_ENABLED=true` on both DIP and the auto-installed core releases.
- [ ] `./deploy/deploy.sh kweaver-core install --set businessDomain.enabled=true` → respected.
- [ ] Install ISF + Core, ensure no `Context Loader toolset import via port-forward failed (HTTP 401)` WARN; instead see the manual-import hint.

Made with [Cursor](https://cursor.com)