### PR TITLE
fix: Logic View bug fixes and SQL validation

### DIFF
--- a/adp/docs/design/vega/features/vega-backend/VEGA_Part8_LogicView.md
+++ b/adp/docs/design/vega/features/vega-backend/VEGA_Part8_LogicView.md
@@ -447,7 +447,10 @@ type Property struct {
                 "resource_id": "d7g5433kqlq74cujv3qg",
                 "distinct": false,
                 "filters": {}
-            }
+            },
+            "output_fields": [
+                "*"
+            ]
         },
         {
             "id": "node2",

--- a/adp/docs/design/vega/features/vega-backend/VEGA_Part8_LogicView.md
+++ b/adp/docs/design/vega/features/vega-backend/VEGA_Part8_LogicView.md
@@ -432,7 +432,7 @@ type Property struct {
                 "node3"
             ],
             "config": {
-                "sql": "SELECT \n channel AS '渠道',\n    COUNT(order_id) AS '总订单量',\n    SUM(revenue) AS '总销售额',\n    ROUND(SUM(revenue) / COUNT(order_id), 2) AS '平均客单价'\nFROM (\n    SELECT order_no AS order_id, amount AS revenue, '商城' AS channel FROM {{.node1}} AS u1 \n    UNION ALL\n    SELECT pdd_id AS order_id, price AS revenue, '拼多多' AS channel FROM {{.node2}} AS u2\n    UNION ALL\n    SELECT dy_code AS order_id, total_fee AS revenue, '抖音' AS channel FROM {{.node3}} AS u3\n) AS all_sales \nGROUP BY channel WITH ROLLUP;"
+                "sql": "SELECT \n channel AS '渠道',\n    COUNT(order_id) AS '总订单量',\n    SUM(revenue) AS '总销售额',\n    ROUND(SUM(revenue) / COUNT(order_id), 2) AS '平均客单价'\nFROM (\n    SELECT order_no AS order_id, amount AS revenue, '商城' AS channel FROM {{.node1}} \n    UNION ALL\n    SELECT pdd_id AS order_id, price AS revenue, '拼多多' AS channel FROM {{.node2}} \n    UNION ALL\n    SELECT dy_code AS order_id, total_fee AS revenue, '抖音' AS channel FROM {{.node3}} \n) AS all_sales \nGROUP BY channel WITH ROLLUP;"
             },
             "output_fields": [
                "*"

--- a/adp/vega/vega-backend/server/config/vega-backend-config.yaml
+++ b/adp/vega/vega-backend/server/config/vega-backend-config.yaml
@@ -11,7 +11,7 @@ log:
   maxBackups: 20
   maxSize: 100
 crypto:
-  enabled: false
+  enabled: true
   privateKeyPath: /opt/vega-backend/secret-config/rsa_private_key_pkcs8.pem
   publicKeyPath: /opt/vega-backend/secret-config/rsa_public_key.pem
 
@@ -19,10 +19,10 @@ depServices:
   class-443:
     ingressClass: class-443
   rds:
-    host: 127.0.0.1
-    port: 3306
+    host: mariadb-mariadb-master.resource.svc.cluster.local.
+    port: 3330
     user: root
-    password: eisoo.com123
+    password: ""
     type: MariaDB
   mq:
     mqType: kafka
@@ -35,27 +35,27 @@ depServices:
       password: ""
       mechanism: PLAIN
   opensearch:
-    host: 192.168.40.115
+    host: opensearch-master.resource.svc.cluster.local.
     port: 9200
     protocol: http
     user: admin
-    password: eisoo.com123
+    password: ""
   redis:
     connectInfo:
-      username: ''
-      password: eisoo.com123
+      username: root
+      password: ''
       sentinelHost: proton-redis-proton-redis-sentinel.resource.svc.cluster.local
       sentinelPort: 26379
       sentinelUsername: root
       sentinelPassword: ''
       masterGroupName: mymaster
-      host: 127.0.0.1
-      port: 6379
+      host: ""
+      port: 0
       masterHost: ""
       masterPort: 0
       slaveHost: ""
       slavePort: 0
-    connectType: standalone
+    connectType: sentinel
   authorization-private:
     host: authorization-private
     port: 30920

--- a/adp/vega/vega-backend/server/config/vega-backend-config.yaml
+++ b/adp/vega/vega-backend/server/config/vega-backend-config.yaml
@@ -11,7 +11,7 @@ log:
   maxBackups: 20
   maxSize: 100
 crypto:
-  enabled: true
+  enabled: false
   privateKeyPath: /opt/vega-backend/secret-config/rsa_private_key_pkcs8.pem
   publicKeyPath: /opt/vega-backend/secret-config/rsa_public_key.pem
 
@@ -19,10 +19,10 @@ depServices:
   class-443:
     ingressClass: class-443
   rds:
-    host: mariadb-mariadb-master.resource.svc.cluster.local.
-    port: 3330
+    host: 127.0.0.1
+    port: 3306
     user: root
-    password: ""
+    password: eisoo.com123
     type: MariaDB
   mq:
     mqType: kafka
@@ -35,27 +35,27 @@ depServices:
       password: ""
       mechanism: PLAIN
   opensearch:
-    host: opensearch-master.resource.svc.cluster.local.
+    host: 192.168.40.115
     port: 9200
     protocol: http
     user: admin
-    password: ""
+    password: eisoo.com123
   redis:
     connectInfo:
-      username: root
-      password: ''
+      username: ''
+      password: eisoo.com123
       sentinelHost: proton-redis-proton-redis-sentinel.resource.svc.cluster.local
       sentinelPort: 26379
       sentinelUsername: root
       sentinelPassword: ''
       masterGroupName: mymaster
-      host: ""
-      port: 0
+      host: 127.0.0.1
+      port: 6379
       masterHost: ""
       masterPort: 0
       slaveHost: ""
       slavePort: 0
-    connectType: sentinel
+    connectType: standalone
   authorization-private:
     host: authorization-private
     port: 30920

--- a/adp/vega/vega-backend/server/interfaces/logic_view_service.go
+++ b/adp/vega/vega-backend/server/interfaces/logic_view_service.go
@@ -82,9 +82,8 @@ var (
 
 type LogicView struct {
 	Resource
-	FieldsMap      map[string]*ViewProperty `json:"fields_map,omitempty" mapstructure:"-"`
-	IsSingleSource bool                     `json:"is_single_source,omitempty" mapstructure:"-"`
-	RefResources   map[string]*Resource     `json:"ref_resources,omitempty" mapstructure:"-"`
+	IsSingleSource bool                 `json:"is_single_source,omitempty" mapstructure:"-"`
+	RefResources   map[string]*Resource `json:"ref_resources,omitempty" mapstructure:"-"`
 }
 
 // LogicDefinitionNode 表示图中的节点

--- a/adp/vega/vega-backend/server/logics/resource/logic_view.go
+++ b/adp/vega/vega-backend/server/logics/resource/logic_view.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
 
 	"github.com/dlclark/regexp2"
 	"github.com/kweaver-ai/TelemetrySDK-Go/exporter/v2/ar_trace"
@@ -51,6 +52,12 @@ func (rs *resourceService) validateLogicDefinition(ctx context.Context, view *in
 	refResourceMap := make(map[string]*interfaces.Resource)
 
 	for _, node := range view.LogicDefinition {
+		// 节点不能自引用
+		if slices.Contains(node.Inputs, node.ID) {
+			return "", rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+				WithErrorDetails(fmt.Sprintf("Node '%s' cannot reference itself: %s", node.ID, node.ID))
+		}
+
 		switch node.Type {
 		case interfaces.LogicDefinitionNodeType_Resource:
 			// 校验资源节点
@@ -61,22 +68,22 @@ func (rs *resourceService) validateLogicDefinition(ctx context.Context, view *in
 
 			resourceNodeCount++
 		case interfaces.LogicDefinitionNodeType_Join:
-			err := validateJoinNode(ctx, node, nodeMap)
+			err := validateJoinNode(ctx, rs, node, view.LogicDefinition, nodeMap)
 			if err != nil {
 				return "", err
 			}
 		case interfaces.LogicDefinitionNodeType_Union:
-			err := validateUnionNode(ctx, view.Category, node, nodeMap)
+			err := validateUnionNode(ctx, rs, view.Category, node, view.LogicDefinition, nodeMap)
 			if err != nil {
 				return "", err
 			}
 		case interfaces.LogicDefinitionNodeType_Sql:
-			err := validateSqlNode(ctx, node, nodeMap)
+			err := validateSqlNode(ctx, rs, node, view.LogicDefinition, nodeMap)
 			if err != nil {
 				return "", err
 			}
 		case interfaces.LogicDefinitionNodeType_Output:
-			err := validateOutputNode(ctx, node, nodeMap)
+			err := validateOutputNode(ctx, rs, node, view.LogicDefinition, nodeMap)
 			if err != nil {
 				return "", err
 			}
@@ -89,11 +96,8 @@ func (rs *resourceService) validateLogicDefinition(ctx context.Context, view *in
 		}
 	}
 
-	// 如果只有一个资源节点和一个输出节点，则为衍生视图
-	logicType := interfaces.LogicType_Composite
-	if len(view.LogicDefinition) == 2 && resourceNodeCount == 1 && outputNodeCount == 1 {
-		logicType = interfaces.LogicType_Derived
-	}
+	// 判断视图类型：衍生视图还是组合视图
+	logicType := determineLogicType(view.LogicDefinition)
 
 	var refResourceCategory string
 	refResourceCategoryMap := make(map[string]struct{})
@@ -117,6 +121,152 @@ func (rs *resourceService) validateLogicDefinition(ctx context.Context, view *in
 
 	span.SetStatus(codes.Ok, "")
 	return logicType, nil
+}
+
+// determineLogicType 判断视图类型：衍生视图还是组合视图
+// 衍生视图：输出节点只引用一个资源节点（没有经过 Join/Union/SQL 等多源处理节点）
+// 组合视图：输出节点引用了多个资源节点，或经过了 Join/Union/SQL 等处理节点
+func determineLogicType(nodes []*interfaces.LogicDefinitionNode) string {
+	// 默认是组合视图
+	logicType := interfaces.LogicType_Composite
+
+	// 找到输出节点
+	var outputNode *interfaces.LogicDefinitionNode
+	for _, node := range nodes {
+		if node.Type == interfaces.LogicDefinitionNodeType_Output {
+			outputNode = node
+			break
+		}
+	}
+
+	if outputNode != nil && len(outputNode.Inputs) == 1 {
+		// 输出节点只有一个输入，检查是否只引用了一个资源节点
+		// 递归追踪输入节点，看是否最终只引用了一个资源节点，且没有经过 Join/Union/SQL 节点
+		hasProcessingNode := false
+		resourceNodeIDs := make(map[string]struct{})
+
+		// 使用 BFS 遍历所有上游节点
+		visited := make(map[string]struct{})
+		queue := []string{outputNode.Inputs[0]}
+		visited[outputNode.Inputs[0]] = struct{}{}
+
+		for len(queue) > 0 {
+			currentID := queue[0]
+			queue = queue[1:]
+
+			// 找到当前节点
+			var currentNode *interfaces.LogicDefinitionNode
+			for _, n := range nodes {
+				if n.ID == currentID {
+					currentNode = n
+					break
+				}
+			}
+
+			if currentNode == nil {
+				continue
+			}
+
+			// 检查节点类型
+			switch currentNode.Type {
+			case interfaces.LogicDefinitionNodeType_Resource:
+				// 记录资源节点
+				resourceNodeIDs[currentNode.ID] = struct{}{}
+			case interfaces.LogicDefinitionNodeType_Join,
+				interfaces.LogicDefinitionNodeType_Union,
+				interfaces.LogicDefinitionNodeType_Sql:
+				// 遇到处理节点，标记为组合视图
+				hasProcessingNode = true
+			case interfaces.LogicDefinitionNodeType_Output:
+				// 不应该出现，但忽略
+				break
+			}
+
+			// 将输入节点加入队列
+			for _, inputID := range currentNode.Inputs {
+				if _, ok := visited[inputID]; !ok {
+					visited[inputID] = struct{}{}
+					queue = append(queue, inputID)
+				}
+			}
+		}
+
+		// 如果只有一个资源节点且没有经过处理节点，则为衍生视图
+		if !hasProcessingNode && len(resourceNodeIDs) == 1 {
+			logicType = interfaces.LogicType_Derived
+		}
+	}
+
+	return logicType
+}
+
+// 获取节点的输出字段映射（用于校验字段是否存在）
+func getNodeOutputFieldsMap(ctx context.Context, rs *resourceService, nodeID string,
+	allNodes []*interfaces.LogicDefinitionNode, nodeCache map[string]map[string]*interfaces.Property) (map[string]*interfaces.Property, error) {
+
+	// 如果已经计算过，直接返回缓存结果
+	if cached, ok := nodeCache[nodeID]; ok {
+		return cached, nil
+	}
+
+	// 找到节点
+	var node *interfaces.LogicDefinitionNode
+	for _, n := range allNodes {
+		if n.ID == nodeID {
+			node = n
+			break
+		}
+	}
+	if node == nil {
+		return nil, fmt.Errorf("node %s not found", nodeID)
+	}
+
+	fieldsMap := make(map[string]*interfaces.Property)
+
+	switch node.Type {
+	case interfaces.LogicDefinitionNodeType_Resource:
+		// Resource 节点：从资源获取字段列表
+		var cfg interfaces.ResourceNodeCfg
+		if err := mapstructure.Decode(node.Config, &cfg); err != nil {
+			return nil, err
+		}
+		resource, err := rs.GetByID(ctx, cfg.ResourceID)
+		if err != nil {
+			return nil, err
+		}
+		for _, field := range resource.SchemaDefinition {
+			fieldsMap[field.Name] = field
+		}
+	default:
+		// 其他节点：从 output_fields 中获取字段列表
+		for _, field := range node.OutputFields {
+			if field.Name == "*" {
+				// 通配符模式：需要从上游节点获取所有字段
+				for _, inputID := range node.Inputs {
+					// 递归获取输入节点的字段
+					inputFieldsMap, err := getNodeOutputFieldsMap(ctx, rs, inputID, allNodes, nodeCache)
+					if err != nil {
+						return nil, err
+					}
+					for name, f := range inputFieldsMap {
+						fieldsMap[name] = f
+					}
+				}
+			} else {
+				// 非通配符：直接使用字段定义
+				prop := &interfaces.Property{
+					Name:        field.Name,
+					Type:        field.Type,
+					DisplayName: field.DisplayName,
+				}
+				fieldsMap[field.Name] = prop
+			}
+		}
+	}
+
+	// 缓存结果
+	nodeCache[nodeID] = fieldsMap
+	return fieldsMap, nil
 }
 
 func validateResourceNode(ctx context.Context, dvs *resourceService, node *interfaces.LogicDefinitionNode,
@@ -176,11 +326,25 @@ func validateResourceNode(ctx context.Context, dvs *resourceService, node *inter
 		}
 	}
 
-	// 校验输出字段是否在视图字段列表里
+	// 校验输出字段格式：resource节点支持通配符模式和投影模式
 	for _, field := range node.OutputFields {
+		// 通配符模式：只允许 "*"
 		if field.Name == "*" {
+			// 通配符模式下，不应有其他字段配置
+			if field.Type != "" || field.From != "" || field.FromNode != "" || len(field.FromList) > 0 {
+				return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+					WithErrorDetails("Wildcard field '*' should not have additional configuration")
+			}
 			continue
 		}
+
+		// 投影模式：只允许字段名，不应有映射或对齐配置
+		if field.From != "" || field.FromNode != "" || len(field.FromList) > 0 {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+				WithErrorDetails(fmt.Sprintf("Resource node output field '%s' should not have from, from_node or from_list configuration", field.Name))
+		}
+
+		// 校验字段是否存在于资源字段列表中
 		if _, ok := fieldsMap[field.Name]; !ok {
 			return rest.NewHTTPError(ctx, http.StatusBadRequest, rest.PublicError_BadRequest).
 				WithErrorDetails(fmt.Sprintf("The field '%s' is not in the view '%s' field list", field.Name, atomicView.Name))
@@ -190,7 +354,8 @@ func validateResourceNode(ctx context.Context, dvs *resourceService, node *inter
 	return nil
 }
 
-func validateJoinNode(ctx context.Context, node *interfaces.LogicDefinitionNode, nodeMap map[string]struct{}) error {
+func validateJoinNode(ctx context.Context, rs *resourceService, node *interfaces.LogicDefinitionNode,
+	allNodes []*interfaces.LogicDefinitionNode, nodeMap map[string]struct{}) error {
 	// 仅支持两个视图join
 	if len(node.Inputs) != 2 {
 		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
@@ -249,10 +414,73 @@ func validateJoinNode(ctx context.Context, node *interfaces.LogicDefinitionNode,
 		}
 	}
 
+	// 校验输出字段不能为空
+	if len(node.OutputFields) == 0 {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+			WithErrorDetails("Join node must have output fields")
+	}
+
+	// 校验输出字段格式：join节点只支持映射模式
+	// 先获取所有输入节点的输出字段
+	nodeCache := make(map[string]map[string]*interfaces.Property)
+	inputFieldsMap := make(map[string]map[string]*interfaces.Property)
+	for _, inputID := range node.Inputs {
+		fieldsMap, err := getNodeOutputFieldsMap(ctx, rs, inputID, allNodes, nodeCache)
+		if err != nil {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+				WithErrorDetails(fmt.Sprintf("Failed to get output fields from input node '%s': %v", inputID, err))
+		}
+		inputFieldsMap[inputID] = fieldsMap
+	}
+
+	// 校验每个输出字段
+	for _, field := range node.OutputFields {
+		// Join节点不支持通配符模式
+		if field.Name == "*" {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+				WithErrorDetails("Join node does not support wildcard field '*'")
+		}
+
+		// 映射模式：必须指定 from 和 from_node
+		if field.From == "" || field.FromNode == "" {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+				WithErrorDetails(fmt.Sprintf("Join node output field '%s' must have 'from' and 'from_node' configuration", field.Name))
+		}
+
+		// 映射模式：不应有 FromList 配置
+		if len(field.FromList) > 0 {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+				WithErrorDetails(fmt.Sprintf("Join node output field '%s' should not have 'from_list' configuration", field.Name))
+		}
+
+		// 校验 from_node 是否在输入节点中
+		found := false
+		for _, inputNode := range node.Inputs {
+			if inputNode == field.FromNode {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+				WithErrorDetails(fmt.Sprintf("Join node output field '%s' references non-existent input node '%s'", field.Name, field.FromNode))
+		}
+
+		// 校验 from 字段是否存在于源节点中
+		if sourceFields, ok := inputFieldsMap[field.FromNode]; ok {
+			if _, exists := sourceFields[field.From]; !exists {
+				return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+					WithErrorDetails(fmt.Sprintf("Join node output field '%s' references non-existent field '%s' in node '%s'",
+						field.Name, field.From, field.FromNode))
+			}
+		}
+	}
+
 	return nil
 }
 
-func validateUnionNode(ctx context.Context, category string, node *interfaces.LogicDefinitionNode, nodeMap map[string]struct{}) error {
+func validateUnionNode(ctx context.Context, rs *resourceService, category string, node *interfaces.LogicDefinitionNode,
+	allNodes []*interfaces.LogicDefinitionNode, nodeMap map[string]struct{}) error {
 	// 当前仅支持两个视图union
 	if len(node.Inputs) < 2 {
 		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
@@ -290,7 +518,7 @@ func validateUnionNode(ctx context.Context, category string, node *interfaces.Lo
 			WithErrorDetails("The logic definition union config is invalid, union_type must be all, distinct")
 	}
 
-	// TODO 如果查询类型是DSL或索引基类，只允许union all
+	// 如果是索引resource，只允许union all
 	if category == interfaces.ResourceCategoryIndex {
 		if cfg.UnionType != interfaces.UnionType_All {
 			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
@@ -298,13 +526,74 @@ func validateUnionNode(ctx context.Context, category string, node *interfaces.Lo
 		}
 	}
 
-	// TODO 校验 output_fields 中每个字段的 FromList 长度是否与 inputs 长度一致
-	if category == interfaces.ResourceCategoryTable {
-		for _, field := range node.OutputFields {
-			if len(field.FromList) != len(node.Inputs) {
+	// 校验输出字段不能为空
+	if len(node.OutputFields) == 0 {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+			WithErrorDetails("Union node must have output fields")
+	}
+
+	// 校验输出字段格式：union节点只支持对齐模式
+	// 先获取所有输入节点的输出字段
+	nodeCache := make(map[string]map[string]*interfaces.Property)
+	inputFieldsMap := make(map[string]map[string]*interfaces.Property)
+	for _, inputID := range node.Inputs {
+		fieldsMap, err := getNodeOutputFieldsMap(ctx, rs, inputID, allNodes, nodeCache)
+		if err != nil {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+				WithErrorDetails(fmt.Sprintf("Failed to get output fields from input node '%s': %v", inputID, err))
+		}
+		inputFieldsMap[inputID] = fieldsMap
+	}
+
+	for _, field := range node.OutputFields {
+		// Union节点不支持通配符模式
+		if field.Name == "*" {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+				WithErrorDetails("Union node does not support wildcard field '*'")
+		}
+
+		// 对齐模式：必须有 FromList 配置
+		if len(field.FromList) == 0 {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+				WithErrorDetails(fmt.Sprintf("Union node output field '%s' must have 'from_list' configuration", field.Name))
+		}
+
+		// 对齐模式：不应有单独的 from 和 from_node 配置（除非在FromList中使用）
+		if field.From != "" || field.FromNode != "" {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+				WithErrorDetails(fmt.Sprintf("Union node output field '%s' should not have 'from' or 'from_node' at field level, use 'from_list' instead", field.Name))
+		}
+
+		// 校验 FromList 长度是否与 inputs 长度一致
+		if len(field.FromList) != len(node.Inputs) {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+				WithErrorDetails(fmt.Sprintf("The union output field '%s' from list count (%d) not equal inputs count (%d)",
+					field.Name, len(field.FromList), len(node.Inputs)))
+		}
+
+		// 校验 FromList 中的每个引用是否都指向有效的输入节点和字段
+		for _, ref := range field.FromList {
+			found := false
+			for _, inputNode := range node.Inputs {
+				if inputNode == ref.FromNode {
+					found = true
+					break
+				}
+			}
+			if !found {
 				return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
-					WithErrorDetails(fmt.Sprintf("The union output field '%s' from list count (%d) not equal inputs count (%d)",
-						field.Name, len(field.FromList), len(node.Inputs)))
+					WithErrorDetails(fmt.Sprintf("Union node output field '%s' references non-existent input node '%s' in from_list", field.Name, ref.FromNode))
+			}
+
+			// 校验 from 字段是否存在于源节点中
+			if ref.From != "" {
+				if sourceFields, ok := inputFieldsMap[ref.FromNode]; ok {
+					if _, exists := sourceFields[ref.From]; !exists {
+						return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+							WithErrorDetails(fmt.Sprintf("Union node output field '%s' references non-existent field '%s' in node '%s'",
+								field.Name, ref.From, ref.FromNode))
+					}
+				}
 			}
 		}
 	}
@@ -312,7 +601,8 @@ func validateUnionNode(ctx context.Context, category string, node *interfaces.Lo
 	return nil
 }
 
-func validateSqlNode(ctx context.Context, node *interfaces.LogicDefinitionNode, nodeMap map[string]struct{}) error {
+func validateSqlNode(ctx context.Context, rs *resourceService, node *interfaces.LogicDefinitionNode,
+	allNodes []*interfaces.LogicDefinitionNode, nodeMap map[string]struct{}) error {
 	// 输入节点不能为空
 	if len(node.Inputs) == 0 {
 		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
@@ -351,10 +641,36 @@ func validateSqlNode(ctx context.Context, node *interfaces.LogicDefinitionNode, 
 			WithErrorDetails("The logic definition sql config is invalid, sql must be set")
 	}
 
+	// 校验输出字段不能为空
+	if len(node.OutputFields) == 0 {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+			WithErrorDetails("SQL node must have output fields")
+	}
+
+	// 校验输出字段格式：sql节点支持定义模式和通配符模式
+	for _, field := range node.OutputFields {
+		// 通配符模式：只允许 "*"
+		if field.Name == "*" {
+			// 通配符模式下，不应有其他字段配置（但允许 type 用于类型推断）
+			if field.From != "" || field.FromNode != "" || len(field.FromList) > 0 {
+				return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+					WithErrorDetails("Wildcard field '*' in SQL node should not have from, from_node or from_list configuration")
+			}
+			continue
+		}
+
+		// 定义模式：不应有映射或对齐配置（SQL节点自行定义字段）
+		if field.From != "" || field.FromNode != "" || len(field.FromList) > 0 {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+				WithErrorDetails(fmt.Sprintf("SQL node output field '%s' should not have from, from_node or from_list configuration", field.Name))
+		}
+	}
+
 	return nil
 }
 
-func validateOutputNode(ctx context.Context, node *interfaces.LogicDefinitionNode, nodeMap map[string]struct{}) error {
+func validateOutputNode(ctx context.Context, rs *resourceService, node *interfaces.LogicDefinitionNode,
+	allNodes []*interfaces.LogicDefinitionNode, nodeMap map[string]struct{}) error {
 	// 输入节点只能有一个
 	if len(node.Inputs) != 1 {
 		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
@@ -368,15 +684,47 @@ func validateOutputNode(ctx context.Context, node *interfaces.LogicDefinitionNod
 			WithErrorDetails(fmt.Sprintf("The output node input '%s' is not exist", inputNode))
 	}
 
-	// 如果没传fields字段列表，默认使用output节点的输出字段
 	if len(node.OutputFields) == 0 {
 		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
 			WithErrorDetails("The output node must have output fields")
 	}
 
+	// 校验输出字段格式：output节点支持通配符模式和投影模式
+	// 获取输入节点的输出字段
+	nodeCache := make(map[string]map[string]*interfaces.Property)
+	inputNodeID := node.Inputs[0]
+	inputFieldsMap, err := getNodeOutputFieldsMap(ctx, rs, inputNodeID, allNodes, nodeCache)
+	if err != nil {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+			WithErrorDetails(fmt.Sprintf("Failed to get output fields from input node '%s': %v", inputNodeID, err))
+	}
+
+	for _, field := range node.OutputFields {
+		// 通配符模式：只允许 "*"
+		if field.Name == "*" {
+			// 通配符模式下，不应有其他字段配置
+			if field.Type != "" || field.From != "" || field.FromNode != "" || len(field.FromList) > 0 {
+				return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+					WithErrorDetails("Wildcard field '*' should not have additional configuration")
+			}
+			continue
+		}
+
+		// 投影模式：只允许字段名，不应有映射或对齐配置
+		if field.From != "" || field.FromNode != "" || len(field.FromList) > 0 {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+				WithErrorDetails(fmt.Sprintf("Output node field '%s' should not have from, from_node or from_list configuration", field.Name))
+		}
+
+		// 校验字段是否存在于输入节点中
+		if _, ok := inputFieldsMap[field.Name]; !ok {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+				WithErrorDetails(fmt.Sprintf("Output node field '%s' is not in the input node '%s' output fields", field.Name, inputNodeID))
+		}
+	}
+
 	// 校验name不能重复，display_name 不能重复
 	nameMap := make(map[string]struct{})
-	// originalNameMap := make(map[string]struct{})
 	displayNameMap := make(map[string]struct{})
 	for _, field := range node.OutputFields {
 		if _, ok := nameMap[field.Name]; ok {
@@ -384,12 +732,6 @@ func validateOutputNode(ctx context.Context, node *interfaces.LogicDefinitionNod
 				WithErrorDetails("The output node field name is repeated")
 		}
 		nameMap[field.Name] = struct{}{}
-
-		// if _, ok := originalNameMap[field.OriginalName]; ok {
-		// 	return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
-		// 		WithErrorDetails("The output node field original_name is repeated")
-		// }
-		// originalNameMap[field.OriginalName] = struct{}{}
 
 		if _, ok := displayNameMap[field.DisplayName]; ok {
 			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).

--- a/adp/vega/vega-backend/server/logics/resource/logic_view.go
+++ b/adp/vega/vega-backend/server/logics/resource/logic_view.go
@@ -9,7 +9,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"regexp"
 	"slices"
+	"strings"
 
 	"github.com/dlclark/regexp2"
 	"github.com/kweaver-ai/TelemetrySDK-Go/exporter/v2/ar_trace"
@@ -641,6 +643,11 @@ func validateSqlNode(ctx context.Context, rs *resourceService, node *interfaces.
 			WithErrorDetails("The logic definition sql config is invalid, sql must be set")
 	}
 
+	// 校验 SQL 语法是否正确
+	if err := validateSQLSyntax(ctx, cfg.SQL); err != nil {
+		return err
+	}
+
 	// 校验输出字段不能为空
 	if len(node.OutputFields) == 0 {
 		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
@@ -1100,4 +1107,110 @@ func fillMissingMetadata(target, source *interfaces.Property) {
 	if len(target.Features) == 0 {
 		target.Features = source.Features
 	}
+}
+
+// validateSQLSyntax 校验 SQL 语法是否正确
+// 1. 先将 SQL 中的变量（如 .node1）替换为占位符
+// 2. 再使用标准 SQL 语法规则校验
+func validateSQLSyntax(ctx context.Context, sql string) error {
+	if sql == "" {
+		return nil // 空 SQL 已在前面的校验中处理
+	}
+
+	// 步骤 1: 替换 SQL 中的变量（如 .node1, .node2 等）为占位符
+	// 匹配模式：点后跟标识符，例如 .node1, .my_table
+	nodeVarRegex := regexp.MustCompile(`\.[a-zA-Z_][a-zA-Z0-9_]*`)
+	cleanedSQL := nodeVarRegex.ReplaceAllString(sql, " placeholder_table ")
+
+	// 步骤 2: 标准 SQL 语法校验
+	// 2.1 检查是否以 SELECT 或 WITH 开头
+	trimmedSQL := strings.TrimSpace(strings.ToUpper(cleanedSQL))
+	if !strings.HasPrefix(trimmedSQL, "SELECT") && !strings.HasPrefix(trimmedSQL, "WITH") {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+			WithErrorDetails("SQL must start with SELECT or WITH clause")
+	}
+
+	// 2.2 检查括号是否匹配
+	openParen := strings.Count(cleanedSQL, "(")
+	closeParen := strings.Count(cleanedSQL, ")")
+	if openParen != closeParen {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+			WithErrorDetails(fmt.Sprintf("Unbalanced parentheses: %d opening vs %d closing", openParen, closeParen))
+	}
+
+	// 2.3 检查常见的语法错误
+	if err := checkCommonSQLErrors(ctx, cleanedSQL); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// checkCommonSQLErrors 检查常见的 SQL 语法错误
+func checkCommonSQLErrors(ctx context.Context, sql string) error {
+	upperSQL := strings.ToUpper(sql)
+	trimmedSQL := strings.TrimSpace(sql)
+
+	// 检查重复的关键字
+	duplicatePatterns := []struct {
+		pattern *regexp.Regexp
+		message string
+	}{
+		{regexp.MustCompile(`\bFROM\s+FROM\b`), "Duplicate FROM keyword"},
+		{regexp.MustCompile(`\bSELECT\s+SELECT\b`), "Duplicate SELECT keyword"},
+		{regexp.MustCompile(`\bWHERE\s+WHERE\b`), "Duplicate WHERE keyword"},
+		{regexp.MustCompile(`\bJOIN\s+JOIN\b`), "Duplicate JOIN keyword"},
+		{regexp.MustCompile(`\bGROUP\s+BY\s+BY\b`), "Duplicate BY in GROUP BY"},
+		{regexp.MustCompile(`\bORDER\s+BY\s+BY\b`), "Duplicate BY in ORDER BY"},
+	}
+
+	for _, dp := range duplicatePatterns {
+		if dp.pattern.MatchString(upperSQL) {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+				WithErrorDetails(fmt.Sprintf("SQL syntax error: %s", dp.message))
+		}
+	}
+
+	// 检查 FROM 后是否有表名（优先检查）
+	fromWithoutTable := regexp.MustCompile(`(?i)\bFROM\s*$`)
+	if fromWithoutTable.MatchString(trimmedSQL) {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+			WithErrorDetails("SQL syntax error: FROM clause must specify a table")
+	}
+
+	// 检查 SELECT 后是否有 FROM（简单检查）
+	if strings.HasPrefix(upperSQL, "SELECT") {
+		// 检查是否包含 FROM 关键字
+		if !strings.Contains(upperSQL, " FROM ") && !strings.HasSuffix(upperSQL, " FROM") {
+			// 检查是否是 SELECT * 或 SELECT 1 这种简单形式（不含 FROM）
+			simpleSelectRegex := regexp.MustCompile(`(?i)^SELECT\s+[*\d]+\s*$`)
+			if !simpleSelectRegex.MatchString(trimmedSQL) {
+				return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+					WithErrorDetails("SQL syntax error: SELECT statement must contain a FROM clause")
+			}
+		}
+	}
+
+	// 检查 WHERE 后是否有条件
+	whereWithoutCondition := regexp.MustCompile(`(?i)\bWHERE\s*$`)
+	if whereWithoutCondition.MatchString(trimmedSQL) {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+			WithErrorDetails("SQL syntax error: WHERE clause must have a condition")
+	}
+
+	// 检查 GROUP BY 后是否有列名
+	groupByWithoutColumn := regexp.MustCompile(`(?i)\bGROUP\s+BY\s*$`)
+	if groupByWithoutColumn.MatchString(trimmedSQL) {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+			WithErrorDetails("SQL syntax error: GROUP BY must have at least one column")
+	}
+
+	// 检查 ORDER BY 后是否有列名
+	orderByWithoutColumn := regexp.MustCompile(`(?i)\bORDER\s+BY\s*$`)
+	if orderByWithoutColumn.MatchString(trimmedSQL) {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_LogicView_InvalidParameter_LogicDefinition).
+			WithErrorDetails("SQL syntax error: ORDER BY must have at least one column")
+	}
+
+	return nil
 }

--- a/adp/vega/vega-backend/server/logics/resource/logic_view_sql_test.go
+++ b/adp/vega/vega-backend/server/logics/resource/logic_view_sql_test.go
@@ -1,0 +1,190 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package resource
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestValidateSQLSyntax(t *testing.T) {
+	tests := []struct {
+		name          string
+		sql           string
+		expectError   bool
+		errorContains string // 期望的错误消息包含的内容
+	}{
+		// 有效的 SQL 语句（包含变量 .nodeX，会被替换为占位符）
+		{
+			name:        "valid SQL with node variable",
+			sql:         "SELECT * FROM .node1",
+			expectError: false,
+		},
+		{
+			name:        "valid SQL with multiple node variables",
+			sql:         "SELECT .node1.id, .node2.name FROM .node1 JOIN .node2 ON .node1.id = .node2.user_id",
+			expectError: false,
+		},
+		{
+			name:        "valid SQL with node variable in subquery",
+			sql:         "SELECT * FROM (SELECT id, name FROM .node1) AS subq",
+			expectError: false,
+		},
+		{
+			name:        "valid SQL with node variable and WHERE",
+			sql:         "SELECT * FROM .node1 WHERE .node1.age > 18",
+			expectError: false,
+		},
+		{
+			name:        "valid SQL with node variable and GROUP BY",
+			sql:         "SELECT .node1.department, COUNT(*) FROM .node1 GROUP BY .node1.department",
+			expectError: false,
+		},
+		{
+			name:        "valid SQL with node variable and ORDER BY",
+			sql:         "SELECT * FROM .node1 ORDER BY .node1.created_at DESC LIMIT 10",
+			expectError: false,
+		},
+
+		// 有效的标准 SQL 语句（不含变量）
+		{
+			name:        "valid simple SELECT",
+			sql:         "SELECT * FROM users",
+			expectError: false,
+		},
+		{
+			name:        "valid SELECT with columns",
+			sql:         "SELECT id, name, email FROM users WHERE age > 18",
+			expectError: false,
+		},
+		{
+			name:        "valid SELECT with JOIN",
+			sql:         "SELECT u.id, o.total FROM users u JOIN orders o ON u.id = o.user_id",
+			expectError: false,
+		},
+		{
+			name:        "valid SQL with GROUP BY",
+			sql:         "SELECT department, COUNT(*) FROM employees GROUP BY department",
+			expectError: false,
+		},
+		{
+			name:        "valid SQL with ORDER BY",
+			sql:         "SELECT * FROM users ORDER BY created_at DESC LIMIT 10",
+			expectError: false,
+		},
+		{
+			name:        "valid SQL with subquery",
+			sql:         "SELECT * FROM (SELECT id, name FROM users) AS subq",
+			expectError: false,
+		},
+		{
+			name:        "valid SQL with DISTINCT",
+			sql:         "SELECT DISTINCT name FROM users",
+			expectError: false,
+		},
+		{
+			name:        "valid SQL with WITH clause",
+			sql:         "WITH temp AS (SELECT * FROM users) SELECT * FROM temp",
+			expectError: false,
+		},
+		{
+			name:        "empty SQL",
+			sql:         "",
+			expectError: false,
+		},
+
+		// 无效的 SQL 语句 - 语法错误
+		{
+			name:          "invalid SQL - double FROM",
+			sql:           "SELECT * FROM FROM users",
+			expectError:   true,
+			errorContains: "Duplicate FROM",
+		},
+		{
+			name:          "invalid SQL - double SELECT",
+			sql:           "SELECT SELECT * FROM users",
+			expectError:   true,
+			errorContains: "Duplicate SELECT",
+		},
+		{
+			name:          "invalid SQL - missing table after FROM",
+			sql:           "SELECT * FROM",
+			expectError:   true,
+			errorContains: "FROM clause must specify a table",
+		},
+		{
+			name:          "invalid SQL - unclosed parenthesis",
+			sql:           "SELECT * FROM users WHERE (id = 1",
+			expectError:   true,
+			errorContains: "Unbalanced parentheses",
+		},
+		{
+			name:          "invalid SQL - extra closing parenthesis",
+			sql:           "SELECT * FROM users WHERE id = 1)",
+			expectError:   true,
+			errorContains: "Unbalanced parentheses",
+		},
+		{
+			name:          "invalid SQL - missing SELECT keyword",
+			sql:           "* FROM users",
+			expectError:   true,
+			errorContains: "must start with SELECT",
+		},
+		{
+			name:          "invalid SQL - WHERE without condition",
+			sql:           "SELECT * FROM users WHERE",
+			expectError:   true,
+			errorContains: "WHERE clause must have a condition",
+		},
+		{
+			name:          "invalid SQL - GROUP BY without column",
+			sql:           "SELECT * FROM users GROUP BY",
+			expectError:   true,
+			errorContains: "GROUP BY must have at least one column",
+		},
+		{
+			name:          "invalid SQL - ORDER BY without column",
+			sql:           "SELECT * FROM users ORDER BY",
+			expectError:   true,
+			errorContains: "ORDER BY must have at least one column",
+		},
+		{
+			name:          "invalid SQL - dot notation without table",
+			sql:           "SELECT * FROM FROM .node1",
+			expectError:   true,
+			errorContains: "Duplicate FROM",
+		},
+		{
+			name:          "invalid SQL - SELECT without FROM",
+			sql:           "SELECT id, name",
+			expectError:   true,
+			errorContains: "must contain a FROM clause",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			err := validateSQLSyntax(ctx, tt.sql)
+
+			if tt.expectError && err == nil {
+				t.Errorf("expected error but got nil for SQL: %s", tt.sql)
+			}
+
+			if !tt.expectError && err != nil {
+				t.Errorf("unexpected error for SQL: %s, error: %v", tt.sql, err)
+			}
+
+			// 检查错误消息是否包含期望的内容
+			if tt.expectError && err != nil && tt.errorContains != "" {
+				if !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("expected error to contain '%s', but got: %v", tt.errorContains, err)
+				}
+			}
+		})
+	}
+}

--- a/adp/vega/vega-backend/server/logics/resource_data/logic_view/dsl/dsl.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/logic_view/dsl/dsl.go
@@ -23,22 +23,31 @@ type logicViewDSLGenerator struct {
 	nodes         map[string]*interfaces.LogicDefinitionNode
 	outputNode    *interfaces.LogicDefinitionNode
 	nodeFieldsMap map[string]map[string]*interfaces.ViewProperty
+	viewFieldMap  map[string]*interfaces.Property
 }
 
 // NewlogicViewSQLGenerator 创建SQL生成器
-func NewlogicViewDSLGenerator(nodes []*interfaces.LogicDefinitionNode) *logicViewDSLGenerator {
+func NewlogicViewDSLGenerator(view *interfaces.LogicView) *logicViewDSLGenerator {
 	nodeMap := make(map[string]*interfaces.LogicDefinitionNode)
 	var outputNode *interfaces.LogicDefinitionNode
+	nodes := view.LogicDefinition
 	for i := range nodes {
 		nodeMap[nodes[i].ID] = nodes[i]
 		if nodes[i].Type == interfaces.LogicDefinitionNodeType_Output {
 			outputNode = nodes[i]
 		}
 	}
+
+	viewFieldMap := make(map[string]*interfaces.Property)
+	for _, field := range view.SchemaDefinition {
+		viewFieldMap[field.Name] = field
+	}
+
 	return &logicViewDSLGenerator{
 		nodes:         nodeMap,
 		outputNode:    outputNode,
 		nodeFieldsMap: make(map[string]map[string]*interfaces.ViewProperty),
+		viewFieldMap:  viewFieldMap,
 	}
 }
 
@@ -65,7 +74,7 @@ func (g *logicViewDSLGenerator) BuildDSL(ctx context.Context, query interfaces.R
 			}
 
 			sortFieldName := sp.Field
-			sortField, ok := view.FieldsMap[sp.Field]
+			sortField, ok := g.viewFieldMap[sp.Field]
 
 			if ok {
 				if sortField.Type == interfaces.DataType_Binary {
@@ -122,7 +131,7 @@ func (g *logicViewDSLGenerator) BuildDSL(ctx context.Context, query interfaces.R
 	dsl.Query = queryDSL.Query
 
 	// 添加全局过滤条件，全局过滤条件的字段应该在视图字段列表里
-	dsl, err = addGlobalFiltersToDSL(ctx, dsl, query.FilterCondCfg, view.FieldsMap)
+	dsl, err = addGlobalFiltersToDSL(ctx, dsl, query.FilterCondCfg, g.viewFieldMap)
 	if err != nil {
 		return dsl, rest.NewHTTPError(ctx, http.StatusInternalServerError,
 			rest.PublicError_InternalServerError).
@@ -182,7 +191,7 @@ func (g *logicViewDSLGenerator) buildResourceQuery(ctx context.Context, node *in
 
 // 添加全局过滤条件到DSL
 func addGlobalFiltersToDSL(ctx context.Context, dsl interfaces.DSLCfg, filters *interfaces.FilterCondCfg,
-	fieldsMap map[string]*interfaces.ViewProperty) (interfaces.DSLCfg, error) {
+	fieldsMap map[string]*interfaces.Property) (interfaces.DSLCfg, error) {
 	// condStr, needScore, err := buildDSLCondition(ctx, filters, fieldsMap)
 	// if err != nil {
 	// 	return dsl, err
@@ -311,12 +320,12 @@ func completeDSLSortParams(sort []*interfaces.SortField, queryType string) []*in
 }
 
 // 检查字段是否为 text 类型
-func IsTextType(fieldInfo *interfaces.ViewProperty) bool {
+func IsTextType(fieldInfo *interfaces.Property) bool {
 	return fieldInfo != nil && fieldInfo.Type == interfaces.DataType_Text
 }
 
 // 检查字段特征是否包含指定特征
-func HasFeature(fieldInfo *interfaces.ViewProperty, feature string) bool {
+func HasFeature(fieldInfo *interfaces.Property, feature string) bool {
 	for _, f := range fieldInfo.Features {
 		if f.FeatureType == feature {
 			return true

--- a/adp/vega/vega-backend/server/logics/resource_data/logic_view/logic_view.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/logic_view/logic_view.go
@@ -247,7 +247,7 @@ func (lvs *logicViewService) executeCompositeViewByDSL(ctx context.Context, view
 		return nil, 0, nil
 	}
 
-	generator := lvdsl.NewlogicViewDSLGenerator(view.LogicDefinition)
+	generator := lvdsl.NewlogicViewDSLGenerator(view)
 	dsl, httpErr := generator.BuildDSL(ctx, *params, view, viewIndicesMap)
 	if httpErr != nil {
 		span.SetStatus(codes.Error, "Convert to DSL failed")
@@ -350,23 +350,24 @@ func (lvs *logicViewService) executeCompositeViewBySQL(ctx context.Context, view
 	logger.Infof("executeCompositeViewBySQL Final SQL: [%s]", finalSql)
 
 	if view.IsSingleSource {
-		// var resourceType string
-		// for _, ref := range view.RefResources {
-		// 	catalog, err := lvs.cs.GetByID(ctx, ref.CatalogID, true)
-		// 	if err != nil {
-		// 		return nil, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_Resource_InternalError).
-		// 			WithErrorDetails(fmt.Sprintf("failed to get catalog: %v", err))
-		// 	}
-		// 	if catalog == nil {
-		// 		return nil, 0, rest.NewHTTPError(ctx, http.StatusNotFound, verrors.VegaBackend_Resource_CatalogNotFound).
-		// 			WithErrorDetails(fmt.Sprintf("catalog %s not found", ref.CatalogID))
-		// 	}
-		// 	resourceType = catalog.ConnectorType
-		// 	break
-		// }
+		var resourceType string
+		for _, ref := range view.RefResources {
+			catalog, err := lvs.cs.GetByID(ctx, ref.CatalogID, true)
+			if err != nil {
+				return nil, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_Resource_InternalError).
+					WithErrorDetails(fmt.Sprintf("failed to get catalog: %v", err))
+			}
+			if catalog == nil {
+				return nil, 0, rest.NewHTTPError(ctx, http.StatusNotFound, verrors.VegaBackend_Resource_CatalogNotFound).
+					WithErrorDetails(fmt.Sprintf("catalog %s not found", ref.CatalogID))
+			}
+			resourceType = catalog.ConnectorType
+			break
+		}
 
 		req := interfaces.SQLQueryRequest{
 			Query:        finalSql,
+			ResourceType: resourceType,
 			QueryType:    params.QueryType,
 			StreamSize:   params.Limit,
 			QueryTimeout: int(params.Timeout),

--- a/adp/vega/vega-backend/server/logics/resource_data/logic_view/sql/sql.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/logic_view/sql/sql.go
@@ -32,6 +32,7 @@ type logicViewSQLGenerator struct {
 	sqls          map[string]cachedSql
 	nodeFieldsMap map[string]map[string]*interfaces.ViewProperty
 	RefResources  map[string]*interfaces.Resource
+	viewFieldMap  map[string]*interfaces.Property
 }
 
 // NewlogicViewSQLGenerator 创建SQL生成器
@@ -45,12 +46,19 @@ func NewlogicDefinitionSQLGenerator(view *interfaces.LogicView) *logicViewSQLGen
 			outputNode = nodes[i]
 		}
 	}
+
+	viewFieldMap := make(map[string]*interfaces.Property)
+	for _, field := range view.SchemaDefinition {
+		viewFieldMap[field.Name] = field
+	}
+
 	return &logicViewSQLGenerator{
 		nodes:         nodeMap,
 		outputNode:    outputNode,
 		sqls:          make(map[string]cachedSql),
 		nodeFieldsMap: make(map[string]map[string]*interfaces.ViewProperty),
 		RefResources:  view.RefResources,
+		viewFieldMap:  viewFieldMap,
 	}
 }
 
@@ -298,7 +306,7 @@ func (g *logicViewSQLGenerator) buildJoinNodeSQL(ctx context.Context, node *inte
 	allArgs = append(allArgs, leftArgs...)
 	allArgs = append(allArgs, rightArgs...)
 
-	sqlStr := fmt.Sprintf("SELECT %s FROM (%s) AS l %s JOIN (%s) AS r ON %s",
+	sqlStr := fmt.Sprintf("SELECT %s FROM ((%s) AS l %s JOIN (%s) AS r ON %s)",
 		strings.Join(fields, ", "), leftSQL, joinType, rightSQL, joinOn)
 
 	// 处理 Join 节点自身的过滤条件
@@ -587,15 +595,35 @@ func (g *logicViewSQLGenerator) buildOutputNodeSQL(ctx context.Context, node *in
 		return "", nil, fmt.Errorf("output node %s requires exactly one input node", node.ID)
 	}
 
-	// 维护状态
+	// 构建 SELECT 字段列表
+	var fields []string
 	outputFieldsMap := make(map[string]*interfaces.ViewProperty)
-	for _, field := range node.OutputFields {
-		outputFieldsMap[field.Name] = field
+	if len(node.OutputFields) > 0 {
+		fields = make([]string, 0, len(node.OutputFields))
+		for _, f := range node.OutputFields {
+			outputFieldsMap[f.Name] = f // 维护状态
+
+			sourceProp, ok := g.viewFieldMap[f.Name]
+			if !ok {
+				fields = append(fields, QuotationMark(f.Name))
+			} else {
+				if sourceProp.OriginalName != "" && sourceProp.OriginalName != f.Name {
+					// 使用 QuotationMark 替代硬编码引号，支持多数据库
+					fields = append(fields, fmt.Sprintf("%s AS %s",
+						QuotationMark(sourceProp.OriginalName),
+						QuotationMark(f.Name)))
+				} else {
+					fields = append(fields, QuotationMark(f.Name))
+				}
+			}
+		}
+	} else {
+		fields = []string{"*"}
 	}
 	g.nodeFieldsMap[node.ID] = outputFieldsMap
 
-	inputNodeID := node.Inputs[0]
-	return g.buildNodeSQL(ctx, inputNodeID, depth)
+	sql, args, err := g.buildNodeSQL(ctx, node.Inputs[0], depth)
+	return "SELECT " + strings.Join(fields, ", ") + " FROM (" + sql + ") AS " + sanitizeAlias(node.ID), args, err
 }
 
 // 构建sort

--- a/adp/vega/vega-backend/server/logics/resource_data/logic_view/sql/sql.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/logic_view/sql/sql.go
@@ -607,19 +607,40 @@ func (g *logicViewSQLGenerator) buildOutputNodeSQL(ctx context.Context, node *in
 	outputFieldsMap := make(map[string]*interfaces.ViewProperty)
 	if len(node.OutputFields) > 0 {
 		fields = make([]string, 0, len(node.OutputFields))
+
+		// 先构建上游节点的 SQL，以便获取上游节点的输出字段映射
+		upstreamNodeID := node.Inputs[0]
+		_, _, err := g.buildNodeSQL(ctx, upstreamNodeID, depth)
+		if err != nil {
+			return "", nil, fmt.Errorf("failed to build upstream node SQL for output node %s: %w", node.ID, err)
+		}
+
+		// 从上游节点的输出字段映射中获取字段信息
+		upstreamFieldsMap, hasUpstreamFields := g.nodeFieldsMap[upstreamNodeID]
+
 		for _, f := range node.OutputFields {
 			outputFieldsMap[f.Name] = f // 维护状态
 
-			sourceProp, ok := g.viewFieldMap[f.Name]
-			if !ok {
+			// 尝试从上游节点的输出字段中查找
+			var sourceField *interfaces.ViewProperty
+			if hasUpstreamFields {
+				sourceField = upstreamFieldsMap[f.Name]
+			}
+
+			if sourceField == nil {
+				// 如果上游没有字段映射，直接使用字段名
 				fields = append(fields, QuotationMark(f.Name))
 			} else {
-				if sourceProp.OriginalName != "" && sourceProp.OriginalName != f.Name {
-					// 使用 QuotationMark 替代硬编码引号，支持多数据库
+				// 使用上游节点的输出字段名（可能已经被重命名）
+				// sourceField.Name 是上游节点输出的字段名（别名）
+				// f.Name 是当前节点期望的输出字段名
+				if sourceField.Name != f.Name {
+					// 字段名不同，需要别名
 					fields = append(fields, fmt.Sprintf("%s AS %s",
-						QuotationMark(sourceProp.OriginalName),
+						QuotationMark(sourceField.Name),
 						QuotationMark(f.Name)))
 				} else {
+					// 字段名相同，直接使用
 					fields = append(fields, QuotationMark(f.Name))
 				}
 			}

--- a/adp/vega/vega-backend/server/logics/resource_data/logic_view/sql/sql.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/logic_view/sql/sql.go
@@ -512,7 +512,14 @@ func (g *logicViewSQLGenerator) buildSqlNodeSQL(ctx context.Context, node *inter
 		return "", nil, fmt.Errorf("failed to execute SQL template for node %s: %w", node.ID, err)
 	}
 
-	return result.String(), allArgs, nil
+	// 去除 SQL 结尾的分号（可能有多个分号或空格）
+	finalSQL := strings.TrimSpace(result.String())
+	for strings.HasSuffix(finalSQL, ";") {
+		finalSQL = strings.TrimSuffix(finalSQL, ";")
+		finalSQL = strings.TrimSpace(finalSQL)
+	}
+
+	return finalSQL, allArgs, nil
 }
 
 // sanitizeAlias 清理节点 ID 生成合法的 SQL 别名


### PR DESCRIPTION
## 📋 Pull Request 描述

### 1. 变更说明（Purpose）
> 这个 PR 解决了什么问题、实现了什么功能？

- **解决的问题**：修复 Logic View 功能中的多个 bug，包括 SQL 拼接错误、配置校验缺失、output_fields 不生效等问题，并新增 SQL 语法校验功能
- **实现功能**：
  - 修复 output 节点上游字段重命名后 SQL 拼接错误
  - 修复自定义 SQL 语句包含分号时的解析错误
  - 补充 logic definition 的完整配置校验逻辑（+371 行）
  - 修复 output 节点指定 output_fields 不生效的问题
  - 新增 SQL 语法校验功能：支持变量替换和标准 SQL 语法规则校验（+113 行代码 + 190 行测试）
- **关联 Issue**：#240

### 2. 修改类型（Type of Change）
- [ ] 新功能 (Feature)
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [x] 文档更新
- [x] 测试用例
- [ ] 依赖升级
- [ ] 样式/UI 调整

### 3. 实现方案（How & Why）
> 关键逻辑、技术方案、为什么这么改

### 核心修改点：

**1. SQL 语法校验功能（新增）** (`logic_view.go` +113 行, `logic_view_sql_test.go` +190 行)
- 实现基于规则的 SQL 语法校验器，不依赖外部解析器
- 支持自动替换节点变量（如 `.node1`, `.node2`）为占位符
- 校验规则包括：
  - SQL 必须以 SELECT 或 WITH 开头
  - 括号必须匹配
  - 检测重复关键字（FROM FROM, SELECT SELECT 等）
  - FROM 后必须有表名
  - SELECT 必须包含 FROM 子句
  - WHERE/GROUP BY/ORDER BY 后必须有条件/列名
- 包含 26 个测试用例，覆盖有效和无效 SQL 场景

**2. SQL 生成逻辑优化** (`sql/sql.go` +70/-62 行)
- 修复字段重命名映射逻辑，确保上游节点字段别名正确传递到下游节点
- 改进 SQL 解析器，支持包含分号的自定义 SQL 语句
- 优化 output_fields 的处理逻辑

**3. 配置校验增强** (`resource/logic_view.go` +371 行)
- 新增完整的 logic definition 配置校验规则
- 验证节点配置的完整性和一致性
- 提前拦截非法配置，避免运行时错误
- 增加对字段映射、节点依赖关系的校验

**4. DSL 解析改进** (`dsl/dsl.go` +21/-30 行)
- 优化 DSL 到 SQL 的转换逻辑
- 修复 output 节点字段映射问题，确保字段名称正确传递

**5. 服务层调整** (`logic_view_service.go` +5/-1 行)
- 调整 output 字段处理逻辑，配合底层 SQL 生成修复

**6. 配置文件还原** (`vega-backend-config.yaml` +2/-1 行)
- 还原配置文件到正确状态

**7. 文档更新** (`VEGA_Part8_LogicView.md` +7 行)
- 修复和更新 Logic View 相关文档

### 4. 自测清单（Self Check）
- [x] 本地编译/运行通过
- [x] 新增/修改了测试用例（26 个 SQL 语法校验测试）
- [x] 已验证功能正常
- [x] 无日志/异常/报错
- [x] 兼容相关场景

### 5. 变更文件清单

```
adp/docs/design/vega/features/vega-backend/VEGA_Part8_LogicView.md          |   7 +-
adp/vega/vega-backend/server/config/vega-backend-config.yaml                |   2 +-
adp/vega/vega-backend/server/interfaces/logic_view_service.go               |   5 +-
adp/vega/vega-backend/server/logics/resource/logic_view.go                  | 513 ++++++++-
adp/vega/vega-backend/server/logics/resource/logic_view_sql_test.go         | 190 +++
adp/vega/vega-backend/server/logics/resource_data/logic_view/dsl/dsl.go     |  21 +-
adp/vega/vega-backend/server/logics/resource_data/logic_view/logic_view.go  |  31 +-
adp/vega/vega-backend/server/logics/resource_data/logic_view/sql/sql.go     |  70 +-
```

**统计**：8 files changed, 776 insertions(+), 63 deletions(-)

### 提交历史

```
5713a437 [fix]添加sql语法的一些基础校验
10a9bf5e [docs]fix docs
76406cb5 [fix]fix output节点上游节点字段重命名之后拼接sql出错
24bc2f3e [fix]修复自定义sql语句包含分号报错的问题
e3cf5044 [fix]补充logic definition 配置校验
192b681d [fix]还原config文件
fed6ffd8 [fix]fix ouput节点指定 output_fields不生效的问题
ea4878ee cf
```

### 6. 检查项（Reviewer 用）
- [ ] 代码逻辑清晰
- [ ] 命名规范、无冗余代码
- [ ] 安全/权限无问题
- [ ] 符合团队编码规范
- [ ] 合并不会影响主分支

### 7. 备注（Notes）
> 需要注意的点、依赖、部署说明、风险点

**注意事项**：
- ⚠️ **配置校验逻辑有较大变更**（`logic_view.go` +371 行），建议仔细 review 新增的校验规则是否覆盖所有边界情况
- ⚠️ **SQL 生成逻辑有修改**（`sql/sql.go`），需确保不影响现有的 SQL 解析和生成功能，建议进行回归测试
- ✨ **新增 SQL 语法校验功能**：使用基于规则的校验器，支持变量替换，包含 26 个测试用例
- ⚠️ 包含 8 个 commits，其中 `ea4878ee cf` 提交信息不完整，建议 squash 合并以保持提交历史清晰
- 📝 主要影响模块：Vega Backend - Logic View 数据源配置和 SQL 生成
- 🎯 **风险等级**：中等（主要修复现有功能的 bug，但配置校验变更较大）

**测试建议**：
1. 测试上游节点字段重命名后，下游 output 节点 SQL 拼接是否正确
2. 测试包含分号的自定义 SQL 语句能否正常执行
3. 验证各种非法配置是否被正确拦截
4. 验证 output_fields 配置是否正确生效
5. 测试 SQL 语法校验功能（包含变量的 SQL、标准 SQL、语法错误的 SQL）