### PR TITLE
feat(connector-type): 添加连接器类型不匹配错误处理

### DIFF
--- a/adp/docs/api/vega/vega-backend-api/connector-type.yaml
+++ b/adp/docs/api/vega/vega-backend-api/connector-type.yaml
@@ -1,0 +1,552 @@
+---
+openapi: 3.1.1
+info:
+  title: ConnectorType
+  description: |
+    Vega Backend 连接器类型（ConnectorType）相关 API。
+
+    连接器类型描述一个可注册的数据源驱动（如 mysql、postgresql、opensearch 等），
+    提供其元信息、字段配置（field_config，兼容 JSON Schema properties）以及
+    启用状态。Mode 区分本地（local，进程内运行）与远程（remote，独立服务通过
+    HTTP 调用），Category 区分数据源大类。
+  version: 0.1.0
+servers:
+  - url: /api/vega-backend/v1
+paths:
+  /api/vega-backend/v1/connector-types:
+    get:
+      summary: 获取连接器类型列表
+      description: 分页获取已注册的连接器类型；支持按 tag、mode、category、enabled 过滤。
+      parameters:
+        - name: tag
+          description: 按标签精确过滤，默认为空
+          in: query
+          schema:
+            type: string
+        - name: mode
+          description: 按运行模式过滤
+          in: query
+          schema:
+            type: string
+            enum:
+              - local
+              - remote
+        - name: category
+          description: 按分类过滤
+          in: query
+          schema:
+            type: string
+            enum:
+              - table
+              - index
+              - topic
+              - file
+              - fileset
+              - metric
+              - api
+        - name: enabled
+          description: 按启用状态过滤；不传表示不过滤
+          in: query
+          schema:
+            type: boolean
+        - name: offset
+          description: 分页偏移量，>=0，默认 0
+          in: query
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+            default: 0
+        - name: limit
+          description: 每页数量，1-1000，-1 表示不分页，默认 20
+          in: query
+          schema:
+            type: integer
+            format: int64
+            default: 20
+        - name: sort
+          description: 排序字段，默认 name
+          in: query
+          schema:
+            type: string
+            enum:
+              - name
+            default: name
+        - name: direction
+          description: 排序方向，默认 desc
+          in: query
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
+            default: desc
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListConnectorTypes"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+    post:
+      summary: 注册连接器类型
+      description: 创建一个新的连接器类型。`type` 必须唯一，已存在时返回 409。
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConnectorTypeReq"
+            examples:
+              register-mysql:
+                value:
+                  type: mysql
+                  name: MySQL
+                  tags:
+                    - rdbms
+                  description: MySQL 关系型数据库连接器
+                  mode: local
+                  category: table
+                  endpoint: ""
+                  enabled: true
+                  field_config:
+                    host:
+                      name: 主机
+                      type: string
+                      description: 数据库主机地址
+                      required: true
+                      encrypted: false
+                    port:
+                      name: 端口
+                      type: integer
+                      description: 数据库端口
+                      required: true
+                      encrypted: false
+                    password:
+                      name: 密码
+                      type: string
+                      description: 数据库密码
+                      required: true
+                      encrypted: true
+      responses:
+        "201":
+          description: 创建成功
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectorTypeRef"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "406":
+          $ref: "#/components/responses/NotAcceptable"
+        "409":
+          description: 同 type 的连接器类型已存在
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /api/vega-backend/v1/connector-types/{type}:
+    parameters:
+      - name: type
+        description: 连接器类型标识（如 mysql、postgresql）
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      summary: 获取连接器类型详情
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectorType"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+    put:
+      summary: 修改连接器类型
+      description: |
+        全量更新指定连接器类型。连接器类型由路径参数 `type` 唯一确定（主键不可改）。
+
+        请求体可省略 `type` 字段；若携带，则必须与路径参数完全一致，否则返回 409。
+        修改 `name` 时若新名称已被其它类型占用，同样返回 409。
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConnectorTypeUpdateReq"
+      responses:
+        "204":
+          description: 更新成功
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "406":
+          $ref: "#/components/responses/NotAcceptable"
+        "409":
+          description: |
+            主键 / 名称冲突。具体场景：
+            - 请求体 `type` 与路径参数不一致 → `VegaBackend.ConnectorType.TypeMismatch`
+            - 新 `name` 已被其它连接器类型占用 → `VegaBackend.ConnectorType.NameExists`
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+    delete:
+      summary: 删除连接器类型
+      description: 删除指定 type 的连接器类型。`mode=local` 的内置类型不可删除（403）。
+      responses:
+        "204":
+          description: 删除成功
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: 不可删除（如 local 内置类型）
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /api/vega-backend/v1/connector-types/{type}/enable:
+    parameters:
+      - name: type
+        description: 连接器类型标识
+        in: path
+        required: true
+        schema:
+          type: string
+    post:
+      summary: 启用连接器类型
+      description: 启用指定连接器类型；幂等，重复调用不报错。
+      responses:
+        "204":
+          description: 启用成功
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /api/vega-backend/v1/connector-types/{type}/disable:
+    parameters:
+      - name: type
+        description: 连接器类型标识
+        in: path
+        required: true
+        schema:
+          type: string
+    post:
+      summary: 停用连接器类型
+      description: 停用指定连接器类型；幂等，重复调用不报错。
+      responses:
+        "204":
+          description: 停用成功
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+components:
+  responses:
+    BadRequest:
+      description: 请求参数 / 请求体非法
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    Unauthorized:
+      description: 未授权（OAuth Token 校验失败）
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    NotFound:
+      description: 资源不存在
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    NotAcceptable:
+      description: Content-Type 不是 application/json
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    InternalServerError:
+      description: 服务内部错误
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+  schemas:
+    Error:
+      description: |
+        统一错误响应体。由 `kweaver-go-lib/rest.BaseError` JSON 序列化得到，
+        所有非 2xx 响应均返回该结构（Content-Type: application/json）。
+      type: object
+      required:
+        - error_code
+        - description
+        - solution
+        - error_link
+        - error_details
+      properties:
+        error_code:
+          description: 错误码，例如 `VegaBackend.ConnectorType.NotFound`
+          type: string
+        description:
+          description: 错误描述（按请求语言本地化）
+          type: string
+        solution:
+          description: 解决方法（按请求语言本地化）
+          type: string
+        error_link:
+          description: 错误文档链接，可能为空字符串
+          type: string
+        error_details:
+          description: 详细内容，类型不固定（字符串、对象、数组等）；无详情时为空字符串
+    ConnectorFieldConfig:
+      description: 连接器配置字段元信息（兼容 JSON Schema properties）
+      type: object
+      required:
+        - name
+        - type
+      properties:
+        name:
+          description: 字段显示名
+          type: string
+        type:
+          description: 字段类型
+          type: string
+          enum:
+            - string
+            - integer
+            - number
+            - boolean
+            - object
+            - array
+        description:
+          description: 字段描述
+          type: string
+        required:
+          description: 是否必填
+          type: boolean
+          default: false
+        encrypted:
+          description: 是否需要加密存储（自定义扩展）
+          type: boolean
+          default: false
+    ConnectorType:
+      description: 已注册的连接器类型
+      type: object
+      required:
+        - type
+        - name
+        - mode
+        - category
+        - enabled
+      properties:
+        type:
+          description: 连接器类型标识，全局唯一
+          type: string
+        name:
+          description: 连接器类型显示名
+          type: string
+        tags:
+          description: 标签
+          type: array
+          items:
+            type: string
+        description:
+          description: 类型描述
+          type: string
+        mode:
+          description: 运行模式
+          type: string
+          enum:
+            - local
+            - remote
+        category:
+          description: 分类
+          type: string
+          enum:
+            - table
+            - index
+            - topic
+            - file
+            - fileset
+            - metric
+            - api
+        endpoint:
+          description: 仅 remote 模式下的远程服务地址
+          type: string
+        field_config:
+          description: 字段配置（兼容 JSON Schema properties），key 为字段标识
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/ConnectorFieldConfig"
+        enabled:
+          description: 是否启用
+          type: boolean
+        operations:
+          description: 该连接器类型支持的操作集合
+          type: array
+          items:
+            type: string
+    ConnectorTypeReq:
+      description: 注册连接器类型的请求体（POST）
+      type: object
+      required:
+        - type
+        - name
+        - mode
+        - category
+      properties:
+        type:
+          description: 连接器类型标识，全局唯一
+          type: string
+        name:
+          description: 连接器类型显示名
+          type: string
+        tags:
+          description: 标签
+          type: array
+          items:
+            type: string
+        description:
+          description: 类型描述
+          type: string
+        mode:
+          description: 运行模式
+          type: string
+          enum:
+            - local
+            - remote
+        category:
+          description: 分类
+          type: string
+          enum:
+            - table
+            - index
+            - topic
+            - file
+            - fileset
+            - metric
+            - api
+        endpoint:
+          description: 仅 remote 模式下的远程服务地址
+          type: string
+        field_config:
+          description: 字段配置（兼容 JSON Schema properties），key 为字段标识
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/ConnectorFieldConfig"
+        enabled:
+          description: 是否启用
+          type: boolean
+          default: false
+    ConnectorTypeUpdateReq:
+      description: |
+        更新连接器类型的请求体（PUT）。
+
+        连接器类型由路径参数 `type` 唯一确定（主键不可改）。`type` 字段可省略；
+        若携带，则必须与路径参数完全一致，否则返回 409 `VegaBackend.ConnectorType.TypeMismatch`。
+      type: object
+      required:
+        - name
+        - mode
+        - category
+      properties:
+        type:
+          description: 连接器类型标识；可省略，若携带必须与路径参数一致
+          type: string
+        name:
+          description: 连接器类型显示名
+          type: string
+        tags:
+          description: 标签
+          type: array
+          items:
+            type: string
+        description:
+          description: 类型描述
+          type: string
+        mode:
+          description: 运行模式
+          type: string
+          enum:
+            - local
+            - remote
+        category:
+          description: 分类
+          type: string
+          enum:
+            - table
+            - index
+            - topic
+            - file
+            - fileset
+            - metric
+            - api
+        endpoint:
+          description: 仅 remote 模式下的远程服务地址
+          type: string
+        field_config:
+          description: 字段配置（兼容 JSON Schema properties），key 为字段标识
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/ConnectorFieldConfig"
+        enabled:
+          description: 是否启用
+          type: boolean
+          default: false
+    ListConnectorTypes:
+      description: 连接器类型列表
+      type: object
+      required:
+        - entries
+        - total_count
+      properties:
+        entries:
+          description: 条目列表
+          type: array
+          items:
+            $ref: "#/components/schemas/ConnectorType"
+        total_count:
+          description: 总条数
+          type: integer
+          format: int64
+    ConnectorTypeRef:
+      description: 连接器类型引用
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          description: 连接器类型标识
+          type: string

--- a/adp/vega/vega-backend/server/driveradapters/connector_type_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/connector_type_handler.go
@@ -242,6 +242,13 @@ func (r *restHandler) UpdateConnectorType(c *gin.Context) {
 		rest.ReplyError(c, httpErr)
 		return
 	}
+	if req.Type != "" && req.Type != tp {
+		httpErr := rest.NewHTTPError(ctx, http.StatusConflict, verrors.VegaBackend_ConnectorType_TypeMismatch).
+			WithErrorDetails(fmt.Sprintf("path type %q != body type %q", tp, req.Type))
+		o11y.AddHttpAttrs4HttpError(span, httpErr)
+		rest.ReplyError(c, httpErr)
+		return
+	}
 	req.Type = tp
 
 	if err := ValidateConnectorTypeReq(ctx, &req); err != nil {
@@ -345,13 +352,21 @@ func (r *restHandler) DeleteConnectorType(c *gin.Context) {
 	rest.ReplyOK(c, http.StatusNoContent, nil)
 }
 
-// SetConnectorTypeEnabled handles POST /api/vega-backend/v1/connector-types/:type/enable
-func (r *restHandler) SetConnectorTypeEnabled(c *gin.Context) {
+// EnableConnectorType handles POST /api/vega-backend/v1/connector-types/:type/enable
+func (r *restHandler) EnableConnectorType(c *gin.Context) {
+	r.setConnectorTypeEnabled(c, true, "EnableConnectorType")
+}
+
+// DisableConnectorType handles POST /api/vega-backend/v1/connector-types/:type/disable
+func (r *restHandler) DisableConnectorType(c *gin.Context) {
+	r.setConnectorTypeEnabled(c, false, "DisableConnectorType")
+}
+
+func (r *restHandler) setConnectorTypeEnabled(c *gin.Context, value bool, spanName string) {
 	ctx, span := ar_trace.Tracer.Start(rest.GetLanguageCtx(c),
-		"SetConnectorTypeEnabled", trace.WithSpanKind(trace.SpanKindServer))
+		spanName, trace.WithSpanKind(trace.SpanKindServer))
 	defer span.End()
 
-	// 校验token
 	visitor, err := r.verifyOAuth(ctx, c)
 	if err != nil {
 		return
@@ -381,17 +396,7 @@ func (r *restHandler) SetConnectorTypeEnabled(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		Value bool `json:"value"`
-	}
-	if err := c.ShouldBindJSON(&req); err != nil {
-		httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_RequestBody).
-			WithErrorDetails(err.Error())
-		rest.ReplyError(c, httpErr)
-		return
-	}
-
-	if err := r.cts.SetEnabled(ctx, tp, req.Value); err != nil {
+	if err := r.cts.SetEnabled(ctx, tp, value); err != nil {
 		httpErr := err.(*rest.HTTPError)
 		o11y.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, err)
@@ -401,7 +406,7 @@ func (r *restHandler) SetConnectorTypeEnabled(c *gin.Context) {
 	audit.NewInfoLog(audit.OPERATION, audit.UPDATE, audit.TransforOperator(visitor),
 		interfaces.GenerateConnectorTypeAuditObject(tp, ""), "")
 
-	logger.Debug("Handler SetConnectorTypeEnabled Success")
+	logger.Debugf("Handler %s Success", spanName)
 	o11y.AddHttpAttrs4Ok(span, http.StatusNoContent)
 	rest.ReplyOK(c, http.StatusNoContent, nil)
 }

--- a/adp/vega/vega-backend/server/driveradapters/connector_type_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/connector_type_handler_test.go
@@ -1,0 +1,95 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package driveradapters
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/kweaver-ai/kweaver-go-lib/hydra"
+	"go.uber.org/mock/gomock"
+
+	"vega-backend/interfaces"
+	mock_interfaces "vega-backend/interfaces/mock"
+)
+
+// putUpdateConnectorType 构造 PUT /connector-types/:type 的测试上下文，驱动 handler。
+func putUpdateConnectorType(t *testing.T, pathType, body string, ctsSetup func(m *mock_interfaces.MockConnectorTypeService)) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mockAuth := mock_interfaces.NewMockAuthService(ctrl)
+	mockAuth.EXPECT().VerifyToken(gomock.Any(), gomock.Any()).
+		Return(hydra.Visitor{ID: "u1", Type: hydra.VisitorType_User}, nil).
+		AnyTimes()
+
+	mockCTS := mock_interfaces.NewMockConnectorTypeService(ctrl)
+	if ctsSetup != nil {
+		ctsSetup(mockCTS)
+	}
+
+	r := &restHandler{as: mockAuth, cts: mockCTS}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "type", Value: pathType}}
+	c.Request = httptest.NewRequest(http.MethodPut, "/api/vega-backend/v1/connector-types/"+pathType,
+		strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	r.UpdateConnectorType(c)
+	return w
+}
+
+// case 3：请求体 type 与路径不一致 → 409 + TypeMismatch
+func TestUpdateConnectorType_BodyTypeMismatch_409(t *testing.T) {
+	body := `{"type":"postgres","name":"MySQL","mode":"local","category":"table"}`
+	w := putUpdateConnectorType(t, "mysql", body, func(m *mock_interfaces.MockConnectorTypeService) {
+		// 冲突应在调用任何 service 方法前返回，此处无 EXPECT。
+	})
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d, body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "VegaBackend.ConnectorType.TypeMismatch") {
+		t.Fatalf("expected TypeMismatch error_code, got body=%s", w.Body.String())
+	}
+}
+
+// case 1：请求体 type == 路径 → 跳过冲突，进入正常更新流程
+func TestUpdateConnectorType_BodyTypeMatchesPath_OK(t *testing.T) {
+	body := `{"type":"mysql","name":"MySQL","mode":"local","category":"table"}`
+	w := putUpdateConnectorType(t, "mysql", body, func(m *mock_interfaces.MockConnectorTypeService) {
+		m.EXPECT().GetByType(gomock.Any(), "mysql").
+			Return(&interfaces.ConnectorType{Type: "mysql", Name: "MySQL", Mode: "local", Category: "table"}, nil)
+		// name 未变化，故不调用 CheckExistByName
+		m.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
+	})
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d, body=%s", w.Code, w.Body.String())
+	}
+}
+
+// case 2：请求体省略 type → 跳过冲突，进入正常更新流程
+func TestUpdateConnectorType_BodyTypeOmitted_OK(t *testing.T) {
+	body := `{"name":"MySQL","mode":"local","category":"table"}`
+	w := putUpdateConnectorType(t, "mysql", body, func(m *mock_interfaces.MockConnectorTypeService) {
+		m.EXPECT().GetByType(gomock.Any(), "mysql").
+			Return(&interfaces.ConnectorType{Type: "mysql", Name: "MySQL", Mode: "local", Category: "table"}, nil)
+		m.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
+	})
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d, body=%s", w.Code, w.Body.String())
+	}
+}

--- a/adp/vega/vega-backend/server/driveradapters/router.go
+++ b/adp/vega/vega-backend/server/driveradapters/router.go
@@ -93,16 +93,27 @@ func (r *restHandler) RegisterPublic(engine *gin.Engine) {
 			catalogs.DELETE("/:ids", r.DeleteCatalogsByEx)
 			catalogs.GET("/:ids/health-status", r.GetCatalogHealthStatusByEx)
 			catalogs.POST("/:id/test-connection", r.TestConnectionByEx)
+
+			// 资源发现
 			catalogs.POST("/:id/discover", r.DiscoverCatalogResourcesByEx)
+
+			// 资源列表
+			catalogs.GET("/:ids/resources", r.ListCatalogResourcesByEx)
+
 			// 定时&策略采集相关
 			catalogs.GET("/scheduled-discover", r.ListScheduledDiscoverTasksByEx)
 			catalogs.POST("/:id/scheduled-discover", r.verifyJsonContentType(), r.ScheduledDiscoverCatalogResourcesByEx)
 			catalogs.POST("/:id/scheduled-discover/:task_id/start", r.StartScheduledDiscoverTaskByEx)
 			catalogs.POST("/:id/scheduled-discover/:task_id/stop", r.StopScheduledDiscoverTaskByEx)
 			catalogs.PUT("/:id/scheduled-discover/:task_id", r.verifyJsonContentType(), r.UpdateScheduledDiscoverTaskByEx)
-			//adp.t_discover_task
+		}
 
-			catalogs.GET("/:ids/resources", r.ListCatalogResourcesByEx)
+		// DiscoverTask APIs - External
+		discoverTasks := apiV1.Group("/discover-tasks")
+		{
+			discoverTasks.GET("", r.ListDiscoverTasks)
+			discoverTasks.GET("/by-id/:id", r.GetDiscoverTask)
+			discoverTasks.GET("/by-schedule/:scheduleId", r.GetDiscoverTaskByScheduleId)
 		}
 
 		// Resource APIs - External
@@ -137,18 +148,8 @@ func (r *restHandler) RegisterPublic(engine *gin.Engine) {
 			connectorTypes.GET("/:type", r.GetConnectorType)
 			connectorTypes.PUT("/:type", r.verifyJsonContentType(), r.UpdateConnectorType)
 			connectorTypes.DELETE("/:type", r.DeleteConnectorType)
-			connectorTypes.POST("/:type/enabled", r.SetConnectorTypeEnabled)
-		}
-
-		// Query APIs - External
-
-		// DiscoverTask APIs - External
-		discoverTasks := apiV1.Group("/discover-tasks")
-		{
-			discoverTasks.GET("", r.ListDiscoverTasks)
-			discoverTasks.GET("/by-id/:id", r.GetDiscoverTask)
-			discoverTasks.GET("/by-schedule/:scheduleId", r.GetDiscoverTaskByScheduleId)
-
+			connectorTypes.POST("/:type/enable", r.EnableConnectorType)
+			connectorTypes.POST("/:type/disable", r.DisableConnectorType)
 		}
 	}
 
@@ -165,14 +166,27 @@ func (r *restHandler) RegisterPublic(engine *gin.Engine) {
 			catalogs.DELETE("/:ids", r.DeleteCatalogsByIn)
 			catalogs.GET("/:ids/health-status", r.GetCatalogHealthStatusByIn)
 			catalogs.POST("/:id/test-connection", r.TestConnectionByIn)
+
+			//
 			catalogs.POST("/:id/discover", r.DiscoverCatalogResourcesByIn)
+
+			//
+			catalogs.GET("/:ids/resources", r.ListCatalogResourcesByIn)
+
 			// 定时&策略采集相关
 			catalogs.GET("/scheduled-discover", r.ListScheduledDiscoverTasksByIn)
 			catalogs.POST("/:id/scheduled-discover", r.verifyJsonContentType(), r.ScheduledDiscoverCatalogResourcesByIn)
 			catalogs.POST("/:id/scheduled-discover/:task_id/start", r.StartScheduledDiscoverTaskByIn)
 			catalogs.POST("/:id/scheduled-discover/:task_id/stop", r.StopScheduledDiscoverTaskByIn)
 			catalogs.PUT("/:id/scheduled-discover/:task_id", r.verifyJsonContentType(), r.UpdateScheduledDiscoverTaskByIn)
-			catalogs.GET("/:ids/resources", r.ListCatalogResourcesByIn)
+		}
+
+		// DiscoverTask APIs - Internal
+		discoverTasks := apiInV1.Group("/discover-tasks")
+		{
+			discoverTasks.GET("", r.ListDiscoverTasksByIn)
+			discoverTasks.GET("/by-id/:id", r.GetDiscoverTaskByIn)
+			discoverTasks.GET("/by-schedule/:scheduleId", r.GetDiscoverTaskByScheduleIdByIn)
 		}
 
 		// Resource APIs - Internal
@@ -197,15 +211,6 @@ func (r *restHandler) RegisterPublic(engine *gin.Engine) {
 			resources.PUT("/buildtask/:id/:taskid/status", r.verifyJsonContentType(), r.UpdateBuildTaskStatusByIn)
 			resources.GET("/buildtask", r.ListBuildTasksByIn)
 			resources.DELETE("/buildtask/:taskids", r.DeleteBuildTasksByIn)
-		}
-
-		// Query APIs - Internal
-		// DiscoverTask APIs - Internal
-		discoverTasks := apiInV1.Group("/discover-tasks")
-		{
-			discoverTasks.GET("", r.ListDiscoverTasksByIn)
-			discoverTasks.GET("/by-id/:id", r.GetDiscoverTaskByIn)
-			discoverTasks.GET("/by-schedule/:scheduleId", r.GetDiscoverTaskByScheduleIdByIn)
 		}
 	}
 

--- a/adp/vega/vega-backend/server/errors/connector_type.go
+++ b/adp/vega/vega-backend/server/errors/connector_type.go
@@ -18,9 +18,10 @@ const (
 	VegaBackend_ConnectorType_BadRequest                = "VegaBackend.ConnectorType.BadRequest"
 
 	// 404 Not Found / 409 Conflict
-	VegaBackend_ConnectorType_NotFound   = "VegaBackend.ConnectorType.NotFound"
-	VegaBackend_ConnectorType_TypeExists = "VegaBackend.ConnectorType.TypeExists"
-	VegaBackend_ConnectorType_NameExists = "VegaBackend.ConnectorType.NameExists"
+	VegaBackend_ConnectorType_NotFound     = "VegaBackend.ConnectorType.NotFound"
+	VegaBackend_ConnectorType_TypeExists   = "VegaBackend.ConnectorType.TypeExists"
+	VegaBackend_ConnectorType_NameExists   = "VegaBackend.ConnectorType.NameExists"
+	VegaBackend_ConnectorType_TypeMismatch = "VegaBackend.ConnectorType.TypeMismatch"
 
 	// 500 Internal Server Error
 	VegaBackend_ConnectorType_InternalError                = "VegaBackend.ConnectorType.InternalError"
@@ -41,6 +42,7 @@ var ConnectorTypeErrCodeList = []string{
 	VegaBackend_ConnectorType_NotFound,
 	VegaBackend_ConnectorType_NameExists,
 	VegaBackend_ConnectorType_TypeExists,
+	VegaBackend_ConnectorType_TypeMismatch,
 	VegaBackend_ConnectorType_InternalError,
 	VegaBackend_ConnectorType_InternalError_RegisterFailed,
 	VegaBackend_ConnectorType_InternalError_GetFailed,

--- a/adp/vega/vega-backend/server/locale/connector_type.en-US.toml
+++ b/adp/vega/vega-backend/server/locale/connector_type.en-US.toml
@@ -48,6 +48,11 @@ Description = "Connector type name already exists"
 Solution = "Please use a different name"
 ErrorLink = "None"
 
+[VegaBackend.ConnectorType.TypeMismatch]
+Description = "The connector type in the request body does not match the path"
+Solution = "Omit the type field in the body, or make it match the path parameter"
+ErrorLink = "None"
+
 [VegaBackend.ConnectorType.InternalError]
 Description = "Connector type internal error"
 Solution = "Please contact the administrator"

--- a/adp/vega/vega-backend/server/locale/connector_type.zh-CN.toml
+++ b/adp/vega/vega-backend/server/locale/connector_type.zh-CN.toml
@@ -48,6 +48,11 @@ Description = "连接器类型名称已存在"
 Solution = "请使用其他名称"
 ErrorLink = "暂无"
 
+[VegaBackend.ConnectorType.TypeMismatch]
+Description = "请求体中的连接器类型与路径不一致"
+Solution = "省略请求体中的 type 字段，或使其与路径参数保持一致"
+ErrorLink = "暂无"
+
 [VegaBackend.ConnectorType.InternalError]
 Description = "连接器类型内部错误"
 Solution = "请联系管理员"


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] 新增 `connector-type.yaml` OpenAPI 文档（`adp/docs/api/vega/vega-backend-api/`）
- [x] 重构启用/停用接口为独立端点：`POST /connector-types/{type}/enable`、`POST /connector-types/{type}/disable`（替代原合并端点）
- [x] 新增请求体与路径参数 `type` 不一致的校验，返回 `409 Conflict` + 错误码 `VegaBackend.ConnectorType.TypeMismatch`
- [x] 新增对应错误定义与中英文 locale 文案（`errors/connector_type.go`、`locale/connector_type.{en-US,zh-CN}.toml`）
- [x] 路由注册更新（`router.go`）
- [x] 补充 handler 单元测试覆盖新增场景（`connector_type_handler_test.go`）

---

## Why

- Related Issue: #331
- Background:
  - 此前 PUT `/connector-types/{type}` 在请求体 `type` 与路径参数不一致时行为不明确，容易让调用方误以为更新了主键；统一返回 409 + `TypeMismatch` 让契约更清晰
  - 启用/停用此前与更新接口耦合，独立为幂等端点后语义更明确，也便于权限与审计

---

## How

- 关键实现点：
  - `connector_type_handler.go`：在 PUT 处理逻辑中校验 body.Type 与路径 type 是否一致，不一致直接返回 `TypeMismatch` 409
  - 新增独立的 `enable` / `disable` handler，幂等实现
  - `errors/connector_type.go` 新增 `TypeMismatch` 错误码，i18n 文案补齐 zh-CN / en-US
  - OpenAPI 文档覆盖新端点、状态码（含 409 与 `error_code` 区分 `TypeMismatch` / `NameExists`）
- Breaking changes:
  - **API**：原合并的启用/停用端点已被替换为独立端点 `POST /connector-types/{type}/enable` 与 `POST /connector-types/{type}/disable`，前端/调用方需同步更新

---

## Testing

- [x] Unit tests passed locally（`connector_type_handler_test.go` 覆盖一致/不一致 type、enable/disable 幂等等场景）
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:
- 新增测试用例聚焦于 `TypeMismatch` 409 路径与新 enable/disable 端点幂等行为

---

## Risk & Rollback

- 潜在风险：
  - 调用方仍在使用旧的合并启用/停用端点会出现 404；上线前需协调前端发布
  - PUT 接口对 body.Type 严格校验，可能影响早期未携带该字段一致性约束的客户端
- 回滚方案：revert 本 PR 即可恢复原路由与原校验行为；无数据库 schema 变更，无需数据回滚

---

## Additional Notes

- OpenAPI 文档：`adp/docs/api/vega/vega-backend-api/connector-type.yaml`
- 错误码：`VegaBackend.ConnectorType.TypeMismatch`、`VegaBackend.ConnectorType.NameExists`
