### PR TITLE
Add example 04: multi-agent custom-input propagation (closes #326)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ lib64/
 # Track deploy shell helpers (global `lib/` above would otherwise ignore this tree)
 !deploy/scripts/lib/
 !deploy/scripts/lib/**
+# Track example shell helpers
+!examples/*/lib/
+!examples/*/lib/**
 parts/
 sdist/
 var/

--- a/examples/04-multi-agent-session-id/README.md
+++ b/examples/04-multi-agent-session-id/README.md
@@ -1,0 +1,151 @@
+# 04 · Multi-Agent — Custom Input Propagation
+
+> A platform feature audit shows a custom input field travels intact through `father → son1/son2 → SKILL`, every step verifiable.
+
+## The Problem
+
+When you compose multiple agents on the platform, you need to know that user-supplied
+context — a `session_id`, an `org_id`, a tenant marker — actually reaches every nested
+agent and skill. Reading the LLM's reply doesn't prove it: the LLM might just be
+echoing what it saw in the prompt. You need evidence the **platform itself** routed
+the field, not the model's good behavior.
+
+## What This Shows
+
+A minimal three-agent + one-skill setup:
+
+- `exp_father` — Dolphin orchestration, calls `@exp_son1(...)` then `@exp_son2(...)`
+- `exp_son1` / `exp_son2` — identical sons that read `input.session_id` and use the SKILL
+- `exp_session_echo` — a SKILL that echoes the literal `session_id` value verbatim
+
+The script invokes `exp_father` with `custom_querys.session_id=DEMO-XXX` and verifies:
+
+1. **Literal echo** — each son's textual answer contains
+   `[exp_session_echo] RECEIVED session_id=DEMO-XXX from <son_name>`.
+2. **Platform-side routing** — each son's `input_message` (what the platform actually
+   delivered to the son) contains the prefix `[input.session_id=DEMO-XXX]`.
+
+The second assertion is the one that rules out LLM hallucination. Only the platform's
+agent-executor injects that prefix via the son's Dolphin DSL.
+
+## Prerequisites
+
+- `kweaver` CLI ≥ 0.6.4 with an authenticated session (`kweaver auth whoami`)
+- `jq`, `bash`, `curl` on your local machine
+- Business domain `bd_public` (default)
+
+No database, no CSV files, no `.env` setup. The example uses the platform's default
+LLM and the toolboxes that ship with KWeaver Core.
+
+## Quick Start
+
+```bash
+./run.sh                                  # ensure artifacts + invoke + verify
+./run.sh --session-id MY-CUSTOM-XYZ       # custom session_id (default: DEMO-2026-XXXXXX)
+./run.sh --cleanup                        # delete the SKILL + 3 agents from the platform
+```
+
+Successful run tails to:
+
+```
+[exp] son1 answer (first 200 chars): ... [exp_session_echo] RECEIVED session_id=DEMO-2026-A1B2C3 from exp_son1 ...
+[exp] son2 answer (first 200 chars): ... [exp_session_echo] RECEIVED session_id=DEMO-2026-A1B2C3 from exp_son2 ...
+[exp] assert_literal: exp_son1 — PASS
+[exp] assert_literal: exp_son2 — PASS
+[exp] assert_propagation: exp_son1 input contains [input.session_id=DEMO-2026-A1B2C3] — PASS
+[exp] assert_propagation: exp_son2 input contains [input.session_id=DEMO-2026-A1B2C3] — PASS
+[exp] ALL ASSERTIONS PASSED. session_id=DEMO-2026-A1B2C3, conversation=01KQ...
+[exp] (artifacts kept on platform; run with --cleanup to remove)
+```
+
+End-to-end takes ~30 seconds.
+
+## Architecture
+
+```
+user
+  │  POST /api/agent-factory/v1/app/<father_key>/chat/completion
+  │  body: { ..., query, custom_querys: { session_id: "DEMO-XXX" }, stream: false }
+  ▼
+exp_father  is_dolphin_mode=1
+  dolphin DSL:
+    @exp_son1(session_id=$session_id, query=$query) -> res_1
+    @exp_son2(session_id=$session_id, query=$query) -> res_2
+  ├─► exp_son1
+  │     "[input.session_id=" + $session_id + "] " + $query -> q
+  │     /explore/(history=true) <prompt>\n$q\n -> answer
+  │     ├─ list_skills_v2() — discovers exp_session_echo
+  │     ├─ builtin_skill_load(skill_id) — fetches SKILL.md
+  │     └─ echoes "[exp_session_echo] RECEIVED session_id=DEMO-XXX from exp_son1"
+  └─► exp_son2  (identical config except agent name)
+```
+
+The full final answer lives at `final_answer.answer_type_other.{res_1,res_2}.answer.answer`.
+The `input_message` field on the same path proves the platform routed `session_id` from
+father into the son's call.
+
+## Flow
+
+| Step | What happens |
+|------|-------------|
+| 1 | Register the `exp_session_echo` SKILL (or reuse if already registered) |
+| 2 | Create + publish `exp_son1` and `exp_son2` from the jq template (or reuse) |
+| 3 | Create + publish `exp_father` binding both sons via `skills.agents` |
+| 4 | POST to `/chat/completion` with `custom_querys.session_id` set |
+| 5 | Two assertions on the response (literal echo + routed-input prefix) |
+
+Default behavior is **idempotent**: agents and skill are kept on the platform after a
+successful run, so the next invocation just reuses them. Use `--cleanup` to remove.
+
+## File Layout
+
+```
+04-multi-agent-session-id/
+├── README.md / README.zh.md       # this file (and Chinese long-form notes)
+├── run.sh                         # entry point
+├── skills/
+│   └── exp_session_echo/SKILL.md  # SKILL content
+├── configs/
+│   ├── base.config.json           # platform-template-derived base
+│   ├── son.config.template.jq     # son renderer (Dolphin mode)
+│   ├── father.config.template.jq  # father renderer (Dolphin orchestration)
+│   └── .schema-notes.md           # swagger field-name notes
+└── lib/
+    ├── common.sh   # shared helpers + name vars
+    ├── render.sh   # jq render functions
+    ├── verify.sh   # the two assertions
+    └── cleanup.sh  # opt-in teardown (only --cleanup invokes this)
+```
+
+## Where to Look for Evidence
+
+After a run:
+
+- `/tmp/exp_run_resp.json` — full chat completion response (the source of both assertions)
+- `kweaver agent get <agent_id> --verbose` — current platform-side config of any agent
+  (note the `--verbose` flag — without it, `agent get` returns a thin response)
+
+Note: `kweaver agent trace` currently returns HTTP 500 on the demo platform
+(Uniquery DataView issue). The chat completion response carries enough information for
+the two assertions, so this example does not depend on it.
+
+## Cleanup
+
+Unlike the other examples in this folder, **artifacts are kept by default** — the SKILL
+and three agents stay on the platform so you can browse them in the Web UI or invoke
+them again without paying the create cost. Run `./run.sh --cleanup` when you're done.
+
+## Platform Notes Discovered While Building This
+
+- Custom input fields like `session_id` only land in `input.<name>` when sent inside
+  `custom_querys: { ... }` — top-level body keys are ignored.
+- `is_dolphin_mode=0` (plain prompt) ignores the `pre_dolphin` array entirely; the
+  executor synthesizes its own program from `system_prompt`. To inject custom fields
+  into what the LLM sees, switch to `is_dolphin_mode=1` and write the dolphin program.
+- `list_skills_v2` (toolbox `tmp_skill_discovery_R1`) requires a `tool_input` entry
+  mapping `X-Authorization` from `header.authorization` (`map_type=var`); without it
+  the proxy returns 401.
+- Schema field is `tool_box_id` (with the underscore between `box`), not `toolbox_id`.
+- LLM id lives at `.llms[0].llm_config.id`, not `.llms[0].id`.
+
+The Chinese long-form [README.zh.md](./README.zh.md) goes deeper on each of these.

--- a/examples/04-multi-agent-session-id/README.zh.md
+++ b/examples/04-multi-agent-session-id/README.zh.md
@@ -1,0 +1,219 @@
+# multi-agent-session-id
+
+**证明 `session_id` 可以从用户请求穿透 father agent → son agents → SKILL，全链路零丢失。**
+
+---
+
+## 它证明了什么
+
+KWeaver 平台支持通过 `custom_querys.session_id` 向 agent 注入自定义会话标识。这个 demo 验证：
+该字段不仅由 father agent 接收到，还能被 father 的 dolphin DSL 显式传递给下游的 son agents，最终被 son 调用的 SKILL (`exp_session_echo`) 原文回显出来。
+
+整个链路没有任何硬编码的 session_id 值——SKILL 必须从运行时的 `input.session_id` 读取并原文输出。
+两条独立的 shell 断言（见下方"校验做了什么"）从平台返回的响应 JSON 中机械地检查这一点，
+不依赖 LLM 描述，也不依赖人工肉眼核对。
+
+---
+
+## 架构
+
+```
+user
+  │  POST /api/agent-factory/v1/app/<father_key>/chat/completion
+  │  body: { agent_id, agent_key, agent_version, query,
+  │          custom_querys: { session_id: "DEMO-XXX" }, stream: false }
+  ▼
+exp_father  (is_dolphin_mode=1)
+  dolphin DSL:
+    @exp_son1(session_id=$session_id, query=$query) -> res_1
+    @exp_son2(session_id=$session_id, query=$query) -> res_2
+    {"res_1": $res_1, "res_2": $res_2} -> answer
+  │
+  ├─► exp_son1  (is_dolphin_mode=1)
+  │     dolphin DSL:
+  │       "[input.session_id=" + $session_id + "] " + $query -> q
+  │       /explore/(history=true) <prompt>\n$q\n -> answer
+  │     skills.skills = [{ skill_id: exp_session_echo }]
+  │     skills.tools  = [list_skills_v2 with X-Authorization mapping]
+  │     │
+  │     ├── list_skills_v2()       → 返回可用 skill 列表
+  │     ├── builtin_skill_load()   → 加载 exp_session_echo 内容
+  │     └── LLM 输出: "[exp_session_echo] RECEIVED session_id=DEMO-XXX from exp_son1"
+  │
+  └─► exp_son2  (配置与 exp_son1 完全相同，仅 name/profile 不同)
+        同样链路 → "[exp_session_echo] RECEIVED session_id=DEMO-XXX from exp_son2"
+
+响应路径:
+  .message.content.final_answer.answer_type_other.{res_1,res_2}.answer.answer
+  .message.content.final_answer.answer_type_other.{res_1,res_2}.answer.input_message
+```
+
+---
+
+## 怎么跑
+
+### 前提
+
+- `kweaver` CLI 已通过 `kweaver auth login` 认证到 `admin` 平台（`https://115.190.186.186`）
+- 环境中有 `jq`、`bash`、`curl`
+
+### 三条命令
+
+```bash
+# 默认：检测现有产物（已存在则复用），调用 father，跑两条断言
+./run.sh
+
+# 指定自定义 session_id（默认随机生成 DEMO-2026-XXXXXX）
+./run.sh --session-id MY-CUSTOM-ID
+
+# 清理：在平台上 unpublish + 删除三个 agent 和 skill（不可逆，慎用）
+./run.sh --cleanup
+```
+
+> **警告**：`--cleanup` 会永久删除平台上的 `exp_father`、`exp_son1`、`exp_son2`、`exp_session_echo`。
+> 这些产物目前被保留供人工验证，请勿随意清理。
+
+### 成功时的输出尾部
+
+```
+[exp] session_id=DEMO-2026-XXXXXX
+[exp] skill_id=30537b46-b510-4964-b235-eb529394d00e (reused if existed)
+[exp] agent exp_son1 already exists (01KQA4JH5QNBJBD42KN43458FW), reusing as-is
+[exp] agent exp_son2 already exists (01KQA4MD1K463BDK6F10WGBRT5), reusing as-is
+[exp] agent exp_father already exists (01KQA4NZXQFQP6EJMXSGH2S8DM), reusing as-is
+[exp] invoking father with custom_querys.session_id=DEMO-2026-XXXXXX...
+[exp] conversation_id=<conv_id>, elapsed=33s
+[exp] son1 answer (first 200 chars):
+[exp_session_echo] RECEIVED session_id=DEMO-2026-XXXXXX from exp_son1 ...
+[exp] son2 answer (first 200 chars):
+[exp_session_echo] RECEIVED session_id=DEMO-2026-XXXXXX from exp_son2 ...
+[exp] assert_literal: exp_son1 — PASS
+[exp] assert_literal: exp_son2 — PASS
+[exp] assert_propagation: exp_son1 input contains [input.session_id=DEMO-2026-XXXXXX] — PASS
+[exp] assert_propagation: exp_son2 input contains [input.session_id=DEMO-2026-XXXXXX] — PASS
+[exp] ALL ASSERTIONS PASSED. session_id=DEMO-2026-XXXXXX, conversation=<conv_id>
+[exp] (artifacts kept on platform; run with --cleanup to remove)
+```
+
+---
+
+## 校验做了什么
+
+校验逻辑在 `lib/verify.sh`，两条断言都从 `/tmp/exp_run_resp.json` 读取平台响应。
+
+### 断言 1：`assert_literal_in_answer`
+
+检查每个 son 的文本回答中是否包含：
+
+```
+[exp_session_echo] RECEIVED session_id=<sid> from <son_name>
+```
+
+这一行由 SKILL（`exp_session_echo`）严格按照 `SKILL.md` 格式输出。
+如果平台没有把 `session_id` 传进 son 的上下文，SKILL 就无法知道它——
+这条断言排除了 LLM 猜测或硬编码的可能。
+
+### 断言 2：`assert_session_id_in_son_input`
+
+检查每个 son 在响应中的 `input_message` 字段是否包含：
+
+```
+[input.session_id=<sid>]
+```
+
+这一段前缀是 son 的 dolphin DSL 主动拼接的：
+
+```
+"[input.session_id=" + $session_id + "] " + $query -> q
+```
+
+`input_message` 是平台记录的"son 实际收到的 query 字符串"，不经过 LLM 加工。
+该断言证明平台确实把 father 传来的 `session_id` 路由进了 son 的执行上下文，
+而不是 LLM 在回答中自行编造。
+
+---
+
+## 现网产物（保留状态）
+
+以下产物已部署在 `https://115.190.186.186`（business domain: `bd_public`），**请勿删除**：
+
+| 类型   | 名称               | ID                                       | 额外信息                       |
+|--------|--------------------|------------------------------------------|--------------------------------|
+| SKILL  | `exp_session_echo` | `30537b46-b510-4964-b235-eb529394d00e`   | status: published              |
+| Agent  | `exp_son1`         | `01KQA4JH5QNBJBD42KN43458FW`            | key: `01KQA4JH5QNBJBD42KN2K1S5JK`, v1 |
+| Agent  | `exp_son2`         | `01KQA4MD1K463BDK6F10WGBRT5`            | key: `01KQA4MD1K463BDK6F10CZFMM1`, v1 |
+| Agent  | `exp_father`       | `01KQA4NZXQFQP6EJMXSGH2S8DM`            | key: `01KQA4NZXQFQP6EJMXSD36ZBXD`, v1 |
+
+Web UI：`https://115.190.186.186/dip-hub/studio/digital-human`
+（在 agent 列表中按名称搜索 `exp_father` / `exp_son1` / `exp_son2`）
+
+---
+
+## 看证据在哪
+
+运行 `./run.sh` 后：
+
+**完整响应 JSON**
+
+```bash
+cat /tmp/exp_run_resp.json | jq .
+```
+
+两个 son 的回答分别在：
+
+```bash
+jq '.message.content.final_answer.answer_type_other.res_1.answer.answer' /tmp/exp_run_resp.json
+jq '.message.content.final_answer.answer_type_other.res_2.answer.answer' /tmp/exp_run_resp.json
+```
+
+son 收到的实际 input（含 `[input.session_id=...]` 前缀）：
+
+```bash
+jq '.message.content.final_answer.answer_type_other.res_1.answer.input_message' /tmp/exp_run_resp.json
+```
+
+**查看平台上 agent 的当前配置**
+
+```bash
+kweaver agent get 01KQA4NZXQFQP6EJMXSGH2S8DM --verbose   # exp_father
+kweaver agent get 01KQA4JH5QNBJBD42KN43458FW  --verbose   # exp_son1
+```
+
+> 注意：`kweaver agent trace <agent_id> <conv_id>` 当前返回 HTTP 500（平台 Trace API 故障），
+> 不推荐使用。所有需要的证据都在 chat completion 的响应 JSON 中。
+
+---
+
+## 平台行为踩坑记录
+
+以下是构建过程中发现的平台非直觉行为，记录供后续排查参考：
+
+- **`custom_querys.session_id` 是唯一有效路径**：自定义输入字段必须放在请求体的 `custom_querys` 对象内；直接放在顶层的 body 字段不会被路由进 agent 的 `input.*`。`kweaver agent chat` 命令不支持传 `custom_querys`，必须用 `kweaver call -d <body>`。
+
+- **`is_dolphin_mode=0` 会忽略 `pre_dolphin`**：在纯 prompt 模式下，平台会用 system_prompt 自动合成 dolphin 程序，忽略用户设置的 `pre_dolphin` 数组。要让 `session_id`（或任何自定义输入字段）出现在 LLM 的上下文里，必须用 `is_dolphin_mode=1` 加显式 dolphin DSL。
+
+- **`list_skills_v2` 必须配置 X-Authorization 映射**：工具箱 `tmp_skill_discovery_R1` 的 `list_skills_v2` 工具（id `51382ef3-b35b-44a6-8a53-c670cbf53f10`）在 agent 调用时会返回 401，除非 agent 配置中为该工具的 `tool_input` 添加了 `X-Authorization` → `header.authorization` 的 `map_type=var` 映射。
+
+- **`kweaver agent get` 默认返回精简字段**：不带 `--verbose` 时只返回 `{id, name, description, status, kn_ids}`。要看完整的 `.config`（包括 dolphin DSL、skills 等），必须加 `--verbose`。
+
+- **Trace API 当前不可用**：`kweaver agent trace <agent_id> <conv_id>` 返回 HTTP 500（Uniquery DataView 错误）。用 chat completion 响应 JSON 替代——所有验证所需数据都在里面。
+
+- **LLM id 路径是 `.llms[0].llm_config.id`**：平台的 base agent 模板中，LLM 配置的 id 存在 `.llms[0].llm_config.id`，而非 `.llms[0].id`（后者为空）。jq 模板和 `common.sh` 均按前者取值。
+
+---
+
+## 前提
+
+- `kweaver` CLI 已通过 `kweaver auth login` 认证到 `admin` 平台
+- `jq` >= 1.6
+- `bash` >= 4
+- `curl`（由 `kweaver call` 内部使用）
+
+---
+
+## 设计文档
+
+[`docs/superpowers/plans/2026-04-28-exp-multi-agent-session-id.md`](../../docs/superpowers/plans/2026-04-28-exp-multi-agent-session-id.md)
+
+注意：计划文档大体准确，但部分章节（特别是 SKILL 调用机制、`list_skills_v2` 的鉴权要求、dolphin DSL 的 `is_dolphin_mode` 约束）在实际构建中有经验性修正。
+**README 和 git commit history 是最终权威来源。**

--- a/examples/04-multi-agent-session-id/configs/.schema-notes.md
+++ b/examples/04-multi-agent-session-id/configs/.schema-notes.md
@@ -1,0 +1,82 @@
+# Schema notes (生成自 Task 3 schema 校准)
+
+## skills.tools[] 条目字段
+
+来源 schema：`swagger.AgentConfigSkillTool` / `skillvalobj.SkillTool`（两个定义一致）
+
+```json
+{
+  "tool_box_id": "<工具箱 ID>",
+  "tool_id": "<工具 ID>",
+  "tool_timeout": 300,
+  "intervention": false,
+  "intervention_confirmation_message": "",
+  "result_process_strategies": [],
+  "tool_input": []
+}
+```
+
+**必填字段（required）：** `tool_box_id`、`tool_id`
+
+`tool_input[]` 条目（`swagger.AgentConfigSkillToolInput`）：
+
+```json
+{
+  "input_name": "<参数名>",
+  "input_type": "string|file|object",
+  "enable": true,
+  "map_type": "fixedValue|var|model|auto",
+  "map_value": "<值>",
+  "input_desc": "",
+  "children": []
+}
+```
+
+## skills.skills[] 条目字段
+
+来源 schema：`swagger.AgentConfigSkillSkill`
+
+```json
+{
+  "skill_id": "<skill ID>"
+}
+```
+
+## skills.agents[] 条目字段（顺带记录）
+
+来源 schema：`swagger.AgentConfigSkillAgent`
+
+```json
+{
+  "agent_key": "<agent key>",
+  "agent_version": "<版本>",
+  "agent_timeout": 300,
+  "intervention": false,
+  "intervention_confirmation_message": "",
+  "agent_input": [],
+  "llm_config": {},
+  "data_source_config": {}
+}
+```
+
+**必填字段（required）：** `agent_key`
+
+## skills 顶层结构
+
+来源 schema：`swagger.AgentConfigSkills`
+
+```json
+{
+  "tools":  [...],
+  "agents": [...],
+  "skills": [...],
+  "mcps":   [...]
+}
+```
+
+## 来源
+
+- 现网 agent：`null`（扫描 19 个 agent，全部 `skills.tools = []`，`skills.skills = []`）
+- swagger schema：`swagger.AgentConfigSkillTool`、`skillvalobj.SkillTool`
+  来自 `http://10.110.223.168:13020/swagger/doc.json`（agent-factory pod，host `115.190.186.186`）
+- 日期：2026-04-28

--- a/examples/04-multi-agent-session-id/configs/base.config.json
+++ b/examples/04-multi-agent-session-id/configs/base.config.json
@@ -1,0 +1,818 @@
+{
+  "input": {
+    "fields": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "history",
+        "type": "object",
+        "desc": ""
+      },
+      {
+        "name": "header",
+        "type": "object",
+        "desc": ""
+      },
+      {
+        "name": "self_config",
+        "type": "object",
+        "desc": ""
+      }
+    ],
+    "rewrite": {
+      "enable": false,
+      "llm_config": {
+        "id": "",
+        "name": "test",
+        "model_type": "llm",
+        "temperature": 0.5,
+        "top_p": 0.5,
+        "top_k": 0,
+        "frequency_penalty": 0,
+        "presence_penalty": 0,
+        "max_tokens": 1000
+      }
+    },
+    "augment": {
+      "enable": false,
+      "data_source": {
+        "kg": []
+      }
+    }
+  },
+  "system_prompt": "#角色任务 \n     你是专业的备份智能Agent，专门负责处理备份方案推荐、备份方案执行。你的核心利用“备份业务知识网络（BKN）”提供语义逻辑，引导用户完成从备份方案推荐到备份方案执行的流程。\n\n# 备份业务知识网络\n    1. 备份运行知识网络\n       - id：backup_run_knowledge_network\n       - 用途：直接查询运行态生产资源、基础配置与应用配置。\n    2. 备份规则知识网络\n       - id：`backup_rule_knowledge_network`\n       - 用途：推荐候选方案、备份计划规则、备份窗口规则、副本保留规则、基础配置规则、应用配置规则。\n\n# 备份方案推荐\n1. 查询运行知识网络，定位唯一 `production_resource`；未命中或命中多条时只做澄清，不继续推荐。\n2. 基于生产资源补齐最小上下文：`app_object_type`、`data_type`、`industry_type`、`data_size_gb`、`target_rpo_minutes`、`target_rto_minutes`、`backup_window`。补齐顺序固定为：用户输入 > 运行事实 > `recommendation_policy` 默认值。\n3. 查询 `backup_rule_knowledge_network` 生成唯一备份方案：\n   - 路径：`recommendation_policy` -> `data_rule` -> `legal_rule` -> `rpo_rule` -> `app_rule` -> `backup_solution` -> `backup_plan` / `backup_window` / `retention_plan` -> `basic_config_rule` / `app_config_rule`\n   - 备份方案内容：基础配置、应用配置、备份策略\n   - 备份策略内容：备份窗口、备份计划、副本保留\n   - 最多输出 3个备份策略\n4. 输出方案：生产资源信息、备份方案",
+  "dolphin": "@DESC\n你是一个专业的灾备运维管理员，负责为指定生产资源推荐备份方案。当前优先完成 MySQL 备份策略推荐。\n@DESC\n\n$query -> user_query\n\n'''\n请在同一轮对话中，按顺序完成以下两件事：\n1. 查询并确认用户指定的生产资源信息。\n2. 若已确认唯一生产资源，则继续为该生产资源推荐备份方案。\n\n【工具集约束】\n当前 Agent 固定使用 `contextloader工具集_060`，仅允许调用以下工具，并且必须使用这些英文原始工具名：\n- `kn_search`\n- `query_object_instance`\n- `query_instance_subgraph`\n- `get_logic_properties_values`\n- `get_action_info`\n- 不要调用别名、中文名或其它未在列表中的工具。\n\n【知识网络定义】\n    1. `backup_runtime_knowledge_network`\n       - 用途：直接查询运行态生产资源、保护对象、已生效基础配置与应用配置。\n    2. `backup_rule_knowledge_network`\n       - 用途：推荐规则、候选方案、备份计划、备份窗口、副本保留、基础配置、应用配置。\n       - 禁止调用MCP 工具\n\n【输入模式】\n当前优先支持以下单语句输入：\n- `为生产资源xxx推荐备份方案`\n- `为生产资源xxx推荐备份策略`\n- `给生产资源xxx推荐备份方案`\n\n遇到上述输入时，必须把 `xxx` 作为最优先的生产资源标识线索，并在同一轮中串行完成“查资源 + 推荐方案”。\n\n【总原则】\n1. 同一轮输入里，先查生产资源，再推荐方案，顺序不能颠倒。\n2. 若生产资源未命中或命中多条，本轮只输出澄清问题，不继续推荐。\n3. 若命中唯一生产资源，必须在本轮继续完成推荐，不要要求用户再发起第二轮。\n4. 最终回答中不要暴露任何内部 ID、规则 ID、字段英文名、工具原始返回 JSON。\n5. 每次调用工具前，先用一句简短中文说明“为什么查这个对象”；每次调用后，用一句话总结拿到了什么。\n\n【工具与查询约束】\n1. 查询生产资源时，优先使用 `backup_runtime_knowledge_network`。\n2. 推荐方案时，优先使用 `backup_rule_knowledge_network`；若需要补充已生效运行态上下文，可继续使用 `backup_runtime_knowledge_network`。\n3. 所有对象实例查询必须保守、分步进行，`limit` 不要超过 `10`；生产资源定位建议不超过 `5`。\n4. SQL 视图查询只使用安全操作符：`==`、`!=`、`>`、`>=`、`<`、`<=`、`in`、`like`、`and`、`or`。\n5. 不要使用 `match`、`multi_match`、`regex`、`contain`、`prefix`、`range`、`out_range`。\n6. 不要一次性查询全部对象；只查询当前推理需要的对象。\n7. 若运行态基础配置命中 `storage_service_id=auto_select` 或 `storage_pool_id=auto_select`，直接按“自动选择”输出，不要虚构真实运行态资源。\n\n【contextloader工具集_060 请求参数要求】\n1. `kn_search`\n   - 必须传 `query`。\n   - 需要 schema 时显式传 `only_schema=true`。\n   - 如需调优召回参数，只能放在 `retrieval_config.concept_retrieval` 下，不要平铺未知字段。\n2. `query_object_instance`\n   - 必须传 `ot_id`、`condition`、`limit`。\n   - `condition` 中若使用常量过滤，`value_from` 与 `value` 必须同时出现，并且 `value_from` 固定为 `const`。\n   - 组合条件统一使用 `{\"operation\":\"and|or\",\"sub_conditions\":[...]}`；不要混用非法结构。\n   - 不要设置无必要的 `need_total`、`properties`、`sort`。\n3. `query_instance_subgraph`\n   - 必须传 `relation_type_paths` 数组。\n   - 每条路径都要显式给出 `start_ot_id`、`rt_id`、`direction`，方向不能臆造。\n   - 只有在已明确关系路径时才调用；关系方向应以 schema 或上游结果为准。\n4. `get_logic_properties_values`\n   - `_instance_identities` 必须直接取自上游 `query_object_instance` 或 `query_instance_subgraph` 返回的 `_instance_identity`，不可手写。\n   - 仅在确实需要逻辑属性时调用。\n5. `get_action_info`\n   - `at_id` 必须来自 schema 检索结果。\n   - `_instance_identity` 必须来自上游实例查询结果，不可臆造。\n   - 本 Agent 以推荐为主，除非确有 action 需求，否则不要调用。\n6. 所有工具调用都必须优先复用当前配置自动注入的 `kn_id`、`x-account-id`、`x-account-type`，不要在回答里暴露这些内部参数。\n\n【处理步骤】\n1. 从用户输入中提取最可能的生产资源标识。\n   - 若输入形如“为生产资源xxx推荐备份方案”，优先提取 `xxx`。\n   - 同时补充提取可能的 `production_resource_id`、`production_resource_name`、所属生产系统、别名等线索。\n2. 查询生产资源。\n   - 必须优先通过 `backup_runtime_knowledge_network` 的 `production_resource` 对象做保守查询。\n   - 若命中唯一生产资源，整理其关键信息：生产资源名称、资源类型、对象类型,不需要扩展查询父对象、关联对象。\n   - 若未命中任何生产资源，明确告诉用户当前未定位到目标生产资源，并追问准确的生产资源名称或 ID。\n   - 若命中多条生产资源，列出必要的区分信息并请用户确认，不要继续推荐。\n3. 补全推荐上下文。\n   - 基于已确认的生产资源，补充 `app_object_type`、`data_type`、`industry_type`、`data_size_gb`、`target_rpo_minutes`、`target_rto_minutes`、`backup_window`。\n   - 若能从运行知识网络中继续查到 `protected_object`、`backup_config`、`mysql_backup_config`，优先用它们补全上下文。\n   - 若生产资源已明确属于 MySQL 场景，按 `app_object_type=mysql` 处理；若无法判断应用类型，先做最小澄清，不要硬推。\n4. 查询推荐规则。\n   - 查询 `recommendation_policy`，优先匹配 `industry_type`；若未命中，则回退 `industry_type=未定义`。\n   - 查询 `data_rule`，用归一化后的 `data_type` 精确匹配，并提取 `data_level`。\n   - 查询 `legal_rule`，优先查 `industry_type=用户输入行业` 且 `data_type=归一化数据类型`；若无结果，再查 `industry_type=未定义`。\n   - 查询 `rpo_rule`，判断哪条规则覆盖目标 RPO 区间。\n   - 查询 `app_rule`，用 `app_object_type=mysql` 精确匹配。\n5. 查询候选方案。\n   - 查询 `backup_solution` 候选，筛出满足数据类型、法规、RPO、RTO 的方案。\n   - 严格命中不足时，可以补充相近备选，但最终最多输出 1 个最佳方案。\n6. 组装方案细节。\n   - 对最终选中的候选分别查询 `backup_plan`、`backup_window`、`retention_plan`，并按 `order_index` 组织。\n   - 查询 `basic_config_rule` 与 `app_config_rule`，手工解释 `condition`，同一 `config_category` 只输出一个最终结果。\n7. 排序并输出。\n   - 按法规满足度、数据匹配度、RPO 满足度、RTO 满足度、窗口匹配度、方案优先级进行排序。\n   - 输出 1 个最适合当前生产资源的方案。\n\n【MySQL 推荐特化规则】\n1. 当 `target_rpo_minutes <= 60` 时，优先考虑低 RPO 或实时日志类 MySQL 方案。\n2. 当 `target_rpo_minutes > 60` 时，优先考虑标准逻辑增量或每日全备类方案。\n3. 当 `data_size_gb >= 500` 时，优先提高通道数，并优先考虑大数据量配置规则。\n4. 当 `data_type=普通数据` 且 `industry_type=政府` 时，优先满足政务法规，再在满足法规前提下选择 RPO/RTO 更贴近的 MySQL 方案。\n\n【输出要求】\n1. 如果已成功定位唯一生产资源，并完成推荐，本轮输出结构固定为：\n   - `生产资源信息`\n   - `备份方案`\n   - `备份策略`\n   - `备份计划`\n   - `备份窗口`\n   - `副本保留`\n   - `基础配置`\n   - `应用配置`\n2. 输出内容必须是业务可读中文，不要输出对象 ID、规则 ID、字段英文名。\n3. 最多输出 1 个候选方案，不要凑数。\n4. 如果本轮未定位成功或无法唯一定位，只输出澄清问题，不输出推荐方案。\n5. 回答里要体现这是“先查询该生产资源信息，再为该生产资源推荐备份方案”的单轮处理结果。\n''' -> sys_q\n\n\n/explore/(history=true, system_prompt=$sys_q, tools=[\"kn_search\", \"query_object_instance\", \"query_instance_subgraph\", \"get_logic_properties_values\", \"get_action_info\"])\n\n【用户问题】\n```text\n$user_query\n```\n-> answer\n",
+  "is_dolphin_mode": 0,
+  "pre_dolphin": [
+    {
+      "key": "context_organize",
+      "name": "上下文组织模块",
+      "value": "\n{\"query\": \"用户的问题为: \"+$query} -> context\n",
+      "enabled": true,
+      "edited": false
+    }
+  ],
+  "post_dolphin": [],
+  "data_source": {
+    "kg": [],
+    "doc": [],
+    "metric": [],
+    "kn_entry": [],
+    "knowledge_network": [],
+    "advanced_config": {
+      "kg": null,
+      "doc": null
+    }
+  },
+  "skills": {
+    "tools": [
+      {
+        "tool_id": "51382ef3-b35b-44a6-8a53-c670cbf53f10",
+        "tool_box_id": "f182d75a-7fd2-421a-a8e0-7064d75e39af",
+        "tool_timeout": 300,
+        "tool_input": [
+          {
+            "input_name": "page",
+            "input_type": "integer",
+            "input_desc": "页码，从 1 开始",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": false
+          },
+          {
+            "input_name": "page_size",
+            "input_type": "integer",
+            "input_desc": "每页条数",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": false
+          },
+          {
+            "input_name": "all",
+            "input_type": "boolean",
+            "input_desc": "是否跨所有业务域返回（false=仅当前业务域）",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": false
+          },
+          {
+            "input_name": "X-Authorization",
+            "input_type": "string",
+            "input_desc": "OAuth Bearer token（格式：Bearer <token>）",
+            "map_type": "var",
+            "map_value": "header.authorization",
+            "enable": true
+          },
+          {
+            "input_name": "x-account-id",
+            "input_type": "string",
+            "input_desc": "调用方账户 ID（平台自动注入）",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": false
+          },
+          {
+            "input_name": "x-account-type",
+            "input_type": "string",
+            "input_desc": "调用方账户类型（平台自动注入）",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": false
+          },
+          {
+            "input_name": "x-business-domain",
+            "input_type": "string",
+            "input_desc": "业务域 ID（平台自动注入）",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": false
+          }
+        ],
+        "intervention": false,
+        "intervention_confirmation_message": "",
+        "result_process_strategies": null
+      },
+      {
+        "tool_id": "05275bb1-46e2-4727-9c6f-97d9ea0af94b",
+        "tool_box_id": "e521d454-4a0b-4dc9-8a28-d0986de1cef9",
+        "tool_timeout": 300,
+        "tool_input": [
+          {
+            "input_name": "x-account-id",
+            "input_type": "string",
+            "input_desc": "账户ID，用于内部服务调用时传递账户信息",
+            "map_type": "var",
+            "map_value": "header.x-account-id",
+            "enable": true
+          },
+          {
+            "input_name": "x-account-type",
+            "input_type": "string",
+            "input_desc": "账户类型：user(用户), app(应用), anonymous(匿名)",
+            "map_type": "var",
+            "map_value": "header.x-account-type",
+            "enable": true
+          },
+          {
+            "input_name": "response_format",
+            "input_type": "string",
+            "input_desc": "响应格式：json 或 toon，默认 json",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          },
+          {
+            "input_name": "additional_context",
+            "input_type": "string",
+            "input_desc": "可选。补充上下文，如 timezone、instant、step、对象属性等，帮助生成 dynamic_params。",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          },
+          {
+            "input_name": "kn_id",
+            "input_type": "string",
+            "input_desc": "知识网络ID。例 kn_medical",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          },
+          {
+            "input_name": "options",
+            "input_type": "object",
+            "input_desc": "【可选配置】控制接口行为的高级选项\n",
+            "children": [
+              {
+                "input_name": "return_debug",
+                "input_type": "boolean",
+                "input_desc": "是否返回 debug（dynamic_params、warnings 等）。默认 false",
+                "map_type": "auto",
+                "map_value": "",
+                "enable": false
+              }
+            ]
+          },
+          {
+            "input_name": "ot_id",
+            "input_type": "string",
+            "input_desc": "对象类ID。例 company、drug",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          },
+          {
+            "input_name": "properties",
+            "input_type": "array",
+            "input_desc": "逻辑属性名列表（metric/operator）。自动生成 dynamic_params 并查询。",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          },
+          {
+            "input_name": "query",
+            "input_type": "string",
+            "input_desc": "用户查询，需含时间（如\"最近一年\"）、统计维度、业务上下文，用于生成 dynamic_params",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          },
+          {
+            "input_name": "_instance_identities",
+            "input_type": "array",
+            "input_desc": "对象实例标识数组。**必须从上游提取，不可臆造。** 流程：先调 query_object_instance 或 query_instance_subgraph → 从每个对象的 _instance_identity 字段取值 → 按原顺序组成数组传入。",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          }
+        ],
+        "intervention": false,
+        "intervention_confirmation_message": "",
+        "result_process_strategies": null
+      },
+      {
+        "tool_id": "2fd071fa-a696-4fee-91e1-5b2dc190e88b",
+        "tool_box_id": "e521d454-4a0b-4dc9-8a28-d0986de1cef9",
+        "tool_timeout": 300,
+        "tool_input": [
+          {
+            "input_name": "x-account-id",
+            "input_type": "string",
+            "input_desc": "账户ID，用于内部服务调用时传递账户信息",
+            "map_type": "var",
+            "map_value": "header.x-account-id",
+            "enable": true
+          },
+          {
+            "input_name": "x-account-type",
+            "input_type": "string",
+            "input_desc": "账户类型：user(用户), app(应用), anonymous(匿名)",
+            "map_type": "var",
+            "map_value": "header.x-account-type",
+            "enable": true
+          },
+          {
+            "input_name": "response_format",
+            "input_type": "string",
+            "input_desc": "响应格式：json 或 toon，默认 json",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          },
+          {
+            "input_name": "kn_id",
+            "input_type": "string",
+            "input_desc": "业务知识网络ID",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          },
+          {
+            "input_name": "max_concepts",
+            "input_type": "integer",
+            "input_desc": "最大返回概念数量",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          },
+          {
+            "input_name": "query",
+            "input_type": "string",
+            "input_desc": "用户自然语言查询",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          },
+          {
+            "input_name": "rerank_action",
+            "input_type": "string",
+            "input_desc": "重排动作",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          },
+          {
+            "input_name": "search_scope",
+            "input_type": "object",
+            "input_desc": "【可选】搜索域配置\n",
+            "children": [
+              {
+                "input_name": "include_action_types",
+                "input_type": "boolean",
+                "input_desc": "是否包含行作类",
+                "map_type": "auto",
+                "map_value": "",
+                "enable": true
+              },
+              {
+                "input_name": "include_object_types",
+                "input_type": "boolean",
+                "input_desc": "是否包含对象类",
+                "map_type": "auto",
+                "map_value": "",
+                "enable": true
+              },
+              {
+                "input_name": "include_relation_types",
+                "input_type": "boolean",
+                "input_desc": "是否包含关系类",
+                "map_type": "auto",
+                "map_value": "",
+                "enable": true
+              },
+              {
+                "input_name": "concept_groups",
+                "input_type": "array",
+                "input_desc": "限定的概念分组",
+                "map_type": "auto",
+                "map_value": "",
+                "enable": false
+              }
+            ]
+          }
+        ],
+        "intervention": false,
+        "intervention_confirmation_message": "",
+        "result_process_strategies": null
+      },
+      {
+        "tool_id": "52b35175-cee3-41ea-91c0-1d70e8371f9c",
+        "tool_box_id": "e521d454-4a0b-4dc9-8a28-d0986de1cef9",
+        "tool_timeout": 300,
+        "tool_input": [
+          {
+            "input_name": "x-account-id",
+            "input_type": "string",
+            "input_desc": "账户ID，用于内部服务调用时传递账户信息",
+            "map_type": "var",
+            "map_value": "header.x-account-id",
+            "enable": true
+          },
+          {
+            "input_name": "x-account-type",
+            "input_type": "string",
+            "input_desc": "账户类型：user(用户), app(应用), anonymous(匿名)",
+            "map_type": "var",
+            "map_value": "header.x-account-type",
+            "enable": true
+          },
+          {
+            "input_name": "response_format",
+            "input_type": "string",
+            "input_desc": "响应格式：json 或 toon，默认 json",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          },
+          {
+            "input_name": "retrieval_config",
+            "input_type": "object",
+            "input_desc": "召回配置参数，用于控制不同类型的召回场景（概念召回、语义实例召回、属性过滤）。如果不提供，将使用系统默认配置。",
+            "children": [
+              {
+                "input_name": "concept_retrieval",
+                "input_type": "object",
+                "input_desc": "概念召回/概念流程配置参数（原最外层参数已收敛到此处）",
+                "children": [
+                  {
+                    "input_name": "schema_brief",
+                    "input_type": "boolean",
+                    "input_desc": "概念召回时是否返回精简schema。True仅返回必要字段（概念ID/名称/关系source&target），不返回大字段。",
+                    "map_type": "fixedValue",
+                    "map_value": "false",
+                    "enable": true
+                  },
+                  {
+                    "input_name": "top_k",
+                    "input_type": "integer",
+                    "input_desc": "概念召回返回最相关关系类型数量（对象类型会随关系类型自动过滤）。",
+                    "map_type": "auto",
+                    "map_value": "",
+                    "enable": true
+                  },
+                  {
+                    "input_name": "include_sample_data",
+                    "input_type": "boolean",
+                    "input_desc": "是否获取对象类型的样例数据。True会为每个召回对象类型获取一条样例数据。",
+                    "map_type": "auto",
+                    "map_value": "",
+                    "enable": false
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "input_name": "enable_rerank",
+            "input_type": "boolean",
+            "input_desc": "是否启用重排序。如果为true，则启用重排序。",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          },
+          {
+            "input_name": "kn_id",
+            "input_type": "string",
+            "input_desc": "指定的知识网络ID，必须传递",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          },
+          {
+            "input_name": "only_schema",
+            "input_type": "boolean",
+            "input_desc": "是否只召回概念（schema），不召回语义实例。如果为True，则只返回object_types、relation_types和action_types，不返回nodes。",
+            "map_type": "fixedValue",
+            "map_value": "true",
+            "enable": true
+          },
+          {
+            "input_name": "query",
+            "input_type": "string",
+            "input_desc": "用户查询问题或关键词，多个关键词之间用空格隔开",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          }
+        ],
+        "intervention": false,
+        "intervention_confirmation_message": "",
+        "result_process_strategies": null
+      },
+      {
+        "tool_id": "8542b7c2-f82a-4c1e-ab8c-83e2e73ccfdf",
+        "tool_box_id": "e521d454-4a0b-4dc9-8a28-d0986de1cef9",
+        "tool_timeout": 300,
+        "tool_input": [
+          {
+            "input_name": "x-account-id",
+            "input_type": "string",
+            "input_desc": "账户ID，用于内部服务调用时传递账户信息",
+            "map_type": "var",
+            "map_value": "header.x-account-id",
+            "enable": true
+          },
+          {
+            "input_name": "x-account-type",
+            "input_type": "string",
+            "input_desc": "账户类型：user(用户), app(应用), anonymous(匿名)",
+            "map_type": "var",
+            "map_value": "header.x-account-type",
+            "enable": true
+          },
+          {
+            "input_name": "kn_id",
+            "input_type": "string",
+            "input_desc": "业务知识网络ID",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          },
+          {
+            "input_name": "include_logic_params",
+            "input_type": "boolean",
+            "input_desc": "包含逻辑属性的计算参数，默认false，返回结果不包含逻辑属性的字段和值",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          },
+          {
+            "input_name": "response_format",
+            "input_type": "string",
+            "input_desc": "响应格式：json 或 toon，默认 json",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          },
+          {
+            "input_name": "relation_type_paths",
+            "input_type": "array",
+            "input_desc": "关系类路径集合,数组中可以包含多条不同的关系路径，系统会同时查询并返回所有路径的结果。每条路径必须符合严格的顺序和方向要求。",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          }
+        ],
+        "intervention": false,
+        "intervention_confirmation_message": "",
+        "result_process_strategies": null
+      },
+      {
+        "tool_id": "f46fa5df-f371-447f-8451-2d2f34cc78e9",
+        "tool_box_id": "e521d454-4a0b-4dc9-8a28-d0986de1cef9",
+        "tool_timeout": 300,
+        "tool_input": [
+          {
+            "input_name": "x-account-id",
+            "input_type": "string",
+            "input_desc": "账户ID，用于内部服务调用时传递账户信息",
+            "map_type": "var",
+            "map_value": "header.x-account-id",
+            "enable": true
+          },
+          {
+            "input_name": "x-account-type",
+            "input_type": "string",
+            "input_desc": "账户类型：user(用户), app(应用), anonymous(匿名)",
+            "map_type": "var",
+            "map_value": "header.x-account-type",
+            "enable": true
+          },
+          {
+            "input_name": "kn_id",
+            "input_type": "string",
+            "input_desc": "业务知识网络ID",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          },
+          {
+            "input_name": "ot_id",
+            "input_type": "string",
+            "input_desc": "对象类ID",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          },
+          {
+            "input_name": "include_logic_params",
+            "input_type": "boolean",
+            "input_desc": "包含逻辑属性的计算参数，默认false，返回结果不包含逻辑属性的字段和值",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          },
+          {
+            "input_name": "response_format",
+            "input_type": "string",
+            "input_desc": "响应格式：json 或 toon，默认 json",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          },
+          {
+            "input_name": "condition",
+            "input_type": "object",
+            "input_desc": "过滤条件结构，用于构建对象实例的查询筛选条件。\n\n**重要规则：**\n- `value_from` 和 `value` 必须同时使用，不能单独使用\n- `value_from` 当前仅支持 \"const\"（常量值）\n- 当使用 `value_from: \"const\"` 时，必须同时提供 `value` 字段\n",
+            "children": [
+              {
+                "input_name": "operation",
+                "input_type": "string",
+                "input_desc": "查询条件操作符。\n**注意：** 虽然这里列出了所有可能的操作符，但每个对象类实际支持的操作符列表以对象类定义中的 `condition_operations` 字段为准。\n",
+                "map_type": "auto",
+                "map_value": "",
+                "enable": true
+              },
+              {
+                "input_name": "sub_conditions",
+                "input_type": "array",
+                "input_desc": "子过滤条件数组，用于逻辑操作符(and/or)的组合查询",
+                "map_type": "auto",
+                "map_value": "",
+                "enable": true
+              },
+              {
+                "input_name": "value",
+                "input_type": "unknown",
+                "input_desc": "字段值，格式根据操作符类型而定：\n- 比较操作符: 单个值\n- 范围查询: [min, max]数组\n- 集合操作: 值数组\n- 向量搜索: 特定格式数组\n\n**必须与 `value_from: \"const\"` 同时使用**\n",
+                "map_type": "auto",
+                "map_value": "",
+                "enable": true
+              },
+              {
+                "input_name": "value_from",
+                "input_type": "string",
+                "input_desc": "字段值来源。\n\n**重要：** 当前仅支持 \"const\"（常量值），且必须与 `value` 字段同时使用\n",
+                "map_type": "auto",
+                "map_value": "",
+                "enable": false
+              },
+              {
+                "input_name": "field",
+                "input_type": "string",
+                "input_desc": "字段名称，也即对象类的属性名称",
+                "map_type": "auto",
+                "map_value": "",
+                "enable": true
+              }
+            ]
+          },
+          {
+            "input_name": "limit",
+            "input_type": "integer",
+            "input_desc": "返回的数量，默认值 10。范围 1-100",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          },
+          {
+            "input_name": "need_total",
+            "input_type": "boolean",
+            "input_desc": "是否需要总数，默认false",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": false
+          },
+          {
+            "input_name": "properties",
+            "input_type": "array",
+            "input_desc": "指定返回的对象属性字段列表，默认返回所有属性。",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": false
+          },
+          {
+            "input_name": "sort",
+            "input_type": "array",
+            "input_desc": "排序字段，默认使用 @timestamp排序，排序方向为 desc",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          }
+        ],
+        "intervention": false,
+        "intervention_confirmation_message": "",
+        "result_process_strategies": null
+      },
+      {
+        "tool_id": "00929c5f-3375-4ddc-9fb0-c48a24707f39",
+        "tool_box_id": "e521d454-4a0b-4dc9-8a28-d0986de1cef9",
+        "tool_timeout": 300,
+        "tool_input": [
+          {
+            "input_name": "x-account-id",
+            "input_type": "string",
+            "input_desc": "账户ID，用于内部服务调用时传递账户信息",
+            "map_type": "var",
+            "map_value": "header.x-account-id",
+            "enable": true
+          },
+          {
+            "input_name": "x-account-type",
+            "input_type": "string",
+            "input_desc": "账户类型：user(用户), app(应用), anonymous(匿名)",
+            "map_type": "var",
+            "map_value": "header.x-account-type",
+            "enable": true
+          },
+          {
+            "input_name": "at_id",
+            "input_type": "string",
+            "input_desc": "行动类ID（从 Schema 获取）",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          },
+          {
+            "input_name": "kn_id",
+            "input_type": "string",
+            "input_desc": "知识网络ID",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          },
+          {
+            "input_name": "_instance_identities",
+            "input_type": "array",
+            "input_desc": "对象实例标识列表（可选）。每个元素为主键键值对，必须从 query_object_instance 或 query_instance_subgraph 返回的 _instance_identity 字段提取，不可臆造。",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          }
+        ],
+        "intervention": false,
+        "intervention_confirmation_message": "",
+        "result_process_strategies": null
+      },
+      {
+        "tool_id": "74498bbd-2bdf-4db3-a4da-a90133c7fb65",
+        "tool_box_id": "e521d454-4a0b-4dc9-8a28-d0986de1cef9",
+        "tool_timeout": 300,
+        "tool_input": [
+          {
+            "input_name": "x-account-id",
+            "input_type": "string",
+            "input_desc": "账户 ID，用于内部服务调用时传递账户信息",
+            "map_type": "var",
+            "map_value": "header.x-account-id",
+            "enable": true
+          },
+          {
+            "input_name": "x-account-type",
+            "input_type": "string",
+            "input_desc": "账户类型：user（用户）、app（应用）、anonymous（匿名）",
+            "map_type": "var",
+            "map_value": "header.x-account-type",
+            "enable": true
+          },
+          {
+            "input_name": "response_format",
+            "input_type": "string",
+            "input_desc": "响应格式：json 或 toon，默认 json",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          },
+          {
+            "input_name": "object_type_id",
+            "input_type": "string",
+            "input_desc": "业务对象类型 ID（从 kn_search 或 kn_schema_search 返回的 concept_id 获取）。\n不传时为网络级召回；传入时为对象类级或实例级召回。\n",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          },
+          {
+            "input_name": "skill_query",
+            "input_type": "string",
+            "input_desc": "可选的 Skill 语义过滤词，对 skills 实例的 name/description 字段追加文本过滤。\nBKN 已构建向量时使用 knn，已构建全文索引时使用 match，否则使用 like。\n若 skills ObjectType 元数据获取失败则返回 502。\n",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          },
+          {
+            "input_name": "top_k",
+            "input_type": "integer",
+            "input_desc": "最多返回的 Skill 数量，默认 10，最大 20",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          },
+          {
+            "input_name": "instance_identities",
+            "input_type": "array",
+            "input_desc": "对象实例标识列表。每个元素为主键键值对，必须从 query_object_instance 或\nquery_instance_subgraph 返回的 _instance_identity 字段提取，不可臆造。\n传入时 object_type_id 也必须提供，否则返回 400。\n",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          },
+          {
+            "input_name": "kn_id",
+            "input_type": "string",
+            "input_desc": "知识网络 ID",
+            "map_type": "auto",
+            "map_value": "",
+            "enable": true
+          }
+        ],
+        "intervention": false,
+        "intervention_confirmation_message": "",
+        "result_process_strategies": null
+      }
+    ],
+    "agents": [],
+    "mcps": [],
+    "skills": null
+  },
+  "llms": [
+    {
+      "is_default": true,
+      "llm_config": {
+        "id": "2046436281143136256",
+        "name": "DeepSeek-V3.2",
+        "model_type": "llm",
+        "temperature": 1,
+        "top_p": 1,
+        "top_k": 1,
+        "frequency_penalty": 0,
+        "presence_penalty": 0,
+        "max_tokens": 8192
+      }
+    }
+  ],
+  "is_data_flow_set_enabled": 0,
+  "opening_remark_config": null,
+  "preset_questions": [],
+  "output": {
+    "variables": {
+      "answer_var": "answer",
+      "doc_retrieval_var": "doc_retrieval_res",
+      "graph_retrieval_var": "graph_retrieval_res",
+      "related_questions_var": "related_questions",
+      "other_vars": null,
+      "middle_output_vars": null
+    },
+    "default_format": "markdown"
+  },
+  "built_in_can_edit_fields": null,
+  "memory": {
+    "is_enabled": false
+  },
+  "related_question": {
+    "is_enabled": false
+  },
+  "plan_mode": null,
+  "conversation_history_config": {
+    "strategy": "count",
+    "count_params": {
+      "count_limit": 10
+    },
+    "time_window_params": null,
+    "token_limit_params": null
+  },
+  "metadata": {
+    "config_tpl_version": "v1",
+    "config_last_set_timestamp": 1777128586699486500
+  }
+}

--- a/examples/04-multi-agent-session-id/configs/father.config.template.jq
+++ b/examples/04-multi-agent-session-id/configs/father.config.template.jq
@@ -1,0 +1,65 @@
+# Inputs (--arg):
+#   $son1_key, $son1_version
+#   $son2_key, $son2_version
+#
+# Father uses Dolphin orchestration mode (is_dolphin_mode=1).
+# The dolphin DSL invokes son agents via @<agent_name>(input=value) syntax —
+# the platform's executor binds them based on skills.agents and routes the
+# named arguments into each son's input.fields.
+
+. as $base
+| $base
+| .is_dolphin_mode = 1
+| .dolphin = (
+    "@exp_son1(session_id=$session_id, query=$query) -> res_1\n" +
+    "@exp_son2(session_id=$session_id, query=$query) -> res_2\n" +
+    "{\"res_1\": $res_1, \"res_2\": $res_2} -> answer\n"
+  )
+| .pre_dolphin = []
+| .post_dolphin = []
+| .system_prompt = ""
+| .input.fields = (
+    (.input.fields // []) + [{
+      "name": "session_id",
+      "type": "string",
+      "desc": "外部传入的会话标识，需透传给子 agent"
+    }]
+  )
+| .skills = (
+    (.skills // {}) | .agents = [
+      {
+        "agent_key":                         $son1_key,
+        "agent_version":                     $son1_version,
+        "agent_timeout":                     300,
+        "intervention":                      false,
+        "intervention_confirmation_message": "",
+        "agent_input": [
+          { "enable": true, "map_type": "auto", "input_name": "session_id", "input_type": "string", "input_desc": "透传 session_id" },
+          { "enable": true, "map_type": "auto", "input_name": "query",      "input_type": "string", "input_desc": "透传 query" }
+        ],
+        "data_source_config": { "type": "self_configured", "specific_inherit": "" },
+        "llm_config":         { "type": "self_configured" }
+      },
+      {
+        "agent_key":                         $son2_key,
+        "agent_version":                     $son2_version,
+        "agent_timeout":                     300,
+        "intervention":                      false,
+        "intervention_confirmation_message": "",
+        "agent_input": [
+          { "enable": true, "map_type": "auto", "input_name": "session_id", "input_type": "string", "input_desc": "透传 session_id" },
+          { "enable": true, "map_type": "auto", "input_name": "query",      "input_type": "string", "input_desc": "透传 query" }
+        ],
+        "data_source_config": { "type": "self_configured", "specific_inherit": "" },
+        "llm_config":         { "type": "self_configured" }
+      }
+    ] | .tools = [] | .mcps = [] | .skills = []
+  )
+| .output.variables.answer_var = "answer"
+| .llms = (.llms // [] | map(.llm_config.max_tokens = 2048))
+| .conversation_history_config = {
+    "strategy":           "count",
+    "count_params":       { "count_limit": 1 },
+    "time_window_params": null,
+    "token_limit_params": null
+  }

--- a/examples/04-multi-agent-session-id/configs/son.config.template.jq
+++ b/examples/04-multi-agent-session-id/configs/son.config.template.jq
@@ -1,0 +1,76 @@
+# Inputs (--arg):
+#   $agent_name              e.g. "exp_son1"
+#   $skill_id                exp_session_echo skill_id
+#
+# Discovered platform behavior (validated 2026-04-28 against MySQL Recovery Agent):
+#  - is_dolphin_mode=0 + system_prompt-only path: executor synthesizes its own
+#    dolphin program and IGNORES pre_dolphin → no way to inject session_id.
+#  - is_dolphin_mode=1 + custom dolphin field: full control. Use /explore/ block
+#    with the registered list_skills_v2 / builtin_skill_load tools to find and
+#    invoke exp_session_echo skill.
+#  - skills.tools[0] (list_skills_v2) MUST configure X-Authorization tool_input
+#    with map_type:var → header.authorization, otherwise proxy returns 401
+#    "token is invalid".
+
+. as $base
+| $base
+| .is_dolphin_mode = 1
+| .dolphin = (
+    # Inject session_id (which is in input.fields but not visible to LLM via $query)
+    # into the prompt by string-concatenation.
+    "\"[input.session_id=\" + $session_id + \"] \" + $query -> q\n" +
+    "\n" +
+    "/explore/(history=true)\n" +
+    "你是 " + $agent_name + "。\n" +
+    "用户消息开头会带 [input.session_id=XXX] 的方括号块；XXX 就是当前 session_id。\n" +
+    "任务：\n" +
+    "1) 调用 list_skills_v2 工具拿到全部已发布 skill 列表。\n" +
+    "2) 找到 name 严格等于 exp_session_echo 的那条，拿它的 skill_id。\n" +
+    "3) 调用 builtin_skill_load(skill_id) 读取 SKILL.md。\n" +
+    "4) 严格按 SKILL.md 的指令输出第一行：[exp_session_echo] RECEIVED session_id=<XXX 的字面值> from " + $agent_name + "\n" +
+    "之后可以补一句确认。绝不修改 session_id 的值，绝不翻译。\n" +
+    "\n" +
+    "用户消息：\n" +
+    "$q\n" +
+    "-> answer\n"
+  )
+| .pre_dolphin = []
+| .post_dolphin = []
+| .system_prompt = ""
+| .input.fields = (
+    (.input.fields // []) + [{
+      "name": "session_id",
+      "type": "string",
+      "desc": "外部传入的会话标识，用于全链路透传校验"
+    }]
+  )
+| .skills = (
+    (.skills // {}) | .tools = [{
+      "tool_box_id":  "f182d75a-7fd2-421a-a8e0-7064d75e39af",
+      "tool_id":      "51382ef3-b35b-44a6-8a53-c670cbf53f10",
+      "tool_timeout": 300,
+      "tool_input": [
+        { "input_name": "page",              "input_type": "integer", "map_type": "auto", "map_value": "",                     "enable": false },
+        { "input_name": "page_size",         "input_type": "integer", "map_type": "auto", "map_value": "",                     "enable": false },
+        { "input_name": "all",               "input_type": "boolean", "map_type": "auto", "map_value": "",                     "enable": false },
+        { "input_name": "X-Authorization",   "input_type": "string",  "map_type": "var",  "map_value": "header.authorization", "enable": true,
+          "input_desc": "OAuth Bearer token, mapped from header.authorization to satisfy proxy auth" },
+        { "input_name": "x-account-id",      "input_type": "string",  "map_type": "auto", "map_value": "",                     "enable": false },
+        { "input_name": "x-account-type",    "input_type": "string",  "map_type": "auto", "map_value": "",                     "enable": false },
+        { "input_name": "x-business-domain", "input_type": "string",  "map_type": "auto", "map_value": "",                     "enable": false }
+      ],
+      "intervention":                      false,
+      "intervention_confirmation_message": "",
+      "result_process_strategies":         []
+    }]
+    | .agents = []
+    | .mcps   = []
+    | .skills = [{ "skill_id": $skill_id }]
+  )
+| .llms = (.llms // [] | map(.llm_config.max_tokens = 2048))
+| .conversation_history_config = {
+    "strategy":           "count",
+    "count_params":       { "count_limit": 1 },
+    "time_window_params": null,
+    "token_limit_params": null
+  }

--- a/examples/04-multi-agent-session-id/env.sample
+++ b/examples/04-multi-agent-session-id/env.sample
@@ -1,0 +1,10 @@
+# This example does NOT need a .env file. It runs entirely against an
+# already-authenticated kweaver CLI session and the platform's default LLM.
+#
+# Make sure these are true before running:
+#   - kweaver auth whoami            # works (logged in)
+#   - kweaver config show            # business_domain is set (default bd_public)
+#   - jq, bash, curl                 # available locally
+#
+# This file exists so the example matches the convention of other examples
+# in this folder. You do not need to copy it to .env.

--- a/examples/04-multi-agent-session-id/lib/cleanup.sh
+++ b/examples/04-multi-agent-session-id/lib/cleanup.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Demo teardown: unpublish + delete the three agents and the skill.
+# Only invoked when the user runs `./run.sh --cleanup`. Default run.sh
+# behavior never calls this.
+
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+cleanup_all() {
+  for name in "$EXP_FATHER_NAME" "$EXP_SON1_NAME" "$EXP_SON2_NAME"; do
+    local id
+    id=$(resolve_agent_id "$name")
+    if [ -n "$id" ]; then
+      log "unpublish + delete agent $name ($id)"
+      kweaver agent unpublish "$id" 2>&1 | tail -1 >&2 || true
+      kweaver agent delete "$id" -y 2>&1 | tail -1 >&2 || warn "delete agent $id failed"
+    else
+      log "agent $name not present, skip"
+    fi
+  done
+
+  local sid
+  sid=$(resolve_skill_id "$EXP_SKILL_NAME")
+  if [ -n "$sid" ]; then
+    log "delete skill $EXP_SKILL_NAME ($sid)"
+    kweaver skill delete "$sid" -y 2>&1 | tail -1 >&2 || warn "delete skill $sid failed"
+  else
+    log "skill $EXP_SKILL_NAME not present, skip"
+  fi
+}

--- a/examples/04-multi-agent-session-id/lib/common.sh
+++ b/examples/04-multi-agent-session-id/lib/common.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Shared variables and helpers for the exp multi-agent demo.
+
+set -euo pipefail
+
+EXP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EXP_SKILL_NAME="exp_session_echo"
+EXP_FATHER_NAME="exp_father"
+EXP_SON1_NAME="exp_son1"
+EXP_SON2_NAME="exp_son2"
+
+log()  { printf '\033[1;36m[exp]\033[0m %s\n' "$*" >&2; }
+warn() { printf '\033[1;33m[exp WARN]\033[0m %s\n' "$*" >&2; }
+fail() { printf '\033[1;31m[exp FAIL]\033[0m %s\n' "$*" >&2; exit 1; }
+
+# Resolve agent id by exact name (personal-list). Empty if not found.
+resolve_agent_id() {
+  local name="$1"
+  kweaver agent personal-list --name "$name" 2>/dev/null \
+    | jq -r --arg n "$name" '.[]? | select(.name == $n) | .id' \
+    | head -1
+}
+
+# Resolve skill id by exact name (skill list). Empty if not found.
+resolve_skill_id() {
+  local name="$1"
+  kweaver skill list --name "$name" 2>/dev/null \
+    | jq -r --arg n "$name" '.[]? | select(.name == $n) | .id' \
+    | head -1
+}
+
+# Get agent key + version. Writes to caller's AGENT_KEY / AGENT_VER.
+# After publish, version becomes "v1"; pre-publish .version is null and we
+# default to "v0".
+fetch_agent_keyver() {
+  local id="$1"
+  local raw
+  raw=$(kweaver agent get "$id" --verbose 2>/dev/null)
+  AGENT_KEY=$(echo "$raw" | jq -r '.key // .agent_key // empty')
+  AGENT_VER=$(echo "$raw" | jq -r '.version // "v1"')
+  [ -n "$AGENT_KEY" ] || fail "agent $id has no key in get response"
+}
+
+# Pull the platform default LLM id from base.config.json. The template
+# stores it at .llms[0].llm_config.id (NOT .llms[0].id).
+get_default_llm_id() {
+  jq -r '.llms[0].llm_config.id // empty' "$EXP_DIR/configs/base.config.json"
+}

--- a/examples/04-multi-agent-session-id/lib/render.sh
+++ b/examples/04-multi-agent-session-id/lib/render.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Render son/father agent configs from jq templates.
+
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+# Render a son config (exp_son1 or exp_son2).
+# Args:
+#   $1 agent_name (e.g. "exp_son1")
+#   $2 skill_id (exp_session_echo's UUID)
+#   $3 output file path
+render_son_config() {
+  local agent_name="$1" skill_id="$2" out="$3"
+  jq -f "$EXP_DIR/configs/son.config.template.jq" \
+     --arg agent_name "$agent_name" \
+     --arg skill_id   "$skill_id" \
+     "$EXP_DIR/configs/base.config.json" > "$out"
+}
+
+# Render father config.
+# Args:
+#   $1 son1_key, $2 son1_version
+#   $3 son2_key, $4 son2_version
+#   $5 output file path
+render_father_config() {
+  local son1_key="$1" son1_ver="$2" son2_key="$3" son2_ver="$4" out="$5"
+  jq -f "$EXP_DIR/configs/father.config.template.jq" \
+     --arg son1_key     "$son1_key" \
+     --arg son1_version "$son1_ver" \
+     --arg son2_key     "$son2_key" \
+     --arg son2_version "$son2_ver" \
+     "$EXP_DIR/configs/base.config.json" > "$out"
+}

--- a/examples/04-multi-agent-session-id/lib/verify.sh
+++ b/examples/04-multi-agent-session-id/lib/verify.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Two assertions verifying session_id propagation through father -> sons -> skill.
+#
+# Both assertions read from the chat completion response JSON. The response
+# stores each son's output under .message.content.final_answer.answer_type_other.
+# (We don't use `kweaver agent trace` because the platform's trace endpoint
+# is currently broken — returns 500.)
+
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+# Helper: extract son's textual answer from response JSON.
+# Args: $1 response file path, $2 res_1 or res_2
+_son_answer() {
+  local file="$1" key="$2"
+  jq -r --arg k "$key" '.message.content.final_answer.answer_type_other[$k].answer.answer // ""' "$file"
+}
+
+# Helper: extract son's input_message (which the platform builds from
+# father's @<son>(...) call args plus its system prompt).
+_son_input_message() {
+  local file="$1" key="$2"
+  jq -r --arg k "$key" '.message.content.final_answer.answer_type_other[$k].answer.input_message // ""' "$file"
+}
+
+# Assertion 1: each son's answer contains the literal echo line.
+assert_literal_in_answer() {
+  local resp_file="$1" sid="$2"
+  local missing=0
+  for entry in "res_1:$EXP_SON1_NAME" "res_2:$EXP_SON2_NAME"; do
+    local key="${entry%%:*}"
+    local son="${entry#*:}"
+    local ans
+    ans=$(_son_answer "$resp_file" "$key")
+    local expected="[exp_session_echo] RECEIVED session_id=$sid from $son"
+    if echo "$ans" | grep -qF "$expected"; then
+      log "assert_literal: $son — PASS"
+    else
+      warn "assert_literal: $son — FAIL"
+      warn "  expected substring: $expected"
+      warn "  actual answer (first 200 chars): ${ans:0:200}"
+      missing=1
+    fi
+  done
+  [ "$missing" = "0" ] && return 0 || return 1
+}
+
+# Assertion 2: each son's input_message starts with the [input.session_id=<sid>]
+# prefix injected by son's dolphin DSL — proving the platform really
+# routed father's input.session_id into the son call.
+assert_session_id_in_son_input() {
+  local resp_file="$1" sid="$2"
+  local missing=0
+  for entry in "res_1:$EXP_SON1_NAME" "res_2:$EXP_SON2_NAME"; do
+    local key="${entry%%:*}"
+    local son="${entry#*:}"
+    local input_msg
+    input_msg=$(_son_input_message "$resp_file" "$key")
+    local expected="[input.session_id=$sid]"
+    if echo "$input_msg" | grep -qF "$expected"; then
+      log "assert_propagation: $son input contains $expected — PASS"
+    else
+      warn "assert_propagation: $son — FAIL"
+      warn "  expected substring: $expected"
+      warn "  actual input_message (first 300 chars): ${input_msg:0:300}"
+      missing=1
+    fi
+  done
+  [ "$missing" = "0" ] && return 0 || return 1
+}

--- a/examples/04-multi-agent-session-id/run.sh
+++ b/examples/04-multi-agent-session-id/run.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# End-to-end demo: verify session_id propagates user -> exp_father ->
+# exp_son1 / exp_son2 -> exp_session_echo SKILL.
+#
+# Usage:
+#   ./run.sh                       # ensure artifacts + invoke + verify; keep on platform
+#   ./run.sh --session-id MY-XX    # override the session_id (default: DEMO-2026-XXXXXX)
+#   ./run.sh --cleanup             # unpublish + delete the three agents and the skill
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+source "$HERE/lib/common.sh"
+source "$HERE/lib/render.sh"
+source "$HERE/lib/verify.sh"
+source "$HERE/lib/cleanup.sh"
+
+SID=""
+DO_CLEANUP=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --session-id) SID="$2"; shift 2 ;;
+    --cleanup)    DO_CLEANUP=1; shift ;;
+    -h|--help)    sed -n '1,12p' "$0" >&2; exit 0 ;;
+    *) fail "unknown arg: $1" ;;
+  esac
+done
+
+if [ "$DO_CLEANUP" = "1" ]; then
+  cleanup_all
+  log "cleanup done"
+  exit 0
+fi
+
+[ -z "$SID" ] && SID="DEMO-2026-$(LC_ALL=C tr -dc 'A-Z0-9' </dev/urandom | head -c 6)"
+log "session_id=$SID"
+
+# === ensure SKILL ===
+SKILL_ID=$(resolve_skill_id "$EXP_SKILL_NAME")
+if [ -z "$SKILL_ID" ]; then
+  log "registering skill $EXP_SKILL_NAME"
+  resp=$(kweaver skill register --content-file "$HERE/skills/exp_session_echo/SKILL.md" 2>/dev/null)
+  SKILL_ID=$(echo "$resp" | jq -r '.id // empty')
+  [ -n "$SKILL_ID" ] || fail "skill register failed: $resp"
+  kweaver skill status "$SKILL_ID" published >/dev/null 2>&1 || fail "skill publish failed"
+fi
+log "skill_id=$SKILL_ID (reused if existed)"
+
+LLM_ID=$(get_default_llm_id)
+[ -n "$LLM_ID" ] || fail "no LLM id in base.config.json (.llms[0].llm_config.id is empty)"
+
+# === ensure son1 + son2 ===
+ensure_son() {
+  local name="$1" out_var="$2"
+  local id
+  id=$(resolve_agent_id "$name")
+  if [ -z "$id" ]; then
+    log "creating agent $name"
+    local render_path="/tmp/exp_${name}_render.json"
+    render_son_config "$name" "$SKILL_ID" "$render_path"
+    local resp
+    resp=$(kweaver agent create --name "$name" \
+            --profile "exp demo $name" \
+            --llm-id "$LLM_ID" \
+            --config "$render_path" 2>/dev/null)
+    id=$(echo "$resp" | jq -r '.id // empty')
+    [ -n "$id" ] || fail "create $name failed: $resp"
+    kweaver agent publish "$id" >/dev/null 2>&1 || fail "publish $name failed"
+  else
+    log "agent $name already exists ($id), reusing as-is"
+  fi
+  printf -v "$out_var" '%s' "$id"
+}
+
+SON1_ID=""
+SON2_ID=""
+ensure_son "$EXP_SON1_NAME" SON1_ID
+ensure_son "$EXP_SON2_NAME" SON2_ID
+
+fetch_agent_keyver "$SON1_ID"; SON1_KEY="$AGENT_KEY"; SON1_VER="$AGENT_VER"
+fetch_agent_keyver "$SON2_ID"; SON2_KEY="$AGENT_KEY"; SON2_VER="$AGENT_VER"
+log "son1: id=$SON1_ID key=$SON1_KEY ver=$SON1_VER"
+log "son2: id=$SON2_ID key=$SON2_KEY ver=$SON2_VER"
+
+# === ensure father ===
+FATHER_ID=$(resolve_agent_id "$EXP_FATHER_NAME")
+if [ -z "$FATHER_ID" ]; then
+  log "creating agent $EXP_FATHER_NAME"
+  render_father_config "$SON1_KEY" "$SON1_VER" "$SON2_KEY" "$SON2_VER" /tmp/exp_father_render.json
+  resp=$(kweaver agent create --name "$EXP_FATHER_NAME" \
+          --profile "exp demo father" \
+          --llm-id "$LLM_ID" \
+          --config /tmp/exp_father_render.json 2>/dev/null)
+  FATHER_ID=$(echo "$resp" | jq -r '.id // empty')
+  [ -n "$FATHER_ID" ] || fail "create father failed: $resp"
+  kweaver agent publish "$FATHER_ID" >/dev/null 2>&1 || fail "publish father failed"
+else
+  log "agent $EXP_FATHER_NAME already exists ($FATHER_ID), reusing as-is"
+fi
+fetch_agent_keyver "$FATHER_ID"; FATHER_KEY="$AGENT_KEY"; FATHER_VER="$AGENT_VER"
+log "father: id=$FATHER_ID key=$FATHER_KEY ver=$FATHER_VER"
+
+# === invoke father ===
+log "invoking father with custom_querys.session_id=$SID..."
+BODY=$(jq -nc \
+  --arg id  "$FATHER_ID" \
+  --arg key "$FATHER_KEY" \
+  --arg ver "$FATHER_VER" \
+  --arg sid "$SID" '{
+    agent_id:      $id,
+    agent_key:     $key,
+    agent_version: $ver,
+    query:         "请回显 session_id 验证透传",
+    custom_querys: { session_id: $sid },
+    stream:        false
+  }')
+
+RESP_FILE=/tmp/exp_run_resp.json
+START=$(date +%s)
+kweaver call -X POST "/api/agent-factory/v1/app/$FATHER_KEY/chat/completion" \
+  -H "content-type: application/json" -d "$BODY" 2>/dev/null > "$RESP_FILE"
+END=$(date +%s)
+
+CONV_ID=$(jq -r '.conversation_id // empty' "$RESP_FILE")
+if [ -z "$CONV_ID" ]; then
+  warn "no conversation_id in response (the call may have failed)"
+  log "first 600 bytes of response:"
+  head -c 600 "$RESP_FILE" >&2
+  fail "father call did not return a conversation_id"
+fi
+log "conversation_id=$CONV_ID, elapsed=$((END-START))s"
+
+log "son1 answer (first 200 chars):"
+jq -r '.message.content.final_answer.answer_type_other.res_1.answer.answer // "<missing>"' "$RESP_FILE" | head -c 200 >&2
+echo "" >&2
+log "son2 answer (first 200 chars):"
+jq -r '.message.content.final_answer.answer_type_other.res_2.answer.answer // "<missing>"' "$RESP_FILE" | head -c 200 >&2
+echo "" >&2
+
+# === verify ===
+ok=1
+assert_literal_in_answer        "$RESP_FILE" "$SID" || ok=0
+assert_session_id_in_son_input  "$RESP_FILE" "$SID" || ok=0
+
+if [ "$ok" = "1" ]; then
+  log "ALL ASSERTIONS PASSED. session_id=$SID, conversation=$CONV_ID"
+  log "(artifacts kept on platform; run with --cleanup to remove)"
+  exit 0
+else
+  fail "assertions failed; see warnings above. Response saved at $RESP_FILE"
+fi

--- a/examples/04-multi-agent-session-id/skills/exp_session_echo/SKILL.md
+++ b/examples/04-multi-agent-session-id/skills/exp_session_echo/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: exp_session_echo
+description: Echo back the agent input's session_id verbatim. Designed specifically for verifying session_id propagation through agent chains. Invoke this skill whenever a session_id is present in the agent input.
+---
+# exp_session_echo
+
+This skill exists to PROVE that the agent received `session_id` from its caller.
+
+You MUST do the following exactly:
+
+1. Read the agent input field named `session_id`.
+2. As the FIRST line of your response, output exactly:
+
+   `[exp_session_echo] RECEIVED session_id=<verbatim value of session_id> from <invoking agent name>`
+
+   Rules:
+   - `<verbatim value of session_id>` MUST be the exact string in input.session_id, with no quoting, no truncation, no paraphrasing.
+   - `<invoking agent name>` is the name of the agent that invoked this skill — use the literal agent name like `exp_son1` or `exp_son2`.
+3. If `session_id` is empty or missing, write `<MISSING>` in its place — do NOT fabricate.
+4. After the first line, you may briefly (one sentence) acknowledge the task, but the first line must be exactly as specified.
+
+Do NOT skip the first line. Do NOT reformat. Do NOT translate to Chinese.

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,7 @@ End-to-end examples that demonstrate core KWeaver capabilities using the CLI.
 | [01-db-to-qa](./01-db-to-qa/) | *A supply chain analyst stops waiting for DBA queries — her database answers questions directly in natural language* | MySQL → Knowledge Network → Semantic Search → Agent Chat |
 | [02-csv-to-kn](./02-csv-to-kn/) | *An HR director's scattered spreadsheets become a connected knowledge network she can traverse and query* | CSV → Knowledge Network → Subgraph Traversal → Agent Q&A |
 | [03-action-lifecycle](./03-action-lifecycle/) | *A procurement engineer arrives at 8am to find today's inventory alerts already generated — the knowledge network did it overnight* | CSV → Knowledge Network → Action → Schedule → Audit Log |
+| [04-multi-agent-session-id](./04-multi-agent-session-id/) | *A platform feature audit shows a custom input field travels intact through father → sons → SKILL, every step verifiable* | Dolphin orchestration → Multi-Agent → Custom Input → SKILL invocation |
 
 ## Getting Started
 
@@ -33,5 +34,9 @@ See the README inside each example for specific prerequisites.
 
 ## Cleanup
 
-Scripts delete all created resources (datasources, knowledge networks, actions) automatically
+Most scripts delete all created resources (datasources, knowledge networks, actions) automatically
 on exit — whether the run succeeds or fails.
+
+The exception is `04-multi-agent-session-id`, which keeps the SKILL and three demo agents on the
+platform after a successful run so they can be inspected in the Web UI; pass `--cleanup` to remove
+them.

--- a/examples/README.zh.md
+++ b/examples/README.zh.md
@@ -9,6 +9,7 @@
 | [01-db-to-qa](./01-db-to-qa/) | *供应链分析师不再等 DBA 写 SQL — 数据库直接用自然语言回答问题* | MySQL → 知识网络 → 语义搜索 → Agent 对话 |
 | [02-csv-to-kn](./02-csv-to-kn/) | *HR 总监散落的表格变成了可以遍历和查询的知识网络* | CSV → 知识网络 → 子图遍历 → Agent 问答 |
 | [03-action-lifecycle](./03-action-lifecycle/) | *采购员 8 点到岗，今天的库存预警清单已经生成好了 — 知识网络在夜里自己完成了* | CSV → 知识网络 → 行动 → 调度 → 审计日志 |
+| [04-multi-agent-session-id](./04-multi-agent-session-id/) | *平台特性巡检：自定义入参完整地从父 agent 透传到子 agent 再到 SKILL，每一步都有据可查* | Dolphin 编排 → 多 agent → 自定义入参 → SKILL 调用 |
 
 ## 快速开始
 
@@ -32,4 +33,6 @@ vim .env        # 填写 DB_HOST、DB_USER、DB_PASS 等
 
 ## 清理
 
-脚本退出时（无论成功或失败）自动删除所有创建的资源（数据源、知识网络、行动等）。
+多数脚本退出时（无论成功或失败）自动删除所有创建的资源（数据源、知识网络、行动等）。
+
+例外：`04-multi-agent-session-id` 在跑成功后**默认保留** SKILL 与三个 agent，便于在 Web UI 检视；传 `--cleanup` 即可清理。


### PR DESCRIPTION
Closes #326.

## Summary

- New `examples/04-multi-agent-session-id/` — end-to-end demo of `father → 2× son → SKILL` chain on the platform that verifies a custom `session_id` input field propagates intact at every hop.
- `examples/README.{md,zh.md}` table extended with a 4th row + a note that this example keeps artifacts after a successful run (others auto-cleanup).
- `.gitignore` amended: allow `examples/*/lib/` shell helpers (the global `lib/` rule, which hides Python venv directories, was also hiding our shell helpers).

## What it verifies

Two assertions on the chat-completion response, no platform `agent trace` call needed:

1. **assert_literal_in_answer** — each son's text contains `[exp_session_echo] RECEIVED session_id=<sid> from <son_name>`.
2. **assert_session_id_in_son_input** — each son's `input_message` (recorded by the executor) contains `[input.session_id=<sid>]`.

The second is the load-bearing one — it proves the platform itself routed the field, not the LLM echoing prompt content back.

## Architecture (verified working)

```
user
  │  POST /api/agent-factory/v1/app/<father_key>/chat/completion
  │  body: { ..., query, custom_querys: { session_id }, stream: false }
  ▼
exp_father  is_dolphin_mode=1
  dolphin DSL:
    @exp_son1(session_id=$session_id, query=$query) -> res_1
    @exp_son2(session_id=$session_id, query=$query) -> res_2
  ├─► exp_son1   (dolphin: prefix query → /explore/ → list_skills_v2 + builtin_skill_load)
  └─► exp_son2   (identical configuration)
```

## Test plan

- [x] `./run.sh --session-id MIGRATE-VERIFY` from new location: 38 s, all 4 assertions PASS, agents reused (not recreated).
- [ ] Reviewer pulls the branch, runs `./examples/04-multi-agent-session-id/run.sh` against their own kweaver session, sees `ALL ASSERTIONS PASSED`.
- [ ] Reviewer runs `./run.sh --cleanup` and confirms the SKILL + three agents are gone (and that `kweaver skill list --name exp_session_echo` returns empty).

## Notes for reviewers

The README documents six platform behaviors that are not in the current docs (e.g. `custom_querys` being the only routing path, `is_dolphin_mode=0` ignoring `pre_dolphin`, `list_skills_v2` needing `X-Authorization` map_type=var in `tool_input`). Some of these may deserve their own docs / fix issues — happy to spin off follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)