### PR TITLE
feat(bkn): SearchMetrics 概念分组检索；概念分组全部不存在时返回 404

### DIFF
--- a/adp/bkn/bkn-backend/server/logics/action_type/action_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/action_type/action_type_service.go
@@ -959,8 +959,9 @@ func (ats *actionTypeService) SearchActionTypes(ctx context.Context, query *inte
 				cgCnt, len(query.ConceptGroups))
 			logger.Errorf(errStr)
 
-			return response, rest.NewHTTPError(ctx, http.StatusInternalServerError,
-				berrors.BknBackend_ActionType_InternalError).
+			// 所有概念分组都不存在，报404，概念分组不存在
+			return response, rest.NewHTTPError(ctx, http.StatusNotFound,
+				berrors.BknBackend_ConceptGroup_ConceptGroupNotFound).
 				WithErrorDetails(errStr)
 		}
 

--- a/adp/bkn/bkn-backend/server/logics/metric/metric_service.go
+++ b/adp/bkn/bkn-backend/server/logics/metric/metric_service.go
@@ -41,6 +41,7 @@ type metricService struct {
 	appSetting *common.AppSetting
 	db         *sql.DB
 	ma         interfaces.MetricAccess
+	cga        interfaces.ConceptGroupAccess
 	ps         interfaces.PermissionService
 	uma        interfaces.UserMgmtService
 	vba        interfaces.VegaBackendAccess
@@ -54,6 +55,7 @@ func NewMetricService(appSetting *common.AppSetting) interfaces.MetricService {
 			appSetting: appSetting,
 			db:         logics.DB,
 			ma:         logics.MA,
+			cga:        logics.CGA,
 			ps:         permission.NewPermissionService(appSetting),
 			uma:        logics.UMA,
 			vba:        logics.VBA,
@@ -638,6 +640,8 @@ func (ms *metricService) SearchMetrics(ctx context.Context, query *interfaces.Co
 				}
 				result, err := ms.mfa.GetVector(ctx, dftModel, []string{word})
 				if err != nil {
+					logger.Errorf("GetVector error: %s", err.Error())
+					span.SetStatus(codes.Error, "vector embedding failed")
 					return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
 						berrors.BknBackend_Metric_InternalError).
 						WithErrorDetails(err.Error())
@@ -645,56 +649,118 @@ func (ms *metricService) SearchMetrics(ctx context.Context, query *interfaces.Co
 				return result, nil
 			})
 		if err != nil {
-			return response, rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_InvalidParameter_Condition).
-				WithErrorDetails(fmt.Sprintf("failed to convert condition to filter condition: %s", err.Error()))
+			return response, rest.NewHTTPError(ctx, http.StatusBadRequest,
+				berrors.BknBackend_InvalidParameter_Condition).
+				WithErrorDetails(fmt.Sprintf("failed to convert condition to filter condition, %s", err.Error()))
+		}
+	}
+
+	otIDMap := map[string]bool{}
+	var otIDs []string
+	if len(query.ConceptGroups) > 0 {
+		cgCnt, err := ms.cga.GetConceptGroupsTotal(ctx, interfaces.ConceptGroupsQueryParams{
+			KNID:   query.KNID,
+			Branch: query.Branch,
+			CGIDs:  query.ConceptGroups,
+		})
+		if err != nil {
+			logger.Errorf("GetConceptGroupsTotal in knowledge network[%s] error: %s", query.KNID, err.Error())
+			span.SetStatus(codes.Error, fmt.Sprintf("GetConceptGroupsTotal in knowledge network[%s], error: %v", query.KNID, err))
+
+			return response, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+				berrors.BknBackend_Metric_InternalError).WithErrorDetails(err.Error())
+		}
+		if cgCnt == 0 {
+			errStr := fmt.Sprintf("all concept group not found, expect concept group nums is [%d], actual concept group num is [%d]",
+				cgCnt, len(query.ConceptGroups))
+			logger.Errorf(errStr)
+
+			// 所有概念分组都不存在，报404，概念分组不存在
+			return response, rest.NewHTTPError(ctx, http.StatusNotFound,
+				berrors.BknBackend_ConceptGroup_ConceptGroupNotFound).
+				WithErrorDetails(errStr)
+		}
+
+		otIDArr, err := ms.cga.GetConceptIDsByConceptGroupIDs(ctx, query.KNID,
+			query.Branch, query.ConceptGroups, interfaces.MODULE_TYPE_OBJECT_TYPE)
+		if err != nil {
+			errStr := fmt.Sprintf("GetConceptIDsByConceptGroupIDs failed, kn_id:[%s],branch:[%s],cg_ids:[%v], error: %v",
+				query.KNID, query.Branch, query.ConceptGroups, err)
+			logger.Errorf(errStr)
+			span.SetStatus(codes.Error, errStr)
+
+			return response, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+				berrors.BknBackend_Metric_InternalError).WithErrorDetails(err.Error())
+		}
+
+		if len(otIDArr) == 0 {
+			return response, nil
+		}
+
+		for _, otID := range otIDArr {
+			if !otIDMap[otID] {
+				otIDMap[otID] = true
+				otIDs = append(otIDs, otID)
+			}
 		}
 	}
 
 	if query.NeedTotal {
-		params := &interfaces.ResourceDataQueryParams{
-			FilterCondition: filterCondition,
-			Offset:          0,
-			Limit:           1,
-			NeedTotal:       true,
+		if len(otIDMap) == 0 {
+			total, err := ms.getMetricDatasetTotal(ctx, filterCondition)
+			if err != nil {
+				return response, err
+			}
+			response.TotalCount = total
+		} else {
+			total, err := ms.getTotalWithLargeScopeRefs(ctx, filterCondition, otIDs)
+			if err != nil {
+				return response, err
+			}
+			response.TotalCount = total
 		}
-		datasetResp, err := ms.vba.QueryResourceData(ctx, interfaces.BKN_DATASET_ID, params)
-		if err != nil {
-			return response, rest.NewHTTPError(ctx, http.StatusInternalServerError, berrors.BknBackend_Metric_InternalError).WithErrorDetails(err.Error())
-		}
-		response.TotalCount = datasetResp.TotalCount
 	}
 
-	offset := 0
 	limit := query.Limit
 	if limit == 0 {
 		limit = interfaces.SearchAfter_Limit
 	}
 
-	var entries []*interfaces.MetricDefinition
+	entries := make([]*interfaces.MetricDefinition, 0)
 
 	for {
 		params := &interfaces.ResourceDataQueryParams{
 			FilterCondition: filterCondition,
-			Offset:          offset,
 			Limit:           limit,
 			NeedTotal:       false,
+			SearchAfter:     query.SearchAfter,
 			Sort:            query.Sort,
 		}
 		datasetResp, err := ms.vba.QueryResourceData(ctx, interfaces.BKN_DATASET_ID, params)
 		if err != nil {
-			return response, rest.NewHTTPError(ctx, http.StatusInternalServerError, berrors.BknBackend_Metric_InternalError).WithErrorDetails(err.Error())
+			logger.Errorf("metric concept search query QueryResourceData error: %s", err.Error())
+			span.SetStatus(codes.Error, "metric concept search query failed")
+			return response, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+				berrors.BknBackend_Metric_InternalError).
+				WithErrorDetails(err.Error())
 		}
+
 		if len(datasetResp.Entries) == 0 {
 			break
 		}
+
 		for _, entry := range datasetResp.Entries {
 			jsonByte, err := json.Marshal(entry)
 			if err != nil {
-				return response, rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_InternalError_MarshalDataFailed).WithErrorDetails(err.Error())
+				return response, rest.NewHTTPError(ctx, http.StatusBadRequest,
+					berrors.BknBackend_InternalError_MarshalDataFailed).
+					WithErrorDetails(fmt.Sprintf("failed to Marshal dataset entry, %s", err.Error()))
 			}
 			var m interfaces.MetricDefinition
 			if err := json.Unmarshal(jsonByte, &m); err != nil {
-				return response, rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_InternalError_UnMarshalDataFailed).WithErrorDetails(err.Error())
+				return response, rest.NewHTTPError(ctx, http.StatusBadRequest,
+					berrors.BknBackend_InternalError_UnMarshalDataFailed).
+					WithErrorDetails(fmt.Sprintf("failed to Unmarshal dataset entry to MetricDefinition, %s", err.Error()))
 			}
 			if scoreVal, ok := entry["_score"]; ok {
 				if scoreFloat, ok := scoreVal.(float64); ok {
@@ -703,22 +769,95 @@ func (ms *metricService) SearchMetrics(ctx context.Context, query *interfaces.Co
 				}
 			}
 			m.Vector = nil
-			entries = append(entries, &m)
-			if query.Limit > 0 && len(entries) >= query.Limit {
-				break
+
+			if len(otIDMap) == 0 || otIDMap[m.ScopeRef] {
+				entries = append(entries, &m)
+				if query.Limit > 0 && len(entries) >= query.Limit {
+					break
+				}
 			}
 		}
+
 		query.SearchAfter = datasetResp.SearchAfter
+
 		if (query.Limit > 0 && len(entries) >= query.Limit) || len(datasetResp.Entries) < limit {
 			break
 		}
-		offset += limit
 	}
 
 	response.Entries = entries
 	response.SearchAfter = query.SearchAfter
 	span.SetStatus(codes.Ok, "")
 	return response, nil
+}
+
+// getMetricDatasetTotal returns total document count for the metric concept query (same pattern as object_type.GetTotal).
+func (ms *metricService) getMetricDatasetTotal(ctx context.Context, filterCondition map[string]any) (int64, error) {
+	ctx, span := ar_trace.Tracer.Start(ctx, "logic layer: search metric concept total")
+	defer span.End()
+
+	params := &interfaces.ResourceDataQueryParams{
+		FilterCondition: filterCondition,
+		Offset:          0,
+		Limit:           1,
+		NeedTotal:       true,
+	}
+	datasetResp, err := ms.vba.QueryResourceData(ctx, interfaces.BKN_DATASET_ID, params)
+	if err != nil {
+		span.SetStatus(codes.Error, "Search total metric documents count failed")
+		return 0, rest.NewHTTPError(ctx, http.StatusInternalServerError, berrors.BknBackend_Metric_InternalError).
+			WithErrorDetails(err.Error())
+	}
+
+	span.SetStatus(codes.Ok, "")
+	if datasetResp == nil {
+		return 0, nil
+	}
+	return datasetResp.TotalCount, nil
+}
+
+func (ms *metricService) getTotalWithScopeRefs(ctx context.Context, filterCondition map[string]any, scopeRefs []string) (int64, error) {
+	srCondition := map[string]any{
+		"field":      "scope_ref",
+		"operation":  "in",
+		"value":      scopeRefs,
+		"value_from": "const",
+	}
+
+	var combinedCondition map[string]any
+	if filterCondition == nil {
+		combinedCondition = srCondition
+	} else {
+		combinedCondition = map[string]any{
+			"operation": "and",
+			"sub_conditions": []map[string]any{
+				filterCondition,
+				srCondition,
+			},
+		}
+	}
+
+	return ms.getMetricDatasetTotal(ctx, combinedCondition)
+}
+
+func (ms *metricService) getTotalWithLargeScopeRefs(ctx context.Context, filterCondition map[string]any, otIDs []string) (int64, error) {
+	total := int64(0)
+	for i := 0; i < len(otIDs); i += interfaces.GET_TOTAL_CONCEPTID_BATCH_SIZE {
+		end := i + interfaces.GET_TOTAL_CONCEPTID_BATCH_SIZE
+		if end > len(otIDs) {
+			end = len(otIDs)
+		}
+
+		batchIDs := otIDs[i:end]
+		batchTotal, err := ms.getTotalWithScopeRefs(ctx, filterCondition, batchIDs)
+		if err != nil {
+			return 0, err
+		}
+
+		total += batchTotal
+	}
+
+	return total, nil
 }
 
 func (ms *metricService) validateMetricStrictExternalDeps(ctx context.Context, tx *sql.Tx, metric *interfaces.MetricDefinition) error {

--- a/adp/bkn/bkn-backend/server/logics/metric/metric_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/metric/metric_service_test.go
@@ -16,6 +16,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"bkn-backend/common"
+	cond "bkn-backend/common/condition"
 	berrors "bkn-backend/errors"
 	"bkn-backend/interfaces"
 	bmock "bkn-backend/interfaces/mock"
@@ -382,23 +383,190 @@ func Test_metricService_DeleteMetricsByIDs(t *testing.T) {
 }
 
 func Test_metricService_SearchMetrics(t *testing.T) {
-	Convey("Test SearchMetrics permission\n", t, func() {
+	Convey("Test SearchMetrics\n", t, func() {
 		ctx := context.Background()
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
 
+		appSetting := &common.AppSetting{
+			ServerSetting: common.ServerSetting{
+				DefaultSmallModelEnabled: false,
+			},
+		}
 		ps := bmock.NewMockPermissionService(mockCtrl)
+		vba := bmock.NewMockVegaBackendAccess(mockCtrl)
+		cga := bmock.NewMockConceptGroupAccess(mockCtrl)
+
 		service := &metricService{
-			appSetting: &common.AppSetting{},
+			appSetting: appSetting,
 			ps:         ps,
+			vba:        vba,
+			cga:        cga,
 		}
 
-		q := &interfaces.ConceptsQuery{KNID: "kn1"}
-		ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(rest.NewHTTPError(ctx, 403, berrors.BknBackend_InternalError_CheckPermissionFailed))
+		Convey("permission denied\n", func() {
+			q := &interfaces.ConceptsQuery{KNID: "kn1"}
+			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(rest.NewHTTPError(ctx, 403, berrors.BknBackend_InternalError_CheckPermissionFailed))
 
-		res, err := service.SearchMetrics(ctx, q)
-		So(err, ShouldNotBeNil)
-		So(res.Type, ShouldEqual, interfaces.MODULE_TYPE_METRIC)
+			res, err := service.SearchMetrics(ctx, q)
+			So(err, ShouldNotBeNil)
+			So(res.Type, ShouldEqual, interfaces.MODULE_TYPE_METRIC)
+		})
+
+		Convey("Success without concept groups\n", func() {
+			query := &interfaces.ConceptsQuery{
+				KNID:   "kn1",
+				Branch: interfaces.MAIN_BRANCH,
+				Limit:  10,
+			}
+
+			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			datasetResp := &interfaces.DatasetQueryResponse{
+				Entries: []map[string]any{},
+			}
+			vba.EXPECT().QueryResourceData(gomock.Any(), gomock.Any(), gomock.Any()).Return(datasetResp, nil)
+
+			result, err := service.SearchMetrics(ctx, query)
+			So(err, ShouldBeNil)
+			So(result.Entries, ShouldNotBeNil)
+			So(len(result.Entries), ShouldEqual, 0)
+		})
+
+		Convey("Success with concept groups\n", func() {
+			query := &interfaces.ConceptsQuery{
+				KNID:          "kn1",
+				Branch:        interfaces.MAIN_BRANCH,
+				Limit:         10,
+				ConceptGroups: []string{"cg1"},
+				ActualCondition: &cond.CondCfg{
+					Operation: "and",
+					SubConds: []*cond.CondCfg{
+						{
+							Field:     "name",
+							Operation: cond.OperationEq,
+							ValueOptCfg: cond.ValueOptCfg{
+								ValueFrom: "const",
+								Value:     "m1",
+							},
+						},
+					},
+				},
+			}
+
+			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
+			cga.EXPECT().GetConceptIDsByConceptGroupIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{"ot1"}, nil)
+			datasetResp := &interfaces.DatasetQueryResponse{
+				Entries: []map[string]any{},
+			}
+			vba.EXPECT().QueryResourceData(gomock.Any(), gomock.Any(), gomock.Any()).Return(datasetResp, nil)
+
+			result, err := service.SearchMetrics(ctx, query)
+			So(err, ShouldBeNil)
+			So(result.Entries, ShouldNotBeNil)
+		})
+
+		Convey("Failed when concept groups not found\n", func() {
+			query := &interfaces.ConceptsQuery{
+				KNID:          "kn1",
+				Branch:        interfaces.MAIN_BRANCH,
+				NeedTotal:     false,
+				Limit:         10,
+				ConceptGroups: []string{"cg1"},
+			}
+
+			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(0, nil)
+
+			result, err := service.SearchMetrics(ctx, query)
+			So(err, ShouldNotBeNil)
+			So(len(result.Entries), ShouldEqual, 0)
+		})
+
+		Convey("Success with concept groups returning empty otIDs\n", func() {
+			query := &interfaces.ConceptsQuery{
+				KNID:          "kn1",
+				Branch:        interfaces.MAIN_BRANCH,
+				Limit:         10,
+				ConceptGroups: []string{"cg1"},
+			}
+
+			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
+			cga.EXPECT().GetConceptIDsByConceptGroupIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil)
+
+			result, err := service.SearchMetrics(ctx, query)
+			So(err, ShouldBeNil)
+			So(len(result.Entries), ShouldEqual, 0)
+		})
+
+		Convey("filters entries by scope_ref when concept groups set\n", func() {
+			query := &interfaces.ConceptsQuery{
+				KNID:          "kn1",
+				Branch:        interfaces.MAIN_BRANCH,
+				Limit:         10,
+				ConceptGroups: []string{"cg1"},
+			}
+
+			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
+			cga.EXPECT().GetConceptIDsByConceptGroupIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{"ot_keep"}, nil)
+
+			inDoc := map[string]any{
+				"id":         "metric_drop",
+				"kn_id":      "kn1",
+				"branch":     interfaces.MAIN_BRANCH,
+				"module_type": interfaces.MODULE_TYPE_METRIC,
+				"name":       "x",
+				"scope_ref":  "ot_other",
+			}
+			keepDoc := map[string]any{
+				"id":          "metric_keep",
+				"kn_id":       "kn1",
+				"branch":      interfaces.MAIN_BRANCH,
+				"module_type": interfaces.MODULE_TYPE_METRIC,
+				"name":        "y",
+				"scope_ref":   "ot_keep",
+			}
+
+			datasetResp := &interfaces.DatasetQueryResponse{
+				Entries: []map[string]any{inDoc, keepDoc},
+			}
+			vba.EXPECT().QueryResourceData(gomock.Any(), gomock.Any(), gomock.Any()).Return(datasetResp, nil)
+
+			result, err := service.SearchMetrics(ctx, query)
+			So(err, ShouldBeNil)
+			So(len(result.Entries), ShouldEqual, 1)
+			So(result.Entries[0].ID, ShouldEqual, "metric_keep")
+			So(result.Entries[0].ScopeRef, ShouldEqual, "ot_keep")
+		})
+
+		Convey("NeedTotal with concept groups uses batched scope_ref total\n", func() {
+			query := &interfaces.ConceptsQuery{
+				KNID:          "kn1",
+				Branch:        interfaces.MAIN_BRANCH,
+				NeedTotal:     true,
+				Limit:         5,
+				ConceptGroups: []string{"cg1"},
+			}
+
+			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
+			cga.EXPECT().GetConceptIDsByConceptGroupIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{"ot1"}, nil)
+
+			totalResp := &interfaces.DatasetQueryResponse{
+				TotalCount: 7,
+				Entries:    []map[string]any{},
+			}
+			vba.EXPECT().QueryResourceData(gomock.Any(), gomock.Any(), gomock.Any()).Return(totalResp, nil)
+			emptyPage := &interfaces.DatasetQueryResponse{Entries: []map[string]any{}}
+			vba.EXPECT().QueryResourceData(gomock.Any(), gomock.Any(), gomock.Any()).Return(emptyPage, nil)
+
+			result, err := service.SearchMetrics(ctx, query)
+			So(err, ShouldBeNil)
+			So(result.TotalCount, ShouldEqual, 7)
+			So(len(result.Entries), ShouldEqual, 0)
+		})
 	})
 }

--- a/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
@@ -1583,8 +1583,9 @@ func (ots *objectTypeService) SearchObjectTypes(ctx context.Context,
 				cgCnt, len(query.ConceptGroups))
 			logger.Errorf(errStr)
 
-			return response, rest.NewHTTPError(ctx, http.StatusInternalServerError,
-				berrors.BknBackend_ObjectType_InternalError).
+			// 所有概念分组都不存在，报404，概念分组不存在
+			return response, rest.NewHTTPError(ctx, http.StatusNotFound,
+				berrors.BknBackend_ConceptGroup_ConceptGroupNotFound).
 				WithErrorDetails(errStr)
 		}
 

--- a/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
@@ -945,8 +945,9 @@ func (rts *relationTypeService) SearchRelationTypes(ctx context.Context,
 				cgCnt, len(query.ConceptGroups))
 			logger.Errorf(errStr)
 
-			return response, rest.NewHTTPError(ctx, http.StatusInternalServerError,
-				berrors.BknBackend_RelationType_InternalError).
+			// 所有概念分组都不存在，报404，概念分组不存在
+			return response, rest.NewHTTPError(ctx, http.StatusNotFound,
+				berrors.BknBackend_ConceptGroup_ConceptGroupNotFound).
 				WithErrorDetails(errStr)
 		}
 		// 在当前业务知识网络下查找属于请求的分组范围内的关系类ID


### PR DESCRIPTION
# Pull Request

## What Changed

- SearchMetrics 接入 `ConceptGroupAccess`：按请求中的 `ConceptGroups` 解析关联 ObjectType（scope），过滤返回的指标条目，并在 `NeedTotal` 时按同一 scope 统计总数；未指定概念分组时保持原先基于数据集条件的查询与统计路径。
- 当请求中的概念分组在该知识网络分支下全部不存在时，返回 HTTP 404（`BknBackend_ConceptGroup_ConceptGroupNotFound`），替代原先易误判为 500 的行为。
- 指标语义检索分页与 Vega `QueryResourceData` 对齐，使用 `SearchAfter` 迭代；抽取 `getMetricDatasetTotal`、`getTotalWithLargeScopeRefs` 用于总数计算。
- GetVector 等失败路径补充日志与 OpenTelemetry span 状态；若干错误详情文案微调。
- `action_type` / `object_type` / `relation_type` 服务中与指标检索相关的少量对齐修改。

---

## Why

- Related Issue: #317
- Background: 指标概念检索需要按概念分组限定结果范围；且「用户传入的概念分组 ID 全部无效」应表现为资源不存在（404），而非服务器内部错误（500）。

---

## How

- Key implementation points:
  - `metricService` 注入 `cga`（`ConceptGroupAccess`），在 `SearchMetrics` 中调用 `GetConceptGroupsTotal`、`GetConceptIDsByConceptGroupIDs`（ObjectType 模块）得到允许的 `ScopeRef` 集合并去重。
  - `cgCnt == 0` 且请求携带概念分组时返回 404；解析出的 OT ID 为空时返回空列表。
  - 遍历时仅保留 `ScopeRef` 落在允许集合内的指标（或未启用概念分组过滤时保留全部命中）。
- Breaking changes: 无数据库或对外 API 字段变更；若调用方错误依赖「概念分组全不存在时仍为 5xx」，需改为处理 404。

---

## Testing

- [x] Unit tests：`metric_service_test.go` 新增/扩展用例覆盖概念分组与总数分支
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes: 可在 `adp/bkn/bkn-backend` 下对 `metric` 包执行 `go test`。

---

## Risk & Rollback

- Potential risks: 概念分组与数据集过滤组合下的边界场景建议在测试环境回归。
- Rollback plan: 回退本 PR 对应提交即可恢复旧行为。

---

## Additional Notes

- 变更文件：`metric_service.go`、`metric_service_test.go`，以及 `action_type_service.go`、`object_type_service.go`、`relation_type_service.go` 各少量行。
