### PR TITLE
docs: add KWeaver Core 0.7.0 release notes (CN & EN)

### DIFF
--- a/release-notes/0.7.0/KWeaver Core 0.7.0 Release Notes.md
+++ b/release-notes/0.7.0/KWeaver Core 0.7.0 Release Notes.md
@@ -1,0 +1,352 @@
+# KWeaver Core 0.7.0 Release Notes
+
+---
+
+## Version Overview
+
+### KWeaver Core 0.7.0 Is Now Generally Available
+
+**Metric Semantic Fusion, Streaming Build Ready, Multi-Dimensional Agent Capability Leap**
+
+KWeaver Core 0.7.0 is centered on a **dual-direction upgrade to the BKN Engine**. At the semantic modeling layer, the Metric type officially becomes the fourth first-class citizen of the Business Knowledge Network, standing alongside Object Types, Relation Types, and Action Types to express business entities and quantitative logic. Relation Mapping gains a new `FilteredCrossJoinMapping` type, which supports applying filter conditions on the Cartesian product of two data sources to precisely select matching instance pairs — covering complex multi-table join scenarios. The BKN Specification SDK is simultaneously upgraded to v0.1.3, with a new Exchange email recovery domain knowledge network template added. This release also completes VEGA's support for PostgreSQL streaming index builds; with full, incremental, and streaming modes now all covered. The Logic View engine gains multi-table JOIN, UNION view types, and custom SQL capability. The Execution Factory completes the Skill lifecycle management loop, supporting full-package updates, version control, and rollback. Context Loader consolidates its tools and adds Metric type concept recall, providing unified semantic search across Object, Relation, Action, and Metric entities. Decision Agent introduces a React Agent running mode. The overall system also includes multiple targeted improvements to API error semantics, concurrency stability, and deployment/operations experience.
+
+---
+
+## KWeaver Core 0.7.0 — Core Highlights
+
+**1. Dual-Direction BKN Engine Upgrade: Metric Semantic Modeling & Filtered Cross-Join Mapping**
+
+The BKN Engine achieves two major breakthroughs. **Metric Modeling**: The Metric type officially becomes the fourth first-class citizen in BKN, alongside Object Types, Relation Types, and Action Types, supporting calculation formulas, grouping dimensions, time dimensions, and multiple query modes (instant, trend, period-over-period, and proportion). Context Loader simultaneously adds Metric semantic recall, completing the full chain of "metric modeling → semantic recall → agent Q&A." **Relation Mapping**: The new `FilteredCrossJoinMapping` type supports applying filter conditions on the Cartesian product of two data sources to precisely select matching instance pairs, covering complex multi-table join scenarios such as material–inventory–order conditional cross-matching. Together with existing `DirectMappingRule` / `InDirectMappingRule`, all three types form a complete mapping system.
+
+**2. PostgreSQL Streaming Index Build Now Live — Real-Time Data Ingestion**
+
+VEGA adds PostgreSQL streaming index builds, complementing the existing full and incremental build modes with a real-time streaming mode: row-level changes (INSERT / UPDATE / DELETE) in the database are instantly synchronized to the search index via the PG change-listening mechanism, with no need for scheduled full refreshes. VEGA now fully covers all three build modes for PG data sources — batch (full, incremental) + streaming — meeting real-time analytics scenarios with strict data freshness requirements.
+
+**3. Execution Factory — Full Skill Lifecycle Management with Version Control & Rollback**
+
+The Execution Factory upgrades Skill management from "register-and-execute" to a complete lifecycle: supporting metadata editing (draft/published state separation), full-package version updates, historical version queries, and one-click rollback for already-published Skills, along with Skill Dataset rebuild compensation and incremental build. Organizations can iterate Skills without interrupting live services, with version management ensuring every change is traceable and revertible.
+
+**4. Decision Agent Adds React Running Mode — Enhanced Complex Task Reasoning**
+
+Decision Agent introduces a React Agent running mode (`agent_mode: react`), adding an independent `ReactConfig` (supporting conversation history toggle and LLM cache control) on top of the existing Dolphin mode. React mode provides stronger context continuity in multi-step reasoning and longer tool-call-chain scenarios; combined with the new configurable built-in Skill registration rules, agent execution efficiency for complex decision tasks is significantly improved.
+
+**5. Logic View Engine Extended: Multi-Table JOIN / UNION & Custom SQL**
+
+VEGA Logic Views gain two new view types — multi-table JOIN (left join, etc.) and multi-table UNION — defined through configuration nodes that declare data sources, join keys, and output fields, allowing multi-table query modeling without writing SQL. A custom SQL view mode is also added, supporting full SQL statement definitions. All three view types are exposed through VEGA's unified query interface and seamlessly support MariaDB, PostgreSQL, and OpenSearch data sources.
+
+---
+
+## Detailed Feature Descriptions
+
+### 【BKN Engine】
+
+Version 0.7.0 completes significant upgrades in two directions — Metric modeling and Relation Mapping — while also improving boundary validation and error semantics.
+
+**1. BKN Metric Model: Business-Semantic Metric Definition & Querying**
+
+BKN adds Metric Type, enabling definition of quantitative metrics with business semantics directly within the knowledge network:
+
+- **Metric Structure Modeling**: A metric is fully described by `scope` (the associated Object Type), `calculation formula` (filter conditions + aggregation method + grouping fields), `time dimension`, and `analysis dimensions`, expressing business quantitative logic completely. Supports the `atomic` metric type; composite metric types will be added in future iterations.
+- **Multi-Mode Querying**: Metrics support instant queries (`instant=true`, retrieves current aggregate value), trend queries (`instant=false` + time range, returns time-series data at calendar steps such as day/month/year), period-over-period analysis (`type=parallel`, calculates growth value and growth rate with configurable offsets), and proportion analysis (`type=proportion`, returns percentage breakdown per analysis dimension).
+- **Semantic Retrieval**: Metrics support semantic concept retrieval — vector indexes are generated from ID, name, and description, enabling natural-language-based metric discovery.
+- **Independent Concept Status**: Metrics exist as an independent concept type in BKN, without direct associations with Object Types or other concept types, but can reference a specific Object Type via `scope` to define the statistical subject.
+
+**2. Condition Configuration Refactor & Validation Improvements**
+
+Refactors the BKN Condition configuration structure, separating `ActionCondCfg` from `CondCfg` into an independent struct, and standardizing the field name from `Name` to `Field` for clearer semantics:
+
+- Improves Condition validation for Object Type logical attribute binding resources in strict mode (`strict_mode`).
+- Auto-completes system parameters for Metric Type attributes, reducing manual configuration overhead.
+- Optimizes Relation Type validation logic with new non-strict mode support.
+- Updates Action source type valid values from `tool/map` to `tool/mcp` to align with the current tooling system.
+
+**3. FilteredCrossJoinMapping: Filtered Cross-Join Relation Mapping**
+
+BKN Relation Types gain a new `FilteredCrossJoinMapping` mapping type, supporting the application of filter conditions on the Cartesian product of two data sources to precisely select instance pairs that satisfy the join condition:
+
+- Resolves the limitation of prior relation mappings, which could only express simple field equality joins, by allowing inline declaration of complex multi-field filter logic within Relation Types.
+- Applicable to "select valid associations from the combination of Resource A and Resource B based on business rules" scenarios, such as conditional cross-matching of material, inventory, and order records.
+- Listed alongside existing `DirectMappingRule` / `InDirectMappingRule`; together, the three mapping types cover simple mapping, indirect mapping, and filtered cross-join mapping.
+
+**4. API Error Semantics Standardization**
+
+Standardizes the HTTP status code for resource-not-found scenarios to 404 (previously 403), covering all resource types including knowledge networks, concept groups, action types, relation types, and object types. The `action-type execute` API now returns an explicit 400 error when required `input` parameters are missing (previously silently discarded), improving diagnosability along agent error paths.
+
+---
+
+### 【VEGA Data Virtualization】
+
+Version 0.7.0 delivers significant capability extensions in three areas: data build modes, Logic View capabilities, and data source integration.
+
+**1. PostgreSQL Streaming Index Build**
+
+VEGA adds PostgreSQL streaming index builds, completing three build modes for PG data sources:
+
+- **Full Build**: Synchronizes the entire PG table data to the search index in a single pass.
+- **Incremental Build**: Syncs only new or changed data since the last build, based on an incremental field.
+- **Streaming Build**: Captures row-level changes (INSERT / UPDATE / DELETE) in real time via the PG change-listening mechanism, synchronizing data changes to the index immediately — meeting millisecond-level data freshness requirements.
+
+> Note: Streaming build requires PG Logical Replication to be enabled on the server side. If not enabled, build tasks will return an error prompt. Please verify your database configuration before enabling this mode.
+
+**2. Logic View Extended: New JOIN, UNION, and Custom SQL Types**
+
+Logic Views expand from basic queries to support three complete view types:
+
+- **JOIN View**: Supports multi-table left joins and other join operations. Declare source Resources, join keys, and output fields through configuration nodes; the system automatically translates the configuration into the corresponding SQL. Supports MariaDB and PostgreSQL data sources.
+- **UNION View**: Supports multi-table UNION queries, merging data from different sources with the same structure into a unified view. Supports mixed MariaDB and OpenSearch data sources.
+- **Custom SQL View**: Supports full SQL statement definitions using template syntax (`{{.nodeId}}`) to reference Resources declared in the configuration, balancing flexibility and safety.
+
+All Logic Views are exposed through VEGA's unified query interface (`/resources/{id}/data`), with support for pagination, sorting, condition filtering, and `limit` parameters.
+
+**3. AnyShare Document Library Integration & Filter Condition Support**
+
+Building on the AnyShare Knowledge Base integration in 0.6.0, VEGA Catalog now adds support for the **AnyShare Document Library** type in 0.7.0, enabling enterprise document data (Word, PDF, and other file formats) to be managed within the Business Knowledge Network. A new `cond` condition filter parameter is also added, supporting content filtering within document libraries/knowledge bases at the Catalog discovery stage based on business conditions, reducing unnecessary data ingestion.
+
+**4. Enhanced Resource Data Query Capabilities**
+
+The Resource Data query interface (`/resources/{id}/data`) adds aggregate analysis support:
+
+- **Aggregation / Grouping**: Supports `GROUP BY` grouped statistics.
+- **Having Filtering**: Supports secondary condition filtering on aggregation results.
+- **Query Parameter Fix**: Fixes an issue where the `limit` parameter did not take effect in some scenarios, ensuring pagination behavior matches expectations.
+
+---
+
+### 【Execution Factory】
+
+Version 0.7.0 completes the full Skill lifecycle management loop, upgrading from simple register-and-execute capability to a comprehensive lifecycle management system that supports version control, metadata iteration, and data compensation.
+
+**1. Skill Full-Package Update & Metadata Editing**
+
+Supports two update paths for published Skills:
+
+- **Metadata Editing**: Modify a Skill's name, description, category, and other metadata without replacing the Skill execution package. Changes generate a draft version (edit state) that coexists with the currently published version, without affecting live calls.
+- **Full-Package Update**: Re-upload the complete Skill package to replace the existing implementation with a new version. The update also enters the draft state first and is published to production upon confirmation.
+
+Both update paths take effect through an explicit publish operation, ensuring stability of the live version.
+
+**2. Version Management & Historical Rollback**
+
+Each publish operation records a version history entry, supporting the following version management operations:
+
+- **Version History Query**: View the complete version change history for a specified Skill.
+- **Historical Version Restore to Draft**: Restore any historical version to the draft box as a candidate for the next release.
+- **Direct Historical Version Publish**: Publish a historical version directly as the live version, enabling rapid rollback.
+
+Only one official published version is maintained at any time. The Dataset always stores index data corresponding to the latest live version.
+
+**3. Skill Dataset Rebuild Compensation & Incremental Build**
+
+Adds a Skill Dataset rebuild compensation mechanism: after a Skill version update, the system automatically triggers a rebuild or incremental update task for the associated Dataset, ensuring Dataset index data always stays consistent with the currently published version. Incremental builds process only the portions changed since the last build, reducing the performance overhead of full rebuilds.
+
+---
+
+### 【Context Loader】
+
+Version 0.7.0 completes tool consolidation and capability expansion, incorporating Metric types into the unified semantic recall system and further reducing agent invocation costs.
+
+**1. search_schema Tool Merge: Unified Recall Endpoint for Four Concept Types**
+
+Merges the original `kn_schema_search` and `kn_search` tools into a unified `search_schema` tool, covering unified semantic recall for all four BKN concept types: Object Types, Relation Types, Action Types, and **Metric Types**:
+
+- **search_scope Parameter**: Flexibly controls the recall scope via four toggles — `include_object_types`, `include_relation_types`, `include_action_types`, `include_metric_types` — with all types enabled by default.
+- **Compact Response Mode**: Supports the `schema_brief` parameter; when enabled, returns a compact concept summary format to reduce token consumption.
+- **Response Format**: HTTP interface defaults to JSON; MCP Tool defaults to `toon` compressed format. The original two tools remain in the tool set but are not exposed externally via MCP.
+
+**2. Metric Type Concept Recall**
+
+Via the `search_schema` tool, agents can now discover metrics defined in the knowledge network through natural language queries:
+
+- Returns the metric's `id`, `name`, `comment` (business description), and `metric_type`.
+- Supports semantic vector matching based on metric name and description.
+- Supports mixed recall: queries with semantics like "concept count" can simultaneously return Object Types and related metrics, with cross-scoring to determine the final ranking.
+
+**3. Zombie Dependency Cleanup**
+
+Removes the `data_retrieval` zombie dependency in `agent-retrieval` that was bypassed by a hardcoded feature flag. Cleans up invalidated configuration entries in the codebase, ensuring the tool recall path behavior is consistent with code declarations.
+
+---
+
+### 【Decision Agent】
+
+Version 0.7.0 completes important upgrades in two dimensions — running modes and configurability — while also simplifying the observability system to improve operational maintainability.
+
+**1. React Agent Running Mode**
+
+Adds the `agent_mode: react` running mode, creating React Agent configurations via the `/v3/agent/react` endpoint:
+
+- **ReactConfig**: An independent React mode configuration item supporting `disable_history_in_a_conversation` (disables in-conversation history) and `disable_llm_cache` (disables LLM caching).
+- **AgentMode Enum**: Adds `default / dolphin / react` three-mode enum, reserving extension points for future mode expansion.
+- React mode provides stronger context continuity in multi-step tool-call-chain scenarios and is suitable for complex decision tasks that require precise tracking of reasoning steps.
+
+**2. Built-in Skill Registration Rules Made Configurable**
+
+Supports controlling the registration behavior and invocation rules for built-in Skills via configuration files (`skill_enabled` configuration item), flexibly adapting to the varying scope of built-in capability exposure needs across different deployment environments.
+
+**3. Agent Template Copy Fix**
+
+Fixes an issue where `published_at` and `published_by` fields were not cleared when copying an Agent template, ensuring that newly copied templates are always initialized in an unpublished state, avoiding status confusion.
+
+**4. OAuth Bearer Forwarding Fix**
+
+Fixes an issue where `agent-executor`'s OpenAPI Tool did not forward OAuth Bearer Tokens, ensuring that OAuth-protected downstream services registered through Toolbox can be properly called by Decision Agent.
+
+**5. Observability System Simplification**
+
+Migrates the observability implementation from custom O11Y tracing to standard OpenTelemetry (OTLP) tracing. Removes the outdated `observability handler` and related redundant components, unifies the telemetry configuration structure across services (`agent-factory`, `agent-executor`, `agent-memory`), and reduces operational complexity. Also adds LLM message logging (`LLMMessageLoggingConfig`) for capturing complete LLM input/output messages during development and debugging.
+
+**6. Deprecated Configuration Cleanup**
+
+Removes the following deprecated service configurations: `kn_data_query`, `kn_knowledge_data`, `data_connection`, `search_engine`, `ecosearch`, `ecoindex_public`, and others. Removes the `disable_biz_domain_init` configuration item to simplify business domain initialization logic.
+
+---
+
+### 【Sandbox Runtime】
+
+Version 0.7.0 adds Control Plane Takeover capability to the Sandbox, significantly improving upgrade stability in Kubernetes environments.
+
+**1. Control Plane Takeover**
+
+Adds Control Plane takeover capability for existing session Pods on startup:
+
+- After a Control Plane restart or upgrade, automatically scans and takes over existing session Pods still running in the Kubernetes cluster, restoring the binding between sessions and executors.
+- Uses the Pod Owner Reference mechanism to achieve affinity binding between executor Pods and Control Plane instances, preventing orphaned Pods from continuously consuming resources.
+- Handles same-name Pod rebuild conflicts: waits for Pods in the `Terminating` state to be fully deleted before creating new Pods, eliminating race conditions during startup state synchronization.
+
+**2. Session Pod Resource Configuration Optimization**
+
+In K8s scheduling mode, the CPU and memory Requests for session Pods are adjusted to zero (Limits are retained), reducing Pod scheduling failures caused by per-session resource reservations and improving scheduling success rates in high-density session scenarios.
+
+---
+
+### 【ISF Information Security Fabric】
+
+Version 0.7.0 completes ISF service consolidation and capability extension. The `sharemgnt-single` standalone service is removed, with its functionality unified into the main ISF service, reducing the overall number of deployed services and memory footprint.
+
+**1. Personal Access Token (PAT) Support**
+
+The Authentication module adds Personal Access Token (PAT) capability, supporting PAT creation, querying, and revocation in the ISF management interface:
+
+- Each account can create up to 10 PATs (configurable).
+- Supports both permanent validity and specified expiration times.
+- Token lifecycle is managed uniformly through Hydra OAuth2, deeply integrated with the platform authentication system.
+- Database migration supports MariaDB, DM8, and KDB9.
+
+**2. Bulk User Import / Export**
+
+UserManagement adds bulk user management capability, supporting batch account creation via Excel files:
+
+- **Bulk Import**: Import users via a standard Excel template, supporting fields such as name, department (multi-level, separated by `/`), phone number, validity period, storage quota, initial password, and user security level. Red fields are required; black fields are optional.
+- **Bulk Export**: Export the current user list to Excel, supporting asynchronous background task execution so that large-volume operations do not block the foreground.
+- Internationalization support: Simplified Chinese and Traditional Chinese instructions are embedded in the template, with no additional documentation needed.
+
+---
+
+### 【BKN Specification SDK】
+
+The BKN Specification SDK is an independently released open-specification toolkit for programmatically parsing, building, and serializing BKN Business Knowledge Network specification documents. Version 0.7.0 delivers stable releases, completing an underlying refactor and expanding the example library.
+
+**1. Parser & Serializer Underlying Refactor**
+
+- **Parser Refactor**: Introduces `extractSectionsWithDesc` / `buildDescription` to handle document structure uniformly. Summaries are now automatically extracted from the first sentence of the description content, eliminating the need for a separate `summary` field declaration.
+- **Serializer Optimization**: Extracts a common `encodeYAMLBlock` function, removes redundant fields (`sub_conds`, `value_from`), and standardizes table formatting conventions.
+
+**2. Exchange Email Recovery Domain Template & Example Library Expansion**
+
+Adds an Exchange email recovery domain knowledge network template, covering complete object types including data domains, Exchange servers, backup time points, recovery tasks, and recovery jobs. Includes two risk action types — backup time point validation failure and production data overwrite — along with complete scripts, providing a ready-to-use starting template for enterprise email backup and recovery scenarios. Existing examples (k8s-network, supplychain-hd, mock_system) are updated to support the `filtered_cross_join` relation type and the new format conventions.
+
+---
+
+### 【KWeaver SDK】
+
+Version 0.7.0 delivers multiple capability extensions to the KWeaver SDK, focusing on completing the Toolbox/Tool command set, improving the Action Type execution experience, and aligning Python SDK authentication.
+
+**1. Toolbox / Tool Commands Now Available**
+
+Adds the `kweaver toolbox` and `kweaver tool` command families, covering complete lifecycle management for toolboxes and tools:
+
+- `kweaver toolbox create / list / publish / unpublish / delete`: Toolbox creation, publishing, and unpublishing management.
+- `kweaver tool upload / list / enable / disable`: OpenAPI Spec upload, tool enabling/disabling.
+
+Combined with the new `kweaver call -F <key>=@<file>` multipart file upload support, this fully replaces the original manual `curl + call` workflow in `examples/03-action-lifecycle`.
+
+**2. kweaver tool execute / debug**
+
+Adds `kweaver tool execute` and `kweaver tool debug` subcommands, encapsulating the header / query / body / timeout enum structures required for Toolbox proxy calls:
+
+- Automatically injects the current logged-in Bearer Token into the envelope, eliminating manual authentication header handling.
+- Resolves Authorization header forwarding restrictions in the `agent-operator-integration` service.
+- Python / TypeScript SDKs simultaneously add `ToolboxesResource.execute()` / `.debug()` methods.
+
+**3. BKN Action-Type Execution Experience Upgrade**
+
+Adds the `kweaver bkn action-type inputs <kn> <at>` command, which lists all parameters with `value_from=="input"` and their type-aware starter templates for direct use with `--dynamic-params`. The `bkn action-type execute` command adds a flag-form mode (`--dynamic-params / --instance / --trigger-type`), eliminating the need to manually assemble JSON envelopes, while maintaining backward compatibility with the original positional argument form.
+
+**4. Python SDK Authentication Full Alignment**
+
+The Python SDK completes authentication mechanism alignment with the TypeScript CLI:
+
+- Adds `HttpSigninAuth`, implementing browser-free HTTP login via RSA password encryption + OAuth2 redirect chain, covering edge cases such as `200+JSON` redirects.
+- The `~/.kweaver` storage format (`displayName`, `logoutRedirectUri`, ISO-Z timestamps) is byte-level aligned with the TS CLI; `kweaver auth list/whoami` can correctly recognize sessions written by Python.
+- Adds `change_password` method, supporting forced initial password changes (HTTP 401 code `401001017` automatically triggers guidance).
+
+**5. kweaver agent skill add / remove / list**
+
+Adds an Agent Skill membership management command family, supporting direct Skill configuration for Agents via CLI, replacing the original workflow of manually editing Agent JSON config:
+
+- `kweaver agent skill add <agent_id> <skill_id>`: Add a Skill binding to an Agent.
+- `kweaver agent skill remove <agent_id> <skill_id>`: Remove a Skill binding.
+- `kweaver agent skill list <agent_id>`: View the list of Skills currently bound to an Agent.
+
+---
+
+### 【Deployment & Infrastructure】
+
+**1. kweaver-admin: Platform Admin CLI Now Available**
+
+`kweaver-admin` is a standalone command-line tool for platform administrators. In environments with ISF (Information Security Fabric) installed, it supports complete user, role, and model management operations via CLI, without requiring login to the Web console.
+
+```bash
+npm install -g @kweaver-ai/kweaver-admin
+kweaver-admin auth login https://your-platform.example/
+```
+
+Core capabilities cover the following management domains:
+
+- **User Management** (`user`): List, query, create, update, and delete users; admin password reset; view assigned roles for a user.
+- **Role Management** (`role`): List roles and members; assign/revoke roles for users.
+- **Organization / Department Management** (`org`): List, tree view, create, update, and delete departments; view department members.
+- **Large Model Management** (`llm`): Add, edit, delete, and test large model configurations.
+- **Small Model Management** (`small-model`): Add, edit, delete, and test small model configurations.
+- **Audit Query** (`audit`): Query login audit events by user and time range.
+- **Raw HTTP Calls** (`call` / `curl`): Arbitrary API calls with authentication headers included.
+
+`kweaver-admin` also ships as an Agent Skill, installable via `npx skills add` into Agent workflows that support skill loading, enabling AI assistants to perform platform management operations using natural language:
+
+```bash
+npx skills add https://github.com/kweaver-ai/kweaver-admin --skill kweaver-admin
+```
+
+**2. Stability Fixes**
+
+- Fixes deadlock issues in DAG variable creation (`CreateDagVars`) and index refresh (`refreshDagIndexes`), eliminating probabilistic blocking under concurrent operations.
+- Fixes data insertion exceptions in `vega-backend` caused by a redundant unique index (`uk_catalog_source_identifier`).
+- Fixes an issue where model factory application accounts could not delete small models.
+
+---
+
+## Release Information
+
+### 1. GitHub Packages & Technical Documentation
+
+**KWeaver Core**
+- GitHub Release: https://github.com/kweaver-ai/kweaver-core/tree/release/0.7.0
+
+**KWeaver SDK**
+- GitHub: https://github.com/kweaver-ai/kweaver-sdk
+
+**kweaver-admin**
+- GitHub: https://github.com/kweaver-ai/kweaver-admin
+- npm: `npm install -g @kweaver-ai/kweaver-admin`
+
+---

--- a/release-notes/0.7.0/KWeaver Core 0.7.0 版本发布通知.md
+++ b/release-notes/0.7.0/KWeaver Core 0.7.0 版本发布通知.md
@@ -1,0 +1,352 @@
+# KWeaver Core 0.7.0 版本发布通知
+
+---
+
+## 版本概述
+
+### KWeaver Core 0.7.0 版本正式发布
+
+**指标语义融合，流式构建就绪，智能体能力多维跃升**
+
+KWeaver Core 0.7.0 以 **BKN 引擎双向升级**为核心主题。在语义建模层，指标类型（Metric）正式成为业务知识网络的第四类一等公民，与对象类、关系类、行动类共同表达业务实体与量化逻辑；关系映射新增 `FilteredCrossJoinMapping` 类型，支持在两个数据源的笛卡尔积上施加过滤条件精确筛选关联实例，覆盖复杂多表关联场景；BKN Specification SDK 同步升级至 v0.1.3，并新增 Exchange 邮件恢复领域知识网络模板。本版本同步完成 VEGA 对 PostgreSQL 流式索引构建的支持，三种构建模式（全量、增量、流式）至此完整覆盖；逻辑视图引擎新增多表 JOIN、UNION 视图类型及自定义 SQL 能力；执行工厂完成 Skill 生命周期管理闭环，支持整包更新、版本控制与历史回滚；Context Loader 完成工具合并并新增指标类型概念召回，覆盖对象、关系、行动、指标四类实体的统一语义搜索能力；Decision Agent 新增 React Agent 运行模式。整体系统在 API 错误语义、并发稳定性与部署运维体验方面同步完成多项专项改进。
+
+---
+
+## KWeaver Core 0.7.0 版本核心亮点速览
+
+**1. BKN 引擎双向升级：指标模型语义化与过滤交叉关联映射**
+
+BKN 引擎在两个方向完成重要突破。**指标模型**：指标类型（Metric）正式成为 BKN 第四类一等公民，与对象类、关系类、行动类并列，支持计算公式、分组维度、时间维度与多种查询模式（即时、趋势、同环比、占比）；Context Loader 同步新增指标语义召回，打通"指标建模→语义召回→智能体问答"链路。**关系映射**：新增 `FilteredCrossJoinMapping` 类型，支持在两个数据源的笛卡尔积上施加过滤条件精确筛选关联实例，覆盖物料-库存-订单等复杂多表关联场景，与原有直接映射、间接映射共同形成完整映射体系。
+
+**2. PostgreSQL 流式索引构建正式上线，数据变更实时入库**
+
+VEGA新增 PostgreSQL 流式索引构建，在既有全量构建与增量构建的基础上补齐流式实时模式：数据库中的行级变更（INSERT / UPDATE / DELETE）通过 PG 变更监听机制实时同步到搜索索引，无需定时全量刷新。至此，VEGA 对 PG 数据源的"批次（全量、增量）+ 流式"三种构建模式完整覆盖，满足对数据时效性有严格要求的实时分析场景。
+
+**3. 执行工厂 Skill 生命周期全管理，版本控制与历史回滚就绪**
+
+执行工厂 将 Skill 的管理能力从"注册-执行"升级为完整的生命周期管理：支持对已发布 Skill 进行元数据编辑（草稿态与发布态分离）、整包版本更新、历史版本查询与一键回滚，同时完成 Skill Dataset 重建补偿与增量构建能力。企业可在不中断线上服务的情况下进行 Skill 迭代，版本管理机制确保每次变更可溯源、可回退。
+
+**4. Decision Agent 新增 React 运行模式，复杂任务推理能力升级**
+
+Decision Agent引入 React Agent 运行模式（`agent_mode: react`），在原有 Dolphin 模式基础上新增独立的 ReactConfig 配置（支持对话历史开关与 LLM 缓存控制）。React 模式在多步推理、工具调用链较长的场景下具有更强的上下文连续性，配合新增的可配置内置 Skill 注册规则，智能体在复杂决策任务中的执行效率显著提升。
+
+**5. 逻辑视图引擎扩展：新增多表 JOIN / UNION 与自定义 SQL**
+
+VEGA 逻辑视图新增多表 JOIN（左连接等）与多表 UNION 两种视图类型，以配置化节点方式定义数据来源、关联键与输出字段，无需编写 SQL 即可完成多表联合查询建模；同时新增自定义 SQL 视图模式，支持完整 SQL 语句的灵活查询定义。三种视图类型统一通过 VEGA 统一查询接口对外暴露，底层无缝适配 MariaDB、PostgreSQL 与 OpenSearch 多种数据源。
+
+---
+
+## 详细功能说明
+
+### 【BKN 引擎】
+
+0.7.0 版本在指标模型与关系映射能力两个方向完成重要升级，同时完善边界校验与错误语义。
+
+**1. BKN 指标模型：业务语义化指标定义与查询**
+
+BKN 新增指标类型（Metric Type），支持在知识网络中直接定义具有业务语义的量化指标：
+
+- **指标结构建模**：指标通过 `scope`（所属对象类）、`计算公式`（过滤条件 + 聚合方式 + 分组字段）、`时间维度`、`分析维度`等要素完整描述业务量化逻辑。支持原子指标类型（`atomic`），复合指标类型后续迭代补充
+- **多维查询模式**：指标支持即时查询（`instant=true`，获取当前汇总值）、趋势查询（`instant=false` + 时间范围，按日/月/年等日历步长返回时序数据）、同环比分析（`type=parallel`，配置偏移量后计算增长值与增长率）及占比分析（`type=proportion`，按分析维度返回各维度占比百分比）
+- **语义检索**：指标支持语义化概念检索，通过 ID、名称、描述生成向量索引，支持基于自然语言的指标发现
+- **独立概念地位**：指标在 BKN 中作为独立概念类型存在，不与对象类等其他概念类型产生直接关联，但可通过 scope 引用指定对象类来限定统计主体
+
+**2. Condition 配置重构与校验完善**
+
+重构 BKN Condition 配置结构，将 `ActionCondCfg` 从 `CondCfg` 中分离为独立结构体，字段名从 `Name` 统一调整为 `Field` 以明确语义：
+
+- 完善对象类逻辑属性绑定资源在严格模式（`strict_mode`）下的 Condition 校验
+- 自动补全指标类型属性的系统参数，降低手动配置成本
+- 优化关系类型校验逻辑，新增非严格模式支持
+- 行动来源类型有效值从 `tool/map` 更新为 `tool/mcp`，与当前工具体系对齐
+
+**3. FilteredCrossJoinMapping：过滤式交叉关联映射**
+
+BKN 关系类型新增 `FilteredCrossJoinMapping` 映射类型，支持在两个数据源的笛卡尔积上施加过滤条件，从中精确筛选满足关联条件的实例对：
+
+- 解决了原有关系映射只能表达简单字段等值连接的限制，允许在关系类型中内联声明复杂的多字段过滤逻辑
+- 适用于"从资源 A 和资源 B 的组合中，按业务规则筛选有效关联"的多表关联场景，如物料-库存-订单的条件交叉匹配
+- 与现有 `DirectMappingRule` / `InDirectMappingRule` 并列，三种映射类型共同覆盖简单映射、间接映射与过滤交叉映射全场景
+
+**4. API 错误语义规范化**
+
+统一资源未找到场景的 HTTP 状态码为 404（原为 403），覆盖知识网络、概念组、行动类型、关系类型、对象类型等全部资源类型。Action-type execute 接口在 input 参数缺失时由静默丢弃改为返回明确的 400 错误，提升智能体错误路径的可诊断性。
+
+---
+
+### 【VEGA 数据虚拟化】
+
+0.7.0 版本在数据构建模式、逻辑视图能力与数据源接入三个方向完成重要能力扩展。
+
+**1. PostgreSQL 流式索引构建**
+
+VEGA 新增 PostgreSQL 流式索引构建，至此 PG 数据源覆盖三种构建模式：
+
+- **全量构建**：一次性将 PG 表全量数据同步到搜索索引
+- **增量构建**：基于增量字段仅同步上次构建以来新增或变更的数据
+- **流式构建**：通过 PG 变更监听机制实时捕获行级变更（INSERT / UPDATE / DELETE），数据变更实时同步到索引，满足毫秒级数据时效要求
+
+> 注意：流式构建依赖 PG 服务端开启相关变更监听开关（Logical Replication），未开启时构建任务将报错提示，请在启用前确认数据库配置。
+
+**2. 逻辑视图扩展：新增 JOIN、UNION 与自定义 SQL**
+
+逻辑视图（Logic View）从原有基础查询扩展为支持三种完整视图类型：
+
+- **JOIN 视图**：支持多表左连接（Left Join）等关联操作。通过配置化节点声明来源 Resource、关联键与输出字段，系统自动将配置转化为对应 SQL 执行；支持 MariaDB 与 PostgreSQL 数据源
+- **UNION 视图**：支持多表 UNION 合并查询，将同结构不同来源的数据合并为统一视图；支持 MariaDB 与 OpenSearch 混合数据源
+- **自定义 SQL 视图**：支持完整 SQL 语句定义，通过模板化语法（`{{.nodeId}}`）引用配置中声明的 Resource，兼顾灵活性与安全性
+
+所有逻辑视图通过 VEGA 统一查询接口（`/resources/{id}/data`）对外暴露，支持分页、排序、条件过滤与 limit 参数。
+
+**3. AnyShare 文档库接入与过滤条件支持**
+
+VEGA Catalog 在 0.6.0 AnyShare 知识库接入基础上，0.7.0 新增对 **AnyShare 文档库** 类型的支持，实现企业文档数据（Word、PDF 等格式文件）纳入业务知识网络管理；同时新增 `cond` 条件过滤参数，支持在 Catalog 发现阶段基于业务条件筛选文档库/知识库内容，减少不必要的数据摄取量。
+
+**4. Resource 数据查询能力增强**
+
+Resource Data 查询接口（`/resources/{id}/data`）新增聚合分析支持：
+
+- **聚合/分组**：支持 `GROUP BY` 分组统计
+- **Having 过滤**：支持对聚合结果的二次条件过滤
+- **查询参数修复**：修复 limit 参数在部分场景下未生效的问题，确保查询结果分页行为符合预期
+
+---
+
+### 【执行工厂】
+
+0.7.0 版本完成 Skill 生命周期管理的完整闭环，从单纯的注册-执行能力升级为支持版本控制、元数据迭代与数据补偿的全生命周期管理体系。
+
+**1. Skill 整包更新与元数据编辑**
+
+支持对已发布的 Skill 进行两种更新路径：
+
+- **元数据编辑**：在不替换 Skill 执行包的情况下，对 Skill 的名称、描述、分类等元数据进行修改，更改后生成草稿版本（编辑态），与当前发布版本并存，不影响线上调用
+- **整包更新**：重新上传 Skill 完整包，以新版本替代现有实现，同样先进入草稿态，经确认后发布上线
+
+两种更新路径均通过显式发布操作使变更生效，确保线上版本稳定性。
+
+**2. 版本管理与历史回滚**
+
+每次发布操作均记录版本历史，支持以下版本管理操作：
+
+- **历史版本查询**：查看指定 Skill 的完整版本变更记录
+- **历史版本回灌**：将任意历史版本回灌至草稿箱，作为下一次发布的候选版本
+- **历史版本直接发布**：支持直接将历史版本发布为线上版本，实现快速回滚
+
+线上始终只保留一个正式发布版本，Dataset 中存储的始终是线上最新版本对应的索引数据。
+
+**3. Skill Dataset 重建补偿与增量构建**
+
+新增 Skill Dataset 重建补偿机制：在 Skill 版本更新后，自动触发关联 Dataset 的重建或增量更新任务，确保 Dataset 中的索引数据始终与当前发布版本保持一致。增量构建仅处理自上次构建以来发生变更的部分，降低全量重建的性能开销。
+
+---
+
+### 【Context Loader】
+
+0.7.0 版本完成工具整合与能力扩展，将指标类型纳入统一语义召回体系，进一步降低智能体调用成本。
+
+**1. search_schema 工具合并：四类概念统一召回入口**
+
+将原有 `kn_schema_search` 与 `kn_search` 两个工具合并为统一的 `search_schema` 工具，覆盖对象类、关系类、行动类、**指标类** 四种 BKN 概念类型的统一语义召回：
+
+- **search_scope 参数**：通过 `include_object_types`、`include_relation_types`、`include_action_types`、`include_metric_types` 四个开关灵活控制召回范围，默认全类型覆盖
+- **精简响应模式**：支持 `schema_brief` 参数，开启后返回精简的概念摘要格式，降低 Token 消耗
+- **响应格式**：HTTP 接口默认 JSON，MCP Tool 默认 toon 压缩格式；原有两个工具保留在工具集中但不对外通过 MCP 暴露
+
+**2. 指标类型概念召回**
+
+基于 `search_schema` 工具，智能体现可通过自然语言查询直接发现知识网络中定义的指标：
+
+- 返回指标的 `id`、`name`、`comment`（业务说明）及 `metric_type`
+- 支持基于指标名称与描述的语义向量匹配
+- 支持混合召回：查询 "概念数量" 等语义时可同时返回对象类与相关指标，通过交叉评分确定最终排序
+
+**3. 僵尸依赖清理**
+
+移除 `agent-retrieval` 中被硬编码 feature flag 旁路的 `data_retrieval` 僵尸依赖，清理代码中已失效的配置项，确保工具召回路径行为与代码声明一致。
+
+---
+
+### 【Decision Agent】
+
+0.7.0 版本在运行模式与可配置性两个维度完成重要升级，同时简化了可观测性系统，提升运维可维护性。
+
+**1. React Agent 运行模式**
+
+新增 `agent_mode: react` 运行模式，通过 `/v3/agent/react` 端点创建 React Agent 配置：
+
+- **ReactConfig**：独立的 React 模式配置项，支持 `disable_history_in_a_conversation`（关闭对话内历史）与 `disable_llm_cache`（关闭 LLM 缓存）
+- **AgentMode 枚举**：新增 `default / dolphin / react` 三种模式枚举，为后续模式扩展预留扩展点
+- React 模式在多步工具调用链场景下具有更强的上下文连续性，适用于需要精确跟踪推理步骤的复杂决策任务
+
+**2. 内置 Skill 注册规则可配置化**
+
+支持通过配置文件控制内置 Skill 的注册行为与调用规则（`skill_enabled` 配置项），灵活适配不同部署场景下对内置能力的开放范围需求。
+
+**3. Agent 模板复制修复**
+
+修复复制 Agent 模板时 `published_at` 和 `published_by` 字段未被清除的问题，确保复制出的新模板始终以未发布状态初始化，避免状态混淆。
+
+**4. OAuth Bearer 转发修复**
+
+修复 `agent-executor` 中 OpenAPI Tool 不转发 OAuth Bearer Token 的问题，确保通过 Toolbox 注册的 OAuth 保护下游服务可被 Decision Agent 正常调用。
+
+**5. 可观测性系统简化**
+
+将可观测性实现从自定义 O11Y 追踪迁移至标准 OpenTelemetry（OTLP）链路，移除过时的 `observability handler` 与相关冗余组件，统一各服务（`agent-factory`、`agent-executor`、`agent-memory`）的遥测配置结构，降低运维复杂度。同时新增 LLM 消息日志功能（`LLMMessageLoggingConfig`），用于开发调试阶段捕获 LLM 输入输出的完整消息。
+
+**6. 废弃配置清理**
+
+移除以下已废弃的服务配置：`kn_data_query`、`kn_knowledge_data`、`data_connection`、`search_engine`、`ecosearch`、`ecoindex_public` 等；移除 `disable_biz_domain_init` 配置项，简化业务域初始化逻辑。
+
+---
+
+### 【沙箱运行时】
+
+0.7.0 Sandbox新增控制平面接管能力，大幅提升 Kubernetes 环境下运维升级的稳定性。
+
+**1. 控制平面接管（Control Plane Takeover）**
+
+新增控制平面启动时对既有会话 Pod 的接管能力：
+
+- 控制平面重启或升级后，自动扫描并接管 Kubernetes 集群中仍在运行的存量会话 Pod，恢复会话与执行器的绑定关系
+- 通过 Pod Owner Reference 机制实现执行器 Pod 与控制平面实例的亲和绑定，避免孤立 Pod 持续消耗资源
+- 处理同名 Pod 重建冲突：等待处于 Terminating 状态的旧 Pod 完全删除后再创建新 Pod，消除启动状态同步阶段的竞争条件
+
+**2. 会话 Pod 资源配置优化**
+
+K8s 调度模式下，会话 Pod 的 CPU 与内存 Request 调整为零（保留 Limit），减少因 per-session 资源预留导致的 Pod 调度失败，提升密集会话场景下的调度成功率。
+
+---
+
+### 【ISF 信息安全编织】
+
+0.7.0 完成 ISF 服务整合与能力扩展，移除 `sharemgnt-single` 独立服务，相关功能统一收归 ISF 主服务，降低整体部署服务数量与内存占用。
+
+**1. 个人访问令牌（PAT）支持**
+
+Authentication 模块新增个人访问令牌（Personal Access Token）能力，支持在 ISF 管理界面创建、查询与吊销 PAT：
+
+- 每个账户最多可创建 10 个 PAT（可配置）
+- 支持永久有效或指定到期时间
+- Token 生命周期通过 Hydra OAuth2 统一管理，与平台认证体系深度集成
+- 数据库迁移支持 MariaDB、DM8、KDB9 三种数据库
+
+**2. 批量用户导入/导出**
+
+UserManagement 新增批量用户管理能力，支持通过 Excel 文件批量创建账号：
+
+- **批量导入**：通过标准 Excel 模板导入用户，支持姓名、所属部门（多级，以 `/` 分隔）、手机号、有效期、存储配额、初始密码、用户密级等字段；红色字段为必填，黑色字段选填
+- **批量导出**：将当前用户列表导出为 Excel，支持异步后台任务执行，大数据量场景下不阻塞前台操作
+- 国际化支持：简体中文与繁体中文填写说明随模板内嵌，无需额外文档
+
+---
+
+### 【BKN Specification SDK】
+
+BKN Specification SDK 是独立发布的开放规范工具库，用于以代码方式解析、构建与序列化 BKN 业务知识网络规范文档。0.7.0 周期内发布稳定版本，完成底层重构并扩充示例库。
+
+**1. 解析器与序列化器底层重构**
+
+- **解析器重构**：引入 `extractSectionsWithDesc` / `buildDescription` 统一处理文档结构，摘要（summary）从描述内容首句自动提取，不再需要单独声明 `summary` 字段
+- **序列化器优化**：提取通用 `encodeYAMLBlock` 函数，移除冗余字段（`sub_conds`、`value_from`），统一表格格式规范
+
+**2. Exchange 邮件恢复领域模板与示例库扩展**
+
+新增 Exchange 邮件恢复领域知识网络模板，覆盖数据域、Exchange 服务器、备份时间点、恢复任务、恢复作业等完整对象类型，包含备份时间点验证失败、生产数据覆盖两类风险行动及完整脚本，可直接作为企业邮件备份恢复场景的起点模板；k8s-network、供应链（supplychain-hd）、员工入职（mock_system）等现有示例同步适配 `filtered_cross_join` 关系类型与新格式规范。
+
+---
+
+### 【KWeaver SDK】
+
+0.7.0 周期内 KWeaver SDK完成多项能力扩展，重点补全了 Toolbox/Tool 命令体系、Action Type 执行体验与 Python SDK 认证对齐。
+
+**1. Toolbox / Tool 命令正式上线**
+
+新增 `kweaver toolbox` 与 `kweaver tool` 命令族，覆盖工具箱与工具的完整生命周期管理：
+
+- `kweaver toolbox create / list / publish / unpublish / delete`：工具箱创建、发布与下线管理
+- `kweaver tool upload / list / enable / disable`：OpenAPI Spec 上传、工具启用/停用
+
+配合新增的 `kweaver call -F <key>=@<file>` multipart 文件上传支持，完整替代了原 `examples/03-action-lifecycle` 中的手工 curl + call 组合流程。
+
+**2. kweaver tool execute / debug**
+
+新增 `kweaver tool execute` 与 `kweaver tool debug` 子命令，封装 Toolbox 代理调用所需的 header / query / body / timeout 枚举结构：
+
+- 自动将当前登录 Bearer Token 注入 envelope，无需手动处理认证头
+- 解决 agent-operator-integration 服务对 Authorization 头的转发限制
+- Python / TypeScript SDK 同步新增 `ToolboxesResource.execute()` / `.debug()` 方法
+
+**3. BKN Action-Type 执行体验升级**
+
+新增 `kweaver bkn action-type inputs <kn> <at>` 命令，列出所有 `value_from=="input"` 的参数及其类型感知的起步模板，方便直接复制到 `--dynamic-params` 中使用；`bkn action-type execute` 同步新增 Flag 表单模式（`--dynamic-params / --instance / --trigger-type`），无需手工拼接 JSON envelope，与原位置参数形式保持向后兼容。
+
+**4. Python SDK 认证完整对齐**
+
+Python SDK 完成与 TypeScript CLI 的认证机制对齐：
+
+- 新增 `HttpSigninAuth`，通过 RSA 密码加密 + OAuth2 redirect chain 实现无浏览器 HTTP 登录，覆盖 200+JSON redirect 等边缘场景
+- `~/.kweaver` 存储格式（`displayName`、`logoutRedirectUri`、ISO-Z 时间戳）与 TS CLI 字节级对齐，`kweaver auth list/whoami` 可正常识别 Python 写入的会话
+- 新增 `change_password` 方法，支持初始密码强制修改（HTTP 401 code `401001017` 自动触发引导）
+
+**5. kweaver agent skill add / remove / list**
+
+新增 Agent Skill 成员管理命令族，支持通过 CLI 直接为 Agent 配置挂载 Skill，替代原有手动编辑 Agent JSON config 的工作流：
+
+- `kweaver agent skill add <agent_id> <skill_id>`：为 Agent 添加 Skill 绑定
+- `kweaver agent skill remove <agent_id> <skill_id>`：移除 Skill 绑定
+- `kweaver agent skill list <agent_id>`：查看当前 Agent 已绑定的 Skill 列表
+
+---
+
+### 【部署与基础设施】
+
+**1. kweaver-admin：平台管理员 CLI 正式发布**
+
+`kweaver-admin` 是面向平台管理员的独立命令行工具，在安装了 ISF（信息安全编织）的环境下，支持通过 CLI 完成用户、角色与模型的完整管理操作，无需登录 Web 控制台。
+
+```bash
+npm install -g @kweaver-ai/kweaver-admin
+kweaver-admin auth login https://your-platform.example/
+```
+
+核心能力覆盖以下管理域：
+
+- **用户管理**（`user`）：列出、查询、创建、更新、删除用户，管理员重置密码，查看用户已分配角色
+- **角色管理**（`role`）：列出角色与成员，为用户分配/撤销角色
+- **组织/部门管理**（`org`）：列表、树形结构、创建、更新、删除部门，查看部门成员
+- **大模型管理**（`llm`）：新增、编辑、删除、测试大模型配置
+- **小模型管理**（`small-model`）：新增、编辑、删除、测试小模型配置
+- **审计查询**（`audit`）：按用户、时间范围查询登录审计事件
+- **原始 HTTP 调用**（`call` / `curl`）：携带认证头的任意 API 调用
+
+`kweaver-admin` 同时提供 Agent Skill 形态，可通过 `npx skills add` 安装到支持 skill 加载的 Agent 工作流中，让 AI 助手直接以自然语言完成平台管理操作：
+
+```bash
+npx skills add https://github.com/kweaver-ai/kweaver-admin --skill kweaver-admin
+```
+
+**2. 稳定性修复**
+
+- 修复 DAG 变量创建（`CreateDagVars`）与索引刷新（`refreshDagIndexes`）中的死锁问题，消除并发操作下的概率性阻塞
+- 修复 vega-backend 中因冗余唯一索引（`uk_catalog_source_identifier`）导致的数据插入异常
+- 修复模型工厂应用账户无法删除小模型的问题
+
+---
+
+## 版本发布
+
+### 1. GitHub 安装包和技术文档
+
+**KWeaver Core**
+- GitHub Release: https://github.com/kweaver-ai/kweaver-core/tree/release/0.7.0
+
+**KWeaver SDK**
+- GitHub: https://github.com/kweaver-ai/kweaver-sdk
+
+**kweaver-admin**
+- GitHub: https://github.com/kweaver-ai/kweaver-admin
+- npm: `npm install -g @kweaver-ai/kweaver-admin`
+
+---


### PR DESCRIPTION
## Summary

- 新建 `release-notes/0.7.0/` 目录
- 添加中文版发布通知：`KWeaver Core 0.7.0 版本发布通知.md`
- 添加英文版发布通知：`KWeaver Core 0.7.0 Release Notes.md`

## Highlights

本次发布覆盖以下核心模块更新：
- **BKN 引擎**：指标类型（Metric）成为第四类一等公民 + FilteredCrossJoinMapping 关系映射
- **VEGA**：PostgreSQL 流式索引构建正式上线，逻辑视图新增 JOIN / UNION / 自定义 SQL
- **执行工厂**：Skill 生命周期全管理（版本控制 + 历史回滚）
- **Decision Agent**：新增 React 运行模式
- **Context Loader**：search_schema 工具合并，覆盖四类概念统一召回
- **ISF**：个人访问令牌（PAT）+ 批量用户导入/导出
- **KWeaver SDK**：Toolbox/Tool 命令族正式上线，Python SDK 认证对齐
- **kweaver-admin**：平台管理员 CLI 正式发布

🤖 Generated with [Claude Code](https://claude.com/claude-code)