### PR TITLE
文档(release)：中英文发布规范对齐（冻结发布、RC、Patch）

### DIFF
--- a/rules/RELEASE.md
+++ b/rules/RELEASE.md
@@ -12,7 +12,7 @@ This document defines the version management, branching strategy, and release pr
 - [Versioning](#-versioning)
 - [Release Process](#-release-process)
 - [Changelog Guidelines](#-changelog-guidelines)
-- [Backport Strategy](#-backport-strategy)
+- [Patch Releases](#-patch-releases)
 
 ---
 
@@ -35,8 +35,7 @@ KWeaver follows the **Trunk-based Development** model with these core principles
 | Main branch | `main` | Always-releasable trunk | `main` |
 | Feature branch | `feature/*` | New feature development | `feature/add-oauth-support` |
 | Fix branch | `fix/*` | Bug fixes | `fix/memory-leak-in-loader` |
-| Release branch | `release/x.x.x` | Release preparation | `release/1.2.0` |
-| Support branch | `support/x.y` | Maintenance branch for LTS versions | `support/1.2` |
+| Release branch | `release/x.y.z` | Release prep + patch maintenance | `release/1.2.0` |
 
 ### Branch Lifecycle
 
@@ -55,7 +54,7 @@ main ─────────────────────────
 - ✅ Frequently rebase to stay in sync with `main`
 - ✅ Delete branches immediately after merging
 - ❌ Avoid long-lived feature branches
-- ❌ Avoid merging between feature branches
+- ❌ Avoid merging between branches (merging `release/x.y.z` back into `main` is the declared exception)
 
 ---
 
@@ -119,39 +118,58 @@ git tag v1.0.0.rc.1
 
 ## 🚀 Release Process
 
+KWeaver uses the **Release With Freeze** model: every minor / major release must go through an RC validation cycle, and tag-triggered GitHub Actions perform artifact build & publish.
+
+### End-to-end Overview
+
+```mermaid
+flowchart LR
+  feat["feature/* fix/*"] -->|PR| main
+  main -->|"branch off release/0.7.0"| rel["release/0.7.0"]
+  rel -->|"freeze code+versions<br/>bug fixes"| rel
+  rel -->|"tag v0.7.0-rc.N"| ciRC["GitHub Actions<br/>(prerelease)"]
+  ciRC -->|"test artifacts<br/>no latest update"| testEnv["Test / UAT"]
+  testEnv -->|"pass"| rel
+  rel -->|"tag v0.7.0"| ciGA["GitHub Actions<br/>(release)"]
+  ciGA --> ghRel["GitHub Release"]
+  ciGA --> docker["Docker Images"]
+  ciGA --> pypi["Python Packages"]
+  ciGA --> helm["Helm Charts"]
+  rel -->|"--no-ff merge"| main
+  rel -.->|"keep one minor cycle<br/>then delete"| gone["Branch deleted"]
+```
+
+Equivalent textual steps:
+
+1. Develop on `feature/*` / `fix/*` branches
+2. Merge into `main` via PR
+3. Branch off `release/0.7.0` from `main`
+4. Run tests, fix bugs, freeze versions on `release/0.7.0`
+5. Tag RCs on `release/0.7.0`: `v0.7.0-rc.1` / `v0.7.0-rc.2`
+6. RC tags trigger GitHub Actions to build test artifacts (marked as `prerelease`)
+7. After RC validation, tag the final release on `release/0.7.0`: `v0.7.0`
+8. The release tag triggers GitHub Actions
+9. A GitHub Release is auto-generated (non-prerelease)
+10. Docker images / Python packages / Helm charts are auto-published, and `latest` is updated
+11. `release/0.7.0` is merged back to `main` with `--no-ff`
+12. `release/0.7.0` is kept for one minor cycle for patches (see "Patch Releases"); after that, or once no more patches are needed, the branch is deleted (tags are kept forever)
+
 ### Automated Releases
 
-KWeaver uses a **tag-triggered** automated release process:
+Releases are fully **tag-triggered**:
 
 ```text
-Developer pushes tag  →  CI detects tag  →  Run tests  →  Build artifacts  →  Publish Release
+Developer pushes tag  →  GitHub Actions detects tag  →  Run tests  →  Build artifacts  →  Publish Release
 ```
 
-CI will automatically perform the following:
+#### Tag Type → CI Behavior Matrix
 
-1. ✅ Run full test suite
-2. ✅ Build binaries for all platforms
-3. ✅ Build Docker images
-4. ✅ Generate Release Notes
-5. ✅ Publish to GitHub Releases
-6. ✅ Push images to Container Registry
+| Tag Type | GitHub Release | Image / Package Tag | `latest` / `stable` Alias | Helm Chart |
+| --- | --- | --- | --- | --- |
+| `vX.Y.Z-rc.N` | `prerelease: true` | `X.Y.Z-rc.N` | Not updated | Not pushed (test artifacts only) |
+| `vX.Y.Z` (final) | Regular release | `X.Y.Z` + `latest` | Updated | Pushed to chart repository |
 
-### Release Process (Release With Freeze / RC Flow)
-
-KWeaver uses the **Release With Freeze** model. All releases require an RC (Release Candidate) validation cycle.
-
-```text
-main ─────────┬─────────────────────────────────────────────────►
-              │                                        ▲
-              │ create release branch                  │ merge back to main
-              ▼                                        │
-         release/1.2.0 ──► rc.1 ──► rc.2 ──► v1.2.0 ──┘
-              │              │        │         │
-              │          (fix issues) (fix issues)
-              │              │        │         │
-              └──────────────┴────────┴─────────┘
-                   only bug fixes and release-related changes
-```
+> 📝 The `.github/workflows/` directory does not yet exist in the repo. This section is the agreed-upon contract; the corresponding workflows will land in a separate PR. All workflow trigger conditions and outputs must align with the table above.
 
 ### Steps
 
@@ -178,6 +196,20 @@ Once the release branch is created, it enters **code freeze** state:
 | Version number updates | Performance optimizations (unless fixing issues) |
 | Configuration adjustments | Dependency upgrades (unless security fixes) |
 
+**Version freeze checklist** — align all of the following to the upcoming `X.Y.Z` on the release branch:
+
+- `version` / `appVersion` of every Helm chart, e.g.:
+  - `infra/oss-gateway-backend/charts/Chart.yaml`
+  - `infra/mf-model-manager/charts/Chart.yaml`
+  - `infra/mf-model-api/charts/Chart.yaml`
+  - `deploy/charts/proton-mariadb/Chart.yaml`
+- Every Python package's `pyproject.toml`, e.g.:
+  - `infra/sandbox/sandbox_control_plane/pyproject.toml`
+  - `decision-agent/agent-backend/agent-memory/pyproject.toml`
+  - `decision-agent/agent-backend/agent-executor/pyproject.toml`
+- Repository-level version entry / `CHANGELOG.md` version section
+- Hardcoded versions in image / deployment manifests
+
 #### 3. Publish RC Versions
 
 ```bash
@@ -186,17 +218,19 @@ git checkout release/1.2.0
 git tag -a v1.2.0-rc.1 -m "Release candidate 1 for v1.2.0"
 git push origin v1.2.0-rc.1
 
-# If issues are fixed, publish subsequent RCs
+# After fixing issues, publish subsequent RCs
 git tag -a v1.2.0-rc.2 -m "Release candidate 2 for v1.2.0"
 git push origin v1.2.0-rc.2
 ```
 
+> RC tags must be published as `prerelease: true` GitHub Releases that produce only test artifacts. They must **not** update `latest` / `stable` aliases nor push Helm charts to the production chart repository.
+
 #### 4. RC Validation
 
-- Deploy RC version to test/staging environment
-- Execute full test suite
+- Deploy RC version to test / staging environment
+- Execute the full test suite
 - Perform User Acceptance Testing (UAT)
-- Collect feedback and fix discovered issues
+- Collect feedback, fix issues on the release branch, and publish the next RC
 
 #### 5. Publish Final Release
 
@@ -207,18 +241,34 @@ git tag -a v1.2.0 -m "Release v1.2.0"
 git push origin v1.2.0
 ```
 
+The final tag triggers GitHub Actions to produce:
+
+- ✅ GitHub Release (non-prerelease, with release notes)
+- ✅ Docker images (`X.Y.Z` and `latest`), pushed to the Container Registry
+- ✅ Python packages (from each `pyproject.toml`)
+- ✅ Helm charts (from each `Chart.yaml`), pushed to the chart repository
+
 #### 6. Merge Back to main
 
+KWeaver defaults to "fix directly on the release branch, then merge the whole release branch back into main with `--no-ff`":
+
 ```bash
-# Merge release branch back to main
 git checkout main
 git pull origin main
 git merge release/1.2.0 --no-ff -m "Merge release/1.2.0 into main"
 git push origin main
+```
 
-# Delete release branch (optional)
-git branch -d release/1.2.0
+> If `main` is protected as PR-only, open a `chore/merge-release-1.2.0` branch and merge via PR — keeping the spirit of "no cross-branch merging". This step is the declared exception.
+
+#### 7. Release Branch Retention & Deletion
+
+`release/1.2.0` is **kept for one minor cycle** after `v1.2.0` ships (e.g., until `v1.3.0`), and is used to ship `v1.2.1` / `v1.2.2` patches (see "Patch Releases"). When the cycle ends or no further patches are expected:
+
+```bash
+# Delete the branch; tags are kept forever
 git push origin --delete release/1.2.0
+git branch -D release/1.2.0
 ```
 
 ---
@@ -227,7 +277,8 @@ git push origin --delete release/1.2.0
 
 - Check the [GitHub Releases](https://github.com/kweaver-ai/kweaver-core/releases) page
 - Verify artifact downloads and integrity
-- Confirm Docker images are pullable
+- Confirm Docker images are pullable and Helm charts can be `helm pull`-ed
+- Confirm Python packages are installable from the target index
 
 ### Release Checklist
 
@@ -237,9 +288,11 @@ Before creating a release tag, confirm:
 - [ ] All tests pass
 - [ ] CHANGELOG.md is updated
 - [ ] Version number follows semantic versioning
+- [ ] All `Chart.yaml` / `pyproject.toml` versions match the tag
 - [ ] Documentation is synchronized
 - [ ] Breaking changes are documented
-- [ ] All RC versions have been validated
+- [ ] All RC versions have been validated and their GitHub Releases are marked as prerelease
+- [ ] After the final tag, image `latest` / Helm chart repository have been updated
 - [ ] Release branch has been merged back to main
 
 ---
@@ -317,83 +370,77 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
-## 🔄 Backport Strategy
+## 🔄 Patch Releases
 
-### When to Backport
+After `vX.Y.Z` ships, fixes that surface during the retention window of `release/X.Y.Z` are released as patches (`vX.Y.Z+1`) directly from that branch.
 
-Backports only apply to **Long-Term Support (LTS)** version maintenance branches:
+### When to Issue a Patch
 
-| Scenario | Backport? |
+| Scenario | Patch? |
 | --- | --- |
 | Security vulnerability fixes | ✅ Required |
 | Critical bug fixes | ✅ Recommended |
-| General bug fixes | ⚠️ Case by case |
-| New features | ❌ No backport |
-| Refactoring | ❌ No backport |
+| General bug fixes | ⚠️ Depends on impact; otherwise defer to the next minor |
+| New features | ❌ Never via patch |
+| Refactoring | ❌ Never via patch |
 
-### Support Branch Naming
+### Patch Process
 
-```
-support/x.y
-```
-
-Example: `support/1.2` for maintaining the 1.2.x version series.
-
-### Backport Process
-
-#### 1. Fix on main First
+#### 1. Fix on the Release Branch
 
 ```bash
-# Create fix branch on main
-git checkout main
-git checkout -b fix/security-issue-123
+git checkout release/1.2.0
+git pull origin release/1.2.0
 
 # Commit the fix
 git commit -m "fix(auth): patch security vulnerability CVE-2025-XXXX"
-
-# Merge to main
-# Record the merged commit hash and PR number
+git push origin release/1.2.0
 ```
 
-#### 2. Cherry-pick to Support Branch
+#### 2. (Optional) Publish RC for Validation
+
+For high-impact patches, an RC cycle is still encouraged:
 
 ```bash
-# Switch to support branch
-git checkout support/1.2
-
-# Cherry-pick the fix commit
-git cherry-pick -x <commit-hash>
-
-# The -x flag automatically adds cherry-pick source information
+git tag -a v1.2.1-rc.1 -m "Release candidate 1 for v1.2.1"
+git push origin v1.2.1-rc.1
 ```
 
-#### 3. Record Backport Information
-
-Add the original PR link in the commit message:
+#### 3. Publish the Patch Tag
 
 ```bash
-git commit --amend
-
-# Add to commit message:
-# (cherry picked from commit abc1234)
-# Backport of #123
-```
-
-#### 4. Create Patch Version
-
-```bash
-# Create patch version on support branch
-git tag -a v1.2.1 -m "Release v1.2.1 (security patch)"
+git tag -a v1.2.1 -m "Release v1.2.1"
 git push origin v1.2.1
 ```
 
-### Backport Checklist
+The final tag triggers GitHub Actions in the same way as a regular release tag.
 
-- [ ] Fix has been verified on `main` branch
-- [ ] Used `cherry-pick -x` to preserve source information
-- [ ] Commit message includes original PR link
-- [ ] Support branch CHANGELOG is updated
-- [ ] Patch version number is correctly incremented
+#### 4. Sync the Fix Back to main
+
+The same fix must reach `main` to avoid regressions on the trunk. Choose either approach:
+
+```bash
+# Approach A: cherry-pick standalone
+git checkout main
+git pull origin main
+git cherry-pick -x <commit-hash>
+git push origin main
+```
+
+```bash
+# Approach B: rely on the next overall merge-back
+# (must happen at least once before the release branch is deleted)
+git merge release/1.2.0 --no-ff -m "Merge release/1.2.0 into main"
+```
+
+### Patch Checklist
+
+- [ ] Fix is limited to bug / security fixes — no new features
+- [ ] `release/X.Y.Z` is still within its retention window
+- [ ] CHANGELOG `[X.Y.Z+1]` section is updated
+- [ ] Affected `Chart.yaml` / `pyproject.toml` versions are bumped
+- [ ] Patch version is correctly incremented
+- [ ] Fix has been synced back to `main` via cherry-pick or a merge-back
 
 ---
 
@@ -406,4 +453,4 @@ git push origin v1.2.1
 
 ---
 
-*Last updated: 2025-01-09*
+*Last updated: 2026-04-27*

--- a/rules/RELEASE.zh.md
+++ b/rules/RELEASE.zh.md
@@ -12,7 +12,7 @@
 - [版本号规范](#-版本号规范)
 - [发布流程](#-发布流程)
 - [Changelog 规范](#-changelog-规范)
-- [Backport 策略](#-backport-策略)
+- [Patch 版本发布](#-patch-版本发布)
 
 ---
 
@@ -35,8 +35,7 @@ KWeaver 采用 **Trunk-based Development** 模型，核心原则：
 | 主分支 | `main` | 永远可发布的主干 | `main` |
 | 功能分支 | `feature/*` | 新功能开发 | `feature/add-oauth-support` |
 | 修复分支 | `fix/*` | Bug 修复 | `fix/memory-leak-in-loader` |
-| 发布分支 | `release/x.x.x` | 发布准备 | `release/1.2.0` |
-| 支持分支 | `support/x.y` | 长期支持版本的维护分支 | `support/1.2` |
+| 发布分支 | `release/x.y.z` | 发布准备 + patch 维护 | `release/1.2.0` |
 
 ### 分支生命周期
 
@@ -55,7 +54,7 @@ main ─────────────────────────
 - ✅ 频繁 rebase 保持与 `main` 同步
 - ✅ 合并后立即删除分支
 - ❌ 避免长期存在的功能分支
-- ❌ 避免分支之间相互合并
+- ❌ 避免分支之间相互合并（`release/x.y.z` 合回 `main` 是已声明的例外）
 
 ---
 
@@ -119,39 +118,58 @@ git tag v1.0.0.rc.1
 
 ## 🚀 发布流程
 
+KWeaver 采用 **冻结发布（Release With Freeze）** 模式：所有 minor / major 版本都需要经过 RC 验证周期，由 tag 触发 GitHub Actions 完成产物构建与发布。
+
+### 端到端流程概览
+
+```mermaid
+flowchart LR
+  feat["feature/* fix/*"] -->|PR| main
+  main -->|"切 release/0.7.0"| rel["release/0.7.0"]
+  rel -->|"代码+版本号冻结<br/>bug fix"| rel
+  rel -->|"tag v0.7.0-rc.N"| ciRC["GitHub Actions<br/>(prerelease)"]
+  ciRC -->|"测试产物<br/>不更新 latest"| testEnv["Test / UAT"]
+  testEnv -->|"通过"| rel
+  rel -->|"tag v0.7.0"| ciGA["GitHub Actions<br/>(release)"]
+  ciGA --> ghRel["GitHub Release"]
+  ciGA --> docker["Docker Images"]
+  ciGA --> pypi["Python Packages"]
+  ciGA --> helm["Helm Charts"]
+  rel -->|"--no-ff merge"| main
+  rel -.->|"保留一个 minor 周期<br/>到期或不再 patch 即删除"| gone["分支删除"]
+```
+
+对应文字版步骤：
+
+1. 在 `feature/*` / `fix/*` 分支开发
+2. 通过 PR 合入 `main`
+3. 从 `main` 切出 `release/0.7.0`
+4. 在 `release/0.7.0` 上做测试、bug fix、版本号冻结
+5. 在 `release/0.7.0` 打 RC tag：`v0.7.0-rc.1` / `v0.7.0-rc.2`
+6. RC tag 触发 GitHub Actions 构建测试产物（标记 prerelease）
+7. RC 验证通过后，在 `release/0.7.0` 打正式 tag：`v0.7.0`
+8. 正式 tag 触发 GitHub Actions
+9. 自动生成 GitHub Release（非 prerelease）
+10. 自动发布 Docker 镜像 / Python 包 / Helm Chart，并更新 `latest`
+11. `release/0.7.0` 通过 `--no-ff` merge 合回 `main`
+12. `release/0.7.0` 保留一个 minor 周期用于 patch（详见「Patch 版本发布」），到期或确认无需维护后删除分支；tag 永久保留
+
 ### 自动化发布
 
-KWeaver 采用 **Tag 触发** 的自动化发布流程：
+发布完全由 **tag 触发**：
 
 ```text
-开发者 push tag  →  CI 检测到 tag  →  运行测试  →  构建制品  →  发布 Release
+开发者 push tag  →  GitHub Actions 检测到 tag  →  运行测试  →  构建制品  →  发布 Release
 ```
 
-CI 将自动完成以下步骤：
+#### tag 类型 → CI 行为矩阵
 
-1. ✅ 运行完整测试套件
-2. ✅ 构建各平台二进制文件
-3. ✅ 构建 Docker 镜像
-4. ✅ 生成 Release Notes
-5. ✅ 发布到 GitHub Releases
-6. ✅ 推送镜像到 Container Registry
+| tag 类型 | GitHub Release | 镜像 / 包 tag | `latest` / `stable` 别名 | Helm Chart |
+| --- | --- | --- | --- | --- |
+| `vX.Y.Z-rc.N` | `prerelease: true` | `X.Y.Z-rc.N` | 不更新 | 不推送（仅产出测试产物） |
+| `vX.Y.Z`（正式） | 正式 release | `X.Y.Z` + `latest` | 更新 | 推送到 chart 仓库 |
 
-### 发布流程 (Release With Freeze / RC Flow)
-
-KWeaver 采用 **冻结发布** 模式，所有版本发布都需要经过 RC（Release Candidate）验证周期。
-
-```text
-main ─────────┬─────────────────────────────────────────────────►
-              │                                        ▲
-              │ 创建 release 分支                       │ 合并回 main
-              ▼                                        │
-         release/1.2.0 ──► rc.1 ──► rc.2 ──► v1.2.0 ──┘
-              │              │        │         │
-              │         (修复问题) (修复问题)    │
-              │              │        │         │
-              └──────────────┴────────┴─────────┘
-                    仅允许 bug fix 和发布相关更改
-```
+> 📝 当前仓库尚未落地 `.github/workflows/`，本节为发布约定，对应工作流将作为单独 PR 提交。所有工作流的触发条件、产物输出必须与上表对齐。
 
 ### 步骤
 
@@ -178,6 +196,20 @@ Release 分支创建后进入**代码冻结**状态：
 | 版本号更新 | 性能优化（除非修复问题） |
 | 配置调整 | 依赖升级（除非修复安全问题） |
 
+**版本号冻结清单**：在 release 分支上需要将以下版本号统一对齐到将要发布的 `X.Y.Z`：
+
+- 各 Helm Chart 的 `version` / `appVersion`，例如：
+  - `infra/oss-gateway-backend/charts/Chart.yaml`
+  - `infra/mf-model-manager/charts/Chart.yaml`
+  - `infra/mf-model-api/charts/Chart.yaml`
+  - `deploy/charts/proton-mariadb/Chart.yaml`
+- 各 Python 包的 `pyproject.toml`，例如：
+  - `infra/sandbox/sandbox_control_plane/pyproject.toml`
+  - `decision-agent/agent-backend/agent-memory/pyproject.toml`
+  - `decision-agent/agent-backend/agent-executor/pyproject.toml`
+- 仓库根的版本入口 / `CHANGELOG.md` 版本节
+- 镜像 / 部署清单中显式写死的版本号
+
 #### 3. 发布 RC 版本
 
 ```bash
@@ -186,17 +218,19 @@ git checkout release/1.2.0
 git tag -a v1.2.0-rc.1 -m "Release candidate 1 for v1.2.0"
 git push origin v1.2.0-rc.1
 
-# 如有问题修复后，发布后续 RC
+# 修复问题后，发布后续 RC
 git tag -a v1.2.0-rc.2 -m "Release candidate 2 for v1.2.0"
 git push origin v1.2.0-rc.2
 ```
 
+> RC tag 触发的 GitHub Actions 必须以 `prerelease: true` 发布 Release，仅产出测试产物，**不**更新 `latest` / `stable` 别名，**不**推送 Helm Chart 到正式 chart 仓库。
+
 #### 4. RC 验证
 
-- 在测试/预发布环境部署 RC 版本
+- 在测试 / 预发布环境部署 RC 版本
 - 执行完整的测试用例
 - 进行用户验收测试（UAT）
-- 收集反馈并修复发现的问题
+- 收集反馈并在 release 分支上修复发现的问题，再发下一个 RC
 
 #### 5. 发布正式版本
 
@@ -207,7 +241,16 @@ git tag -a v1.2.0 -m "Release v1.2.0"
 git push origin v1.2.0
 ```
 
-#### 6. 合并回 main
+正式 tag 触发的 GitHub Actions 自动产出以下产物：
+
+- ✅ GitHub Release（非 prerelease，附 Release Notes）
+- ✅ Docker 镜像（`X.Y.Z` 与 `latest`），推送至 Container Registry
+- ✅ Python 包（来自仓库内各 `pyproject.toml`）
+- ✅ Helm Chart（来自仓库内各 `Chart.yaml`），推送至 chart 仓库
+
+#### 6. 合回 main
+
+KWeaver 默认采用「fix 直接在 release 分支提交，最终整体 `--no-ff` 合回 main」的回流策略：
 
 ```bash
 # 将 release 分支合并回 main
@@ -215,10 +258,18 @@ git checkout main
 git pull origin main
 git merge release/1.2.0 --no-ff -m "Merge release/1.2.0 into main"
 git push origin main
+```
 
-# 删除 release 分支（可选）
-git branch -d release/1.2.0
+> 若团队启用了 main 的 PR-only 保护，则改为开 `chore/merge-release-1.2.0` 分支提 PR 合并，与「分支之间避免相互合并」保持口径一致；本步骤是已声明的例外。
+
+#### 7. Release 分支保留与销毁
+
+`release/1.2.0` 在发完 `v1.2.0` 后**保留一个 minor 周期**（例如直到 `v1.3.0` 发布前），期间专门用于发 `v1.2.1` / `v1.2.2` 等 patch（详见「Patch 版本发布」）。周期结束 / 确认不再发 patch 后：
+
+```bash
+# 删除分支；tag 永久保留
 git push origin --delete release/1.2.0
+git branch -D release/1.2.0
 ```
 
 ---
@@ -227,7 +278,8 @@ git push origin --delete release/1.2.0
 
 - 检查 [GitHub Releases](https://github.com/kweaver-ai/kweaver-core/releases) 页面
 - 验证制品下载和完整性
-- 确认 Docker 镜像可拉取
+- 确认 Docker 镜像可拉取，Helm Chart 可 `helm pull`
+- 确认 Python 包可在目标 index 安装
 
 ### 发布检查清单
 
@@ -237,9 +289,11 @@ git push origin --delete release/1.2.0
 - [ ] 所有测试通过
 - [ ] CHANGELOG.md 已更新
 - [ ] 版本号符合语义化版本规范
+- [ ] 各 `Chart.yaml` / `pyproject.toml` 版本号已与 tag 对齐
 - [ ] 文档已同步更新
 - [ ] Breaking Changes 已在文档中说明
-- [ ] 所有 RC 版本已验证通过
+- [ ] 所有 RC 版本已验证通过，且 GitHub Release 标记为 prerelease
+- [ ] 正式 tag 后镜像 `latest` / Helm chart 仓库已更新
 - [ ] Release 分支已合并回 main
 
 ---
@@ -313,87 +367,80 @@ KWeaver 遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/) 规范。
 - ✅ 使用用户可理解的语言描述
 - ✅ Breaking Changes 放在显著位置并加粗
 - ❌ 不要包含内部重构细节（除非影响用户）
-- ❌ 不要包含 CI/测试相关变更
+- ❌ 不要包含 CI / 测试相关变更
 
 ---
 
-## 🔄 Backport 策略
+## 🔄 Patch 版本发布
 
-### 何时需要 Backport
+正式版本 `vX.Y.Z` 发布后，若在保留期内的 `release/X.Y.Z` 上发现需要修复的问题，可在该分支上发 patch（`vX.Y.Z+1`）。
 
-Backport 仅适用于 **长期支持 (LTS)** 版本的维护分支：
+### 何时发 patch
 
-| 场景 | 是否 Backport |
+| 场景 | 是否发 patch |
 | --- | --- |
 | 安全漏洞修复 | ✅ 必须 |
 | 严重 Bug 修复 | ✅ 推荐 |
-| 一般 Bug 修复 | ⚠️ 视情况 |
-| 新功能 | ❌ 不 Backport |
-| 重构 | ❌ 不 Backport |
+| 一般 Bug 修复 | ⚠️ 视影响面决定，必要时合并到下一个 minor |
+| 新功能 | ❌ 不通过 patch 发布 |
+| 重构 | ❌ 不通过 patch 发布 |
 
-### 支持分支命名
+### Patch 流程
 
-```
-support/x.y
-```
-
-例如：`support/1.2` 用于维护 1.2.x 系列版本。
-
-### Backport 流程
-
-#### 1. 在 main 上先修复
+#### 1. 在 release 分支上修复
 
 ```bash
-# 在 main 上创建修复分支
-git checkout main
-git checkout -b fix/security-issue-123
+git checkout release/1.2.0
+git pull origin release/1.2.0
 
 # 提交修复
 git commit -m "fix(auth): patch security vulnerability CVE-2025-XXXX"
-
-# 合并到 main
-# 记录合并后的 commit hash 和 PR 编号
+git push origin release/1.2.0
 ```
 
-#### 2. Cherry-pick 到支持分支
+#### 2.（可选）发 RC 验证
+
+对于影响面较大的 patch，仍可以走 RC 流程：
 
 ```bash
-# 切换到支持分支
-git checkout support/1.2
-
-# Cherry-pick 修复提交
-git cherry-pick -x <commit-hash>
-
-# -x 参数会自动添加 cherry-pick 来源信息
+git tag -a v1.2.1-rc.1 -m "Release candidate 1 for v1.2.1"
+git push origin v1.2.1-rc.1
 ```
 
-#### 3. 记录 Backport 信息
-
-在 commit message 中添加原始 PR 链接：
+#### 3. 发布 patch tag
 
 ```bash
-git commit --amend
-
-# 在 commit message 中添加：
-# (cherry picked from commit abc1234)
-# Backport of #123
-```
-
-#### 4. 创建 Patch 版本
-
-```bash
-# 在支持分支上创建补丁版本
-git tag -a v1.2.1 -m "Release v1.2.1 (security patch)"
+git tag -a v1.2.1 -m "Release v1.2.1"
 git push origin v1.2.1
 ```
 
-### Backport 检查清单
+正式 tag 同样触发 GitHub Actions 完成产物构建与发布，行为与「正式 tag」一致。
 
-- [ ] 修复已在 `main` 分支验证
-- [ ] 使用 `cherry-pick -x` 保留来源信息
-- [ ] commit message 包含原始 PR 链接
-- [ ] 支持分支的 CHANGELOG 已更新
+#### 4. 同步修复到 main
+
+修复同样需要回到 `main`，以避免主干回归。两种方式任选其一：
+
+```bash
+# 方式 A：单独 cherry-pick
+git checkout main
+git pull origin main
+git cherry-pick -x <commit-hash>
+git push origin main
+```
+
+```bash
+# 方式 B：随下次整体合回（在 release 分支销毁前必须完成一次）
+git merge release/1.2.0 --no-ff -m "Merge release/1.2.0 into main"
+```
+
+### Patch 检查清单
+
+- [ ] 修复仅限 bug fix / 安全修复，无新功能
+- [ ] `release/X.Y.Z` 仍在保留期内
+- [ ] CHANGELOG 的 `[X.Y.Z+1]` 节已补
+- [ ] 涉及版本号的 `Chart.yaml` / `pyproject.toml` 已更新
 - [ ] Patch 版本号正确递增
+- [ ] 修复已通过 cherry-pick 或合回 main 同步至主干
 
 ---
 
@@ -406,4 +453,4 @@ git push origin v1.2.1
 
 ---
 
-*最后更新：2025-01-09*
+*最后更新：2026-04-27*


### PR DESCRIPTION
## 背景与目的

将 `rules/RELEASE.md` 与 `rules/RELEASE.zh.md` 从「简略的 tag 触发说明 + 简略 RC 文字图」升级为与团队约定一致的**完整发布规范**：明确 **Release With Freeze**、RC 与正式 tag 的分工、产物与 CI 行为对照表，以及 release 分支生命周期与 **Patch** 流程，便于发版执行与评审对齐。

---

## 本次修改概要（两份文档结构一致，仅语言不同）

### 1. 分支策略

- **发布分支**：表述统一为 `release/x.y.z`，并写明承担「发布准备 + 后续 patch 维护」。
- **移除**原规范中的 **`support/x.y`（LTS 维护分支）** 行，避免与当前主干策略混用。
- **合并规则**：将「禁止功能分支互合并」改为更准确的「避免分支间随意合并」，并**显式声明例外**：`release/x.y.z` 合回 `main` 为已约定流程。

### 2. 发布流程（核心扩写）

- **模型命名**：正文明确采用 **Release With Freeze**（冻结发布）：minor/major 必须经过 RC 验证周期；由 **tag 触发 GitHub Actions** 完成构建与发布。
- **端到端概览**：
  - 新增 **Mermaid 流程图**（`feature/*`、`fix/*` → `main` → `release/x.y.z` → RC tag → 测试/UAT → 正式 tag → GitHub Release / Docker / PyPI / Helm → `--no-ff` 合回 `main` → 分支保留与删除）。
  - 配套 **12 条文字步骤**，与图中阶段一一对应。
- **自动化发布**：保留「完全由 tag 触发」的表述，并将 CI 侧描述与 **GitHub Actions** 对齐。
- **Tag 类型 → CI 行为矩阵**（新建表格）：
  - **`vX.Y.Z-rc.N`**：`prerelease` Release、镜像/包 tag、**不**更新 `latest`/`stable`、**不**向正式 chart 仓库推 Helm。
  - **`vX.Y.Z`（正式）**：正式 Release、镜像 `X.Y.Z` + `latest`、更新别名、Helm 推送到 chart 仓库。
- **脚注约定**：说明当前仓库 **尚未落地 `.github/workflows/`**，本节作为**发布契约**；后续工作流单独 PR 落地时，触发条件与产物须与本表一致。

### 3. 代码冻结（Code Freeze）

- 在原有「允许 / 禁止」表之外，新增 **版本冻结清单**，要求在 release 分支上将下列内容与即将发布的 **`X.Y.Z`** 对齐：
  - 各 Helm Chart 的 `version` / `appVersion`（文档中列举示例路径，如 `infra/oss-gateway-backend/charts/Chart.yaml` 等）。
  - 各 Python 包的 `pyproject.toml`（列举 sandbox、decision-agent 等示例路径）。
  - 仓库级版本入口与 **`CHANGELOG.md`** 对应版本节。
  - 镜像与部署清单中的写死版本号。

### 4. RC 与正式发版步骤

- **RC**：补充说明 RC tag 对应 GitHub Release 必须为 **prerelease**，且不得更新 `latest`/`stable`、不得向正式 chart 仓库推 Helm。
- **RC 验证**：步骤写细（测试环境部署、全量测试、UAT、在 release 分支修问题后再发下一 RC）。
- **正式 tag**：列出 Actions 预期产物（GitHub Release、Docker 镜像、Python 包、Helm chart）。
- **合回 `main`**：默认「在 release 分支修 fix，最后 **`--no-ff`** 整体合回」；若 `main` 为 **仅 PR 合并**，说明可开 `chore/merge-release-*` 分支走 PR，并注明为例外口径。
- **Release 分支保留与删除**：**新建独立小节**——正式版发布后 **保留约一个 minor 周期**用于 `vX.Y.(Z+1)` patch；周期结束或不再发 patch 后删除远程/本地分支；**tag 永久保留**。

### 5. 验证发布与检查清单

- **验证**：除 GitHub Releases、制品完整性、Docker 可拉取、Helm `helm pull`、Python 可安装外，与新版流程表述一致。
- **发版前检查清单**：增加与 RC、正式 tag、**`Chart.yaml` / `pyproject.toml` 与 tag 对齐**、合回 `main` 等相关勾选项。

### 6. 「Backport」→「Patch 版本发布」

- 目录与正文将原 **Backport Strategy** 整段替换为 **Patch Releases**（中英文对应）：说明在 `release/X.Y.Z` 保留期内如何发 **patch**、何时必须/可选发 patch、可选 RC、打 tag、以及 **cherry-pick 或合回** 同步到 `main`，并附 **Patch 检查清单**。

### 7. 刻意不包含的范围

- **不包含**仓库内 **Docker Compose** 作为发布契约的一部分（无流程图节点、无矩阵列、无 compose 路径冻结项）。
- **不包含**任何 **GitHub Actions workflow 实现**，仅文档层面对行为与产物做约定。

---

## 涉及文件

| 文件 | 说明 |
| --- | --- |
| `rules/RELEASE.md` | 英文发布规范 |
| `rules/RELEASE.zh.md` | 中文发布规范，与英文结构、条款对齐 |

---

*以上为本 PR 对发布文档的修改说明，便于 reviewer 对照阅读。*
