### PR TITLE
fix(ontology-query): metric trend parses calendar bucket date strings (#338)

### DIFF
--- a/adp/bkn/ontology-query/server/common/convert.go
+++ b/adp/bkn/ontology-query/server/common/convert.go
@@ -276,6 +276,25 @@ func appLocationOrUTC() *time.Location {
 // AppLocationOrUTC is the exported form of appLocationOrUTC for callers outside package common.
 func AppLocationOrUTC() *time.Location { return appLocationOrUTC() }
 
+// isoWeekMonday returns Monday 00:00 of ISO year y, ISO week w in loc (matches FormatTimeMiliis / t.ISOWeek).
+func isoWeekMonday(y, w int, loc *time.Location) (time.Time, error) {
+	if w < 1 || w > 53 {
+		return time.Time{}, fmt.Errorf("invalid ISO week %d", w)
+	}
+	jan4 := time.Date(y, time.January, 4, 0, 0, 0, 0, loc)
+	d := int(jan4.Weekday())
+	if d == 0 {
+		d = 7
+	}
+	mondayW1 := jan4.AddDate(0, 0, -(d - 1))
+	t := mondayW1.AddDate(0, 0, (w-1)*7)
+	y2, w2 := t.ISOWeek()
+	if y2 != y || w2 != w {
+		return time.Time{}, fmt.Errorf("invalid week bucket for ISO year %d week %d", y, w)
+	}
+	return t, nil
+}
+
 func FormatTimeMiliis(ts int64, formatType string) string {
 	t := time.UnixMilli(ts).In(appLocationOrUTC())
 	switch formatType {
@@ -298,6 +317,88 @@ func FormatTimeMiliis(ts int64, formatType string) string {
 		return t.Format("2006")
 	default:
 		return FormatRFC3339Milli(ts)
+	}
+}
+
+// ParseCalendarBucketToMillis parses a calendar bucket label produced by resource/Vega date_histogram
+// into the bucket start instant in milliseconds. Layouts match FormatTimeMiliis for the same formatType.
+func ParseCalendarBucketToMillis(s, formatType string) (int64, error) {
+	s = strings.TrimSpace(s)
+	formatType = strings.TrimSpace(formatType)
+	if s == "" {
+		return 0, fmt.Errorf("empty calendar bucket string")
+	}
+	loc := appLocationOrUTC()
+	switch formatType {
+	case CALENDAR_STEP_MINUTE:
+		t, err := time.ParseInLocation("2006-01-02 15:04", s, loc)
+		if err != nil {
+			return 0, err
+		}
+		return t.UnixMilli(), nil
+	case CALENDAR_STEP_HOUR:
+		t, err := time.ParseInLocation("2006-01-02 15", s, loc)
+		if err != nil {
+			return 0, err
+		}
+		return t.UnixMilli(), nil
+	case CALENDAR_STEP_DAY:
+		t, err := time.ParseInLocation(time.DateOnly, s, loc)
+		if err != nil {
+			return 0, err
+		}
+		return t.UnixMilli(), nil
+	case CALENDAR_STEP_WEEK:
+		// ISO year-week, same as FormatTimeMiliis (e.g. 2025-46); bucket start = Monday 00:00 in loc.
+		parts := strings.Split(s, "-")
+		if len(parts) != 2 {
+			return 0, fmt.Errorf("invalid week bucket %q", s)
+		}
+		year, err := strconv.Atoi(parts[0])
+		if err != nil {
+			return 0, err
+		}
+		week, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return 0, err
+		}
+		t, err := isoWeekMonday(year, week, loc)
+		if err != nil {
+			return 0, err
+		}
+		return t.UnixMilli(), nil
+	case CALENDAR_STEP_MONTH:
+		t, err := time.ParseInLocation("2006-01", s, loc)
+		if err != nil {
+			return 0, err
+		}
+		return t.UnixMilli(), nil
+	case CALENDAR_STEP_QUARTER:
+		// e.g. 2024-Q1
+		idx := strings.Index(s, "-Q")
+		if idx < 1 {
+			return 0, fmt.Errorf("invalid quarter bucket %q", s)
+		}
+		year, err := strconv.Atoi(s[:idx])
+		if err != nil {
+			return 0, err
+		}
+		qStr := s[idx+2:]
+		q, err := strconv.Atoi(qStr)
+		if err != nil || q < 1 || q > 4 {
+			return 0, fmt.Errorf("invalid quarter bucket %q", s)
+		}
+		month := time.Month((q-1)*3 + 1)
+		t := time.Date(year, month, 1, 0, 0, 0, 0, loc)
+		return t.UnixMilli(), nil
+	case CALENDAR_STEP_YEAR:
+		t, err := time.ParseInLocation("2006", s, loc)
+		if err != nil {
+			return 0, err
+		}
+		return t.UnixMilli(), nil
+	default:
+		return 0, fmt.Errorf("unsupported calendar step %q", formatType)
 	}
 }
 

--- a/adp/bkn/ontology-query/server/common/convert_test.go
+++ b/adp/bkn/ontology-query/server/common/convert_test.go
@@ -7,9 +7,38 @@ package common
 
 import (
 	"testing"
+	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
+
+func Test_ParseCalendarBucketToMillis_roundtrips_FormatTimeMiliis(t *testing.T) {
+	Convey("ParseCalendarBucketToMillis matches FormatTimeMiliis bucket keys", t, func() {
+		ts := time.Date(2024, 3, 15, 14, 30, 0, 0, time.UTC).UnixMilli()
+		steps := []string{
+			CALENDAR_STEP_MINUTE,
+			CALENDAR_STEP_HOUR,
+			CALENDAR_STEP_DAY,
+			CALENDAR_STEP_WEEK,
+			CALENDAR_STEP_MONTH,
+			CALENDAR_STEP_QUARTER,
+			CALENDAR_STEP_YEAR,
+		}
+		for _, step := range steps {
+			key := FormatTimeMiliis(ts, step)
+			ms, err := ParseCalendarBucketToMillis(key, step)
+			So(err, ShouldBeNil)
+			// Re-format must equal the same calendar bucket label
+			So(FormatTimeMiliis(ms, step), ShouldEqual, key)
+		}
+	})
+
+	Convey("day parses YYYY-MM-DD from resource date_histogram", t, func() {
+		ms, err := ParseCalendarBucketToMillis("2024-01-04", CALENDAR_STEP_DAY)
+		So(err, ShouldBeNil)
+		So(FormatTimeMiliis(ms, CALENDAR_STEP_DAY), ShouldEqual, "2024-01-04")
+	})
+}
 
 func Test_Convert_StringToStringSlice(t *testing.T) {
 	Convey("Test StringToStringSlice", t, func() {

--- a/adp/bkn/ontology-query/server/logics/metric/metric_query_service.go
+++ b/adp/bkn/ontology-query/server/logics/metric/metric_query_service.go
@@ -538,13 +538,24 @@ func appendMetricValue(ctx context.Context, v any, values *[]any) (float64, erro
 	return f, nil
 }
 
-// entryTimeToMillis supports numeric buckets (ms) and RFC3339 strings (resource / Vega may use either).
-func entryTimeToMillis(v any) (int64, error) {
+// entryTimeToMillis supports numeric buckets (ms), calendar bucket strings for calendarStep (same layouts as FormatTimeMiliis),
+// and RFC3339 strings when calendar parsing does not apply or fails.
+func entryTimeToMillis(v any, calendarStep *string) (int64, error) {
 	if v == nil {
 		return 0, fmt.Errorf("time field is nil")
 	}
-	if s, ok := v.(string); ok {
-		t, err := time.ParseInLocation(time.RFC3339, s, common.APP_LOCATION)
+	if cs, ok := v.(string); ok {
+		s := strings.TrimSpace(cs)
+		loc := common.AppLocationOrUTC()
+		if calendarStep != nil {
+			step := strings.TrimSpace(*calendarStep)
+			if step != "" {
+				if ms, err := common.ParseCalendarBucketToMillis(s, step); err == nil {
+					return ms, nil
+				}
+			}
+		}
+		t, err := time.ParseInLocation(time.RFC3339, s, loc)
 		if err != nil {
 			return 0, err
 		}
@@ -972,6 +983,14 @@ func convert2TimeSeries(ctx context.Context, def interfaces.MetricDefinition, da
 	valueField := interfaces.VALUE_FIELD
 	timeResField := trend.timeResField
 
+	var calStep *string
+	if query != nil && query.Time != nil && query.Time.Step != nil {
+		calStep = query.Time.Step
+	} else if trend != nil && strings.TrimSpace(trend.step) != "" {
+		st := strings.TrimSpace(trend.step)
+		calStep = &st
+	}
+
 	var allTimes []any
 	var allTimeStrs []string
 	if fillNull {
@@ -1013,7 +1032,7 @@ func convert2TimeSeries(ctx context.Context, def interfaces.MetricDefinition, da
 			return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError, oerrors.OntologyQuery_Metric_InternalError_QueryFailed).
 				WithErrorDetails("missing time bucket field in resource entry")
 		}
-		timei, err := entryTimeToMillis(timeRaw)
+		timei, err := entryTimeToMillis(timeRaw, calStep)
 		if err != nil {
 			return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError, oerrors.OntologyQuery_Metric_InternalError_QueryFailed).
 				WithErrorDetails(fmt.Sprintf("time field: %v", err))


### PR DESCRIPTION
# Pull Request

## What Changed

指标趋势在时间维度上，当底层 resource/Vega `date_histogram` 返回日历分桶的标签为日期字符串（与 `FormatTimeMiliis` 一致的分、时、日、周、季、月、年）时，`entryTimeToMillis` 此前仅尝试 RFC3339，会导致解析失败。

- [x] `common.ParseCalendarBucketToMillis`：按与 `FormatTimeMiliis` 相同的 `formatType` 将分桶标签解析为桶起始毫秒时间戳；周桶使用 ISO 周（含 `isoWeekMonday`）与格式化逻辑对齐
- [x] `metric_query_service`：`entryTimeToMillis` 在存在日历 `step` 时优先按日历布局解析字符串，失败再回退 RFC3339；`convert2TimeSeries` 从查询或 trend 注入 `calStep`
- [x] 单测：`Test_ParseCalendarBucketToMillis_roundtrips_FormatTimeMiliis` 及各 step 与 `FormatTimeMiliis` 的往返一致性

---

## Why

- Related Issue: [Issue #338](https://github.com/kweaver-ai/kweaver-core/issues/338)
- Background: resource 侧日历分桶返回的是 `YYYY-MM-DD` 等字符串键，而非 RFC3339；需与查询侧日历 step 对齐解析，避免趋势接口内部错误。

---

## How

- 关键实现：`ParseCalendarBucketToMillis` 与 `FormatTimeMiliis` 共用布局约定；`entryTimeToMillis(v, calendarStep)` 对 string 类型先尝试日历解析，再 `time.RFC3339`；时区使用 `AppLocationOrUTC()`，与格式化一致。
- Breaking changes：无对外 API 变更；`entryTimeToMillis` 为包内未导出函数，签名增加 `calendarStep *string` 参数。

---

## Testing

- [x] `go test ./common/... -run ParseCalendarBucket`（在 `adp/bkn/ontology-query/server` 下）已通过
- [ ] 全量 `I18N_MODE_UT=true go test ./...` 未在本机跑通全模块（与本改动无强依赖部分可后续 CI 覆盖）
- [ ] 测试环境联调未执行

Test notes: 新增用例覆盖各 `CALENDAR_STEP_*` 与 `FormatTimeMiliis` 往返及日桶 `2024-01-04` 直接解析。

---

## Risk & Rollback

- 风险：若存在同时符合日历布局与 RFC3339 的歧义字符串，将优先走日历解析（需与业务键格式一致）。
- 回滚：还原本分支三个文件的改动即可。

---

## Additional Notes

- Commit: `37126a79` — 【ontology-query】指标趋势：resource 日历分桶返回日期字符串时解析失败
