### PR TITLE
feat(catalog): 添加 ID 字段校验和健康状态映射

### DIFF
--- a/adp/docs/api/vega/vega-backend-api/README.md
+++ b/adp/docs/api/vega/vega-backend-api/README.md
@@ -1,0 +1,30 @@
+# Vega Backend API 文档
+
+> Vega Backend HTTP API 的 OpenAPI 3.1.1 定义。每个文件聚焦一个资源概念；跨资源的"便利端点"按"按谁过滤就归谁"的原则归属到对应资源文件，避免 schema 重复定义和文档撕裂。
+
+## 文件索引
+
+| 文件 | 资源 | 包含的端点 |
+|---|---|---|
+| [catalog.yaml](catalog.yaml) | Catalog | `GET/POST /catalogs`、`GET/PUT/DELETE /catalogs/{id(s)}`、`GET /catalogs/{ids}/health-status`、`POST /catalogs/{id}/test-connection` |
+| [connector-type.yaml](connector-type.yaml) | ConnectorType | `GET/POST /connector-types`、`GET/PUT/DELETE /connector-types/{type}`、`POST .../enable`、`POST .../disable` |
+| [discover-task.yaml](discover-task.yaml) | DiscoverTask | `POST /catalogs/{cid}/discover`（手动触发）、`GET /discover-tasks`、`GET /discover-tasks/{id}` |
+| [discover-schedule.yaml](discover-schedule.yaml) | DiscoverSchedule | `GET/POST /discover-schedules`、`GET/PUT/DELETE /discover-schedules/{sid}`、`POST .../enable`、`POST .../disable`、`GET /catalogs/{cid}/discover-schedules`（便利视图） |
+| [resource.yaml](resource.yaml) | Resource | `GET/POST /resources`、`GET/PUT/DELETE /resources/{id(s)}`、`GET /catalogs/{ids}/resources`（便利视图）、其它 dataset / buildtask 子端点 |
+| [query.yaml](query.yaml) | Query | `POST /query/execute`（结构化查询） |
+| [query-endpoints-comparison.md](query-endpoints-comparison.md) | — | 设计参考：查询相关端点的对比与归属说明（非 OpenAPI 文档） |
+
+## 约定
+
+- **OpenAPI 版本**：3.1.1。
+- **错误响应**：所有非 2xx 响应统一返回 `Error` schema（对应 `kweaver-go-lib/rest.BaseError`），各文件自含一份定义。
+- **内部接口**：`/api/vega-backend/in/v1/...` 与 `/api/vega-backend/v1/...` 一一对应，请求 / 响应结构完全一致；区别仅在鉴权方式（外部 OAuth Token，内部 Header `X-Account-ID` / `X-Account-Type`）。各文件仅描述外部接口，内部接口在 `info.description` 中统一说明。
+- **跨资源便利端点**：归属到"被过滤的目标资源"所在的文件。例如 `GET /catalogs/{cid}/discover-schedules` 是按 catalog 过滤 schedule，归 `discover-schedule.yaml`；`POST /catalogs/{cid}/discover` 创建 DiscoverTask 实例，归 `discover-task.yaml`。
+
+## 待生成
+
+以下文件尚未落地，待对应资源 / 设计稿评审通过后补全：
+
+- `discover-task.yaml`
+- `discover-schedule.yaml`（依赖 [discover_schedule_redesign.md](../../../design/vega/features/vega-backend/discover_schedule_redesign.md) 的重构落地）
+- `resource.yaml`

--- a/adp/docs/api/vega/vega-backend-api/catalog.yaml
+++ b/adp/docs/api/vega/vega-backend-api/catalog.yaml
@@ -1,0 +1,503 @@
+---
+openapi: 3.1.1
+info:
+  title: Catalog
+  description: |
+    Vega Backend Catalog（数据目录）API。
+
+    Catalog 是一个数据源连接的抽象，对应一个物理数据源（MySQL / OpenSearch / S3 等）
+    或逻辑目录（虚拟视图）。资源（`Resource`）按 catalog 归属注册。
+
+    本文件仅包含 catalog 自身的 CRUD 与状态相关端点。跨资源的便利端点：
+    - `POST /catalogs/{id}/discover`（手动发现一次） → 见 `discover-task.yaml`
+    - `GET /catalogs/{ids}/resources`（按 catalog 列资源） → 见 `resource.yaml`
+    - `GET /catalogs/{cid}/discover-schedules`（按 catalog 列调度） → 见 `discover-schedule.yaml`
+
+    每个外部接口都有一一对应的内部版本，路径前缀为 `/api/vega-backend/in/v1`，请求体与
+    响应结构与外部完全一致；区别仅在于鉴权方式：外部走 OAuth Token 校验，内部从请求头
+    （`X-Account-ID` / `X-Account-Type`）解析访问者。本文档仅描述外部接口。
+  version: 0.1.0
+servers:
+  - url: /api/vega-backend/v1
+paths:
+  /api/vega-backend/v1/catalogs:
+    get:
+      summary: 获取 catalog 列表
+      description: 分页获取 catalog；支持按 tag、type、health_check_status 过滤。
+      parameters:
+        - name: tag
+          description: 按标签精确过滤
+          in: query
+          schema:
+            type: string
+        - name: type
+          description: 按 catalog 类型过滤
+          in: query
+          schema:
+            type: string
+            enum:
+              - physical
+              - logical
+        - name: health_check_status
+          description: 按健康检查状态过滤
+          in: query
+          schema:
+            type: string
+            enum:
+              - healthy
+              - degraded
+              - unhealthy
+              - offline
+              - disabled
+        - name: offset
+          description: 分页偏移量，>=0，默认 0
+          in: query
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+            default: 0
+        - name: limit
+          description: 每页数量，1-1000，-1 表示不分页，默认 20
+          in: query
+          schema:
+            type: integer
+            format: int64
+            default: 20
+        - name: sort
+          description: 排序字段
+          in: query
+          schema:
+            type: string
+            enum:
+              - name
+              - create_time
+              - update_time
+            default: update_time
+        - name: direction
+          description: 排序方向
+          in: query
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
+            default: desc
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListCatalogs"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+    post:
+      summary: 创建 catalog
+      description: |
+        创建一个新的 catalog。`name` 全局唯一，已存在时返回 409。
+        `connector_type` 必须是已注册且 enabled 的连接器类型。
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CatalogRequest"
+      responses:
+        "201":
+          description: 创建成功
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CatalogRef"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "406":
+          $ref: "#/components/responses/NotAcceptable"
+        "409":
+          description: 同名 catalog 已存在 / connector_type 未启用
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /api/vega-backend/v1/catalogs/{ids}:
+    parameters:
+      - name: ids
+        description: catalog ID，多个用英文逗号分隔（如 `id1,id2,id3`）
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      summary: 获取 catalog 详情
+      description: 路径参数支持单条或批量（逗号分隔）；批量时不存在的 ID 不会报错，结果中按存在的返回。
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Catalog"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+    delete:
+      summary: 删除 catalog
+      description: 路径参数支持单条或批量（逗号分隔）。删除会同步移除该 catalog 下的资源、调度等关联记录。
+      responses:
+        "204":
+          description: 删除成功
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /api/vega-backend/v1/catalogs/{id}:
+    parameters:
+      - name: id
+        description: catalog ID
+        in: path
+        required: true
+        schema:
+          type: string
+    put:
+      summary: 修改 catalog
+      description: |
+        全量更新指定 catalog。catalog 由路径参数 `id` 唯一确定（主键不可改）。
+
+        请求体的 `id` 字段**必填**，且必须与路径参数完全一致：
+        - 缺失 → 400 `VegaBackend.Catalog.InvalidParameter.ID`。
+        - 不一致 → 409 `VegaBackend.Catalog.IDMismatch`。
+
+        `name` 改动后若新名称已被其它 catalog 占用，返回 409 `VegaBackend.Catalog.NameExists`。
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CatalogRequest"
+      responses:
+        "204":
+          description: 更新成功
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "406":
+          $ref: "#/components/responses/NotAcceptable"
+        "409":
+          description: |
+            主键 / 名称冲突。可能的错误码：
+            - `VegaBackend.Catalog.IDMismatch`
+            - `VegaBackend.Catalog.NameExists`
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /api/vega-backend/v1/catalogs/{ids}/health-status:
+    parameters:
+      - name: ids
+        description: catalog ID，多个用英文逗号分隔
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      summary: 获取 catalog 健康状态
+      description: 返回每个 catalog 的最近一次健康检查结果（状态 + 时间 + 详情）。
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/CatalogHealthStatusEntry"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /api/vega-backend/v1/catalogs/{id}/test-connection:
+    parameters:
+      - name: id
+        description: catalog ID
+        in: path
+        required: true
+        schema:
+          type: string
+    post:
+      summary: 测试 catalog 连接
+      description: |
+        以当前持久化的 `connector_config` 真实建立一次到数据源的连接，验证连通性。
+        与 `health-status`（异步定时检查的最近结果）不同，本端点是**同步实时探测**。
+
+        探测结果通过响应体 `success` 字段返回；连不通**不**视为 HTTP 错误：
+        - 连通 → 200 `{ success: true, latency_ms }`
+        - 连不通 → 200 `{ success: false, message }`
+        - 非 2xx 仅用于"请求 / 鉴权 / 服务内部"问题，与目标连通性无关。
+      responses:
+        "200":
+          description: 探测完成（成功或失败均返回，业务结果看 `success` 字段）
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TestConnectionResult"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+components:
+  responses:
+    BadRequest:
+      description: 请求参数 / 请求体非法
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    Unauthorized:
+      description: 未授权（OAuth Token 校验失败）
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    NotFound:
+      description: 资源不存在
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    NotAcceptable:
+      description: Content-Type 不是 application/json
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    InternalServerError:
+      description: 服务内部错误
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+  schemas:
+    Error:
+      description: |
+        统一错误响应体。由 `kweaver-go-lib/rest.BaseError` JSON 序列化得到。
+      type: object
+      required:
+        - error_code
+        - description
+        - solution
+        - error_link
+        - error_details
+      properties:
+        error_code:
+          type: string
+        description:
+          type: string
+        solution:
+          type: string
+        error_link:
+          type: string
+        error_details:
+          description: 详细内容，类型不固定
+    AccountInfo:
+      description: 账号信息
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          description: 账号类型（user / app / anonymous 等）
+          type: string
+    Catalog:
+      description: Catalog（数据目录）实体
+      type: object
+      required:
+        - id
+        - name
+        - type
+        - enabled
+        - connector_type
+      properties:
+        id:
+          description: catalog ID
+          type: string
+        name:
+          description: catalog 名称，全局唯一
+          type: string
+        tags:
+          description: 标签
+          type: array
+          items:
+            type: string
+        description:
+          description: 描述
+          type: string
+        type:
+          description: catalog 类型
+          type: string
+          enum:
+            - physical
+            - logical
+        enabled:
+          description: 是否启用
+          type: boolean
+        connector_type:
+          description: 连接器类型标识（参见 connector-type.yaml）
+          type: string
+        connector_config:
+          description: 连接器配置（结构由 ConnectorType.field_config 决定）
+          type: object
+          additionalProperties: true
+        metadata:
+          description: 扩展元信息
+          type: object
+          additionalProperties: true
+        health_check_enabled:
+          description: 是否开启周期健康检查
+          type: boolean
+        health_check_status:
+          description: 最近一次健康检查状态
+          type: string
+          enum:
+            - healthy
+            - degraded
+            - unhealthy
+            - offline
+            - disabled
+        last_check_time:
+          description: 最近一次健康检查时间（毫秒时间戳）
+          type: integer
+          format: int64
+        health_check_result:
+          description: 最近一次健康检查详情
+          type: string
+        creator:
+          $ref: "#/components/schemas/AccountInfo"
+        create_time:
+          type: integer
+          format: int64
+        updater:
+          $ref: "#/components/schemas/AccountInfo"
+        update_time:
+          type: integer
+          format: int64
+        operations:
+          description: 当前用户对该 catalog 的操作权限集合
+          type: array
+          items:
+            type: string
+    CatalogRequest:
+      description: |
+        catalog 创建 / 更新请求体。
+
+        - POST：`id` 可省略，由后端生成；若携带且已存在，返回 409 `VegaBackend.Catalog.IdExists`。
+        - PUT：`id` **必填**，且必须与路径参数 `id` 完全一致。缺失返回 400 `VegaBackend.Catalog.InvalidParameter.ID`，不一致返回 409 `VegaBackend.Catalog.IDMismatch`。
+      type: object
+      required:
+        - name
+        - connector_type
+      properties:
+        id:
+          description: catalog ID；POST 时可省略由后端生成，PUT 时必填且必须与路径参数一致
+          type: string
+        name:
+          description: catalog 名称，全局唯一
+          type: string
+        tags:
+          description: 标签
+          type: array
+          items:
+            type: string
+        description:
+          description: 描述
+          type: string
+        connector_type:
+          description: 连接器类型标识；必须是已注册且 enabled 的类型
+          type: string
+        connector_config:
+          description: 连接器配置；字段由 ConnectorType.field_config 决定
+          type: object
+          additionalProperties: true
+    ListCatalogs:
+      description: catalog 列表
+      type: object
+      required:
+        - entries
+        - total_count
+      properties:
+        entries:
+          type: array
+          items:
+            $ref: "#/components/schemas/Catalog"
+        total_count:
+          type: integer
+          format: int64
+    CatalogRef:
+      description: catalog 引用
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+    CatalogHealthStatusEntry:
+      description: catalog 健康状态条目
+      type: object
+      required:
+        - id
+        - health_check_status
+      properties:
+        id:
+          description: catalog ID
+          type: string
+        health_check_status:
+          type: string
+          enum:
+            - healthy
+            - degraded
+            - unhealthy
+            - offline
+            - disabled
+        last_check_time:
+          description: 最近一次检查时间（毫秒时间戳）
+          type: integer
+          format: int64
+        health_check_result:
+          description: 检查详情 / 错误信息
+          type: string
+    TestConnectionResult:
+      description: 连接测试结果
+      type: object
+      required:
+        - success
+      properties:
+        success:
+          description: 是否连通
+          type: boolean
+        message:
+          description: 详情（失败时为错误信息）
+          type: string
+        latency_ms:
+          description: 探测耗时（毫秒）
+          type: integer
+          format: int64

--- a/adp/docs/api/vega/vega-backend-api/connector-type.yaml
+++ b/adp/docs/api/vega/vega-backend-api/connector-type.yaml
@@ -103,37 +103,6 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/ConnectorTypeReq"
-            examples:
-              register-mysql:
-                value:
-                  type: mysql
-                  name: MySQL
-                  tags:
-                    - rdbms
-                  description: MySQL 关系型数据库连接器
-                  mode: local
-                  category: table
-                  endpoint: ""
-                  enabled: true
-                  field_config:
-                    host:
-                      name: 主机
-                      type: string
-                      description: 数据库主机地址
-                      required: true
-                      encrypted: false
-                    port:
-                      name: 端口
-                      type: integer
-                      description: 数据库端口
-                      required: true
-                      encrypted: false
-                    password:
-                      name: 密码
-                      type: string
-                      description: 数据库密码
-                      required: true
-                      encrypted: true
       responses:
         "201":
           description: 创建成功
@@ -183,14 +152,17 @@ paths:
       description: |
         全量更新指定连接器类型。连接器类型由路径参数 `type` 唯一确定（主键不可改）。
 
-        请求体可省略 `type` 字段；若携带，则必须与路径参数完全一致，否则返回 409。
-        修改 `name` 时若新名称已被其它类型占用，同样返回 409。
+        请求体的 `type` 字段**必填**，且必须与路径参数完全一致：
+        - 缺失 → 400 `VegaBackend.ConnectorType.InvalidParameter.Type`。
+        - 不一致 → 409 `VegaBackend.ConnectorType.TypeMismatch`。
+
+        修改 `name` 时若新名称已被其它类型占用，返回 409 `VegaBackend.ConnectorType.NameExists`。
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ConnectorTypeUpdateReq"
+              $ref: "#/components/schemas/ConnectorTypeReq"
       responses:
         "204":
           description: 更新成功
@@ -419,7 +391,12 @@ components:
           items:
             type: string
     ConnectorTypeReq:
-      description: 注册连接器类型的请求体（POST）
+      description: |
+        连接器类型创建 / 更新请求体。
+
+        - `type` 在 POST 与 PUT 中都**必填**，且必须自描述资源主键。
+        - POST：全局唯一，已存在返回 409 `VegaBackend.ConnectorType.TypeExists`。
+        - PUT：必须与路径参数 `type` **完全一致**，缺失返回 400 `VegaBackend.ConnectorType.InvalidParameter.Type`，不一致返回 409 `VegaBackend.ConnectorType.TypeMismatch`。
       type: object
       required:
         - type
@@ -428,62 +405,7 @@ components:
         - category
       properties:
         type:
-          description: 连接器类型标识，全局唯一
-          type: string
-        name:
-          description: 连接器类型显示名
-          type: string
-        tags:
-          description: 标签
-          type: array
-          items:
-            type: string
-        description:
-          description: 类型描述
-          type: string
-        mode:
-          description: 运行模式
-          type: string
-          enum:
-            - local
-            - remote
-        category:
-          description: 分类
-          type: string
-          enum:
-            - table
-            - index
-            - topic
-            - file
-            - fileset
-            - metric
-            - api
-        endpoint:
-          description: 仅 remote 模式下的远程服务地址
-          type: string
-        field_config:
-          description: 字段配置（兼容 JSON Schema properties），key 为字段标识
-          type: object
-          additionalProperties:
-            $ref: "#/components/schemas/ConnectorFieldConfig"
-        enabled:
-          description: 是否启用
-          type: boolean
-          default: false
-    ConnectorTypeUpdateReq:
-      description: |
-        更新连接器类型的请求体（PUT）。
-
-        连接器类型由路径参数 `type` 唯一确定（主键不可改）。`type` 字段可省略；
-        若携带，则必须与路径参数完全一致，否则返回 409 `VegaBackend.ConnectorType.TypeMismatch`。
-      type: object
-      required:
-        - name
-        - mode
-        - category
-      properties:
-        type:
-          description: 连接器类型标识；可省略，若携带必须与路径参数一致
+          description: 连接器类型标识；POST 与 PUT 都必填，PUT 时必须与路径参数一致
           type: string
         name:
           description: 连接器类型显示名

--- a/adp/docs/design/vega/features/vega-backend/discover_schedule_redesign.md
+++ b/adp/docs/design/vega/features/vega-backend/discover_schedule_redesign.md
@@ -1,0 +1,292 @@
+# DiscoverSchedule 顶层资源化与 API 重构 技术设计文档
+
+> **状态**：草案
+> **负责人**：@待补
+> **日期**：2026-04-29
+> **相关 Ticket**：待补
+
+---
+
+## 1. 背景与目标
+
+### 背景
+
+vega-backend 当前 `scheduled-discover`（catalog 资源发现的定时调度）模块在 HTTP 层与底层数据模型之间存在明显错位：
+
+- **数据模型**：`ScheduledDiscoverTask` 拥有全局唯一主键 `id`，service 接口（`GetByID/Update/Delete/Enable/Disable`）只用 `id` 定位，独立 DB 表，与 catalog 是 N:1 关系。
+- **HTTP 层**：路由强制挂在 `/catalogs/{id}/scheduled-discover/{tid}/...` 下，要求双主键 path，且把"列出全部调度"端点（实质跨 catalog）`GET /catalogs/scheduled-discover` 也挂在 catalog 子路径，URI 形态与功能错位。
+- **词典撕裂**：service 层用 `Enable / Disable`，handler 包装成 `start / stop`，与仓库内其它资源（ConnectorType 用 enable/disable）不一致。
+- **缺端点**：service 提供了 `Delete` / `GetByID`，HTTP 没暴露。
+
+此外存在两处规范化问题：
+
+- `DiscoverTask.scheduled_id` 命名不顺（过去分词当前缀），与新顶层资源 `DiscoverSchedule` 的命名约定不一致。
+- `discover-tasks` 路由用了 `/by-id/{id}` `/by-schedule/{sid}` 的非 RESTful 形态，应规范化为 `/{id}` + query string filter。
+
+### 目标
+
+1. 把"发现调度配置"建模为顶层独立资源 `DiscoverSchedule`，URI、service、DB 三层主键对齐。
+2. 状态切换统一为动作端点 `enable / disable`，与 ConnectorType 风格一致。
+3. 重构 `discover-tasks` 路由为标准 REST 形态。
+4. 修正 `scheduled_id` 字段命名为 `schedule_id`，DB / Go / JSON 同步迁移。
+
+### 非目标
+
+- 不抽象成"通用 Schedule + target_type"模型（业务确认非 discover 的周期任务不会出现，其它任务管理走自己的属性）。
+- 不引入 schedule 模板（多 catalog 复用同一调度）能力。
+- 不重做 cron 调度引擎（仍用 `worker.Scheduler` + `robfig/cron/v3`）。
+- 不改 catalog / connector-type 等其它资源的 API 形态。
+- 不改一次性发现入口 `POST /catalogs/{cid}/discover` 的路径或行为。
+
+## 2. 方案概览
+
+### 2.1 资源关系图
+
+```mermaid
+graph LR
+    Catalog[Catalog] -->|0..N| Schedule[DiscoverSchedule]
+    Schedule -->|0..N| Task[DiscoverTask]
+    Catalog -->|0..N 手动触发| Task
+
+    User[用户] -->|手动 POST /catalogs/cid/discover<br/>带 strategies| Catalog
+    Cron[Cron 调度器] -->|按 cron 触发<br/>schedule_id 落入 task| Task
+```
+
+`DiscoverSchedule` 是纯**配置**资源（cron + strategies + 起止时间 + 启停状态），不直接承载执行。`DiscoverTask` 是执行实例集合，由两个入口产出：
+
+- **手动触发**：`POST /catalogs/{cid}/discover`，task.schedule_id 为空。
+- **cron 自动触发**：调度器到点产出，task.schedule_id 指向触发它的 schedule。
+
+### 2.2 端点变化总览
+
+#### 新增
+
+```
+POST   /api/vega-backend/v1/discover-schedules                  # 创建
+GET    /api/vega-backend/v1/discover-schedules                  # ?catalog_id= ?enabled= 过滤
+GET    /api/vega-backend/v1/discover-schedules/{sid}            # 详情
+PUT    /api/vega-backend/v1/discover-schedules/{sid}            # 严格全量替换；不修改 enabled
+DELETE /api/vega-backend/v1/discover-schedules/{sid}            # 删除调度，不影响已产生的 DiscoverTask
+POST   /api/vega-backend/v1/discover-schedules/{sid}/enable     # 启用
+POST   /api/vega-backend/v1/discover-schedules/{sid}/disable    # 停用
+
+GET    /api/vega-backend/v1/catalogs/{cid}/discover-schedules   # 便利只读视图，等价 ?catalog_id={cid}
+```
+
+#### 变更（路径或字段名）
+
+```
+GET    /discover-tasks/by-id/{id}             →  GET /discover-tasks/{id}
+GET    /discover-tasks/by-schedule/{sid}      →  GET /discover-tasks?schedule_id={sid}
+
+字段重命名:
+DiscoverTask.scheduled_id (JSON / Go / DB)    →  schedule_id
+DiscoverTaskQueryParams 新增 ScheduleID 字段
+```
+
+#### 弃用
+
+```
+- POST   /catalogs/{cid}/scheduled-discover
+- POST   /catalogs/{cid}/scheduled-discover/{tid}/start
+- POST   /catalogs/{cid}/scheduled-discover/{tid}/stop
+- PUT    /catalogs/{cid}/scheduled-discover/{tid}
+- GET    /catalogs/scheduled-discover
+```
+
+#### 保留不变
+
+```
+POST   /api/vega-backend/v1/catalogs/{cid}/discover    # 手动触发，唯一手动入口
+```
+
+## 3. 详细设计
+
+### 3.1 核心约束
+
+#### 3.1.1 PUT 严格语义
+
+`PUT /discover-schedules/{sid}` 是**全量替换**，但只允许变更"配置"字段。下表的"只读字段"如果在 body 中携带且与当前值不一致，返回 409。
+
+| 字段 | 类型 | 可改 |
+|---|---|---|
+| `id` | string | 只读，与 path 不一致 → 409 `*.IdMismatch` |
+| `catalog_id` | string | 只读（schedule 创建后归属不可改）→ 409 `*.CatalogMismatch` |
+| `cron_expr` | string | 可改 |
+| `strategies` | string[] | 可改 |
+| `start_time` | int64 | 可改 |
+| `end_time` | int64 | 可改 |
+| `enabled` | bool | 只读（状态切换走 enable/disable） → 409 `*.EnabledFieldNotAllowed` |
+| `last_run` / `next_run` | int64 | 只读（系统维护），携带时静默忽略 |
+| `creator` / `create_time` / `updater` / `update_time` | - | 只读（系统维护），携带时静默忽略 |
+
+#### 3.1.2 状态切换的唯一入口
+
+`enabled` 字段在响应里只读返回；变更走 `POST .../enable` `POST .../disable`。
+- 端点幂等：对已 enable 的资源再 enable 不报错（也可选返回 409 `AlreadyEnabled`，需团队拍板）。
+- 与 ConnectorType 风格一致，避免仓库内启停命名词典分裂。
+
+#### 3.1.3 DELETE 与执行历史的解耦
+
+`DELETE /discover-schedules/{sid}`：
+
+- 从 cron 引擎摘除该 schedule 的注册条目。
+- DB 中删除 schedule 记录。
+- **不删除已有 DiscoverTask 历史记录**——schedule_id 字段保留为孤儿引用，便于审计追溯"该 schedule 历史触发了哪些任务"。
+- 不影响正在执行（status=running）的 DiscoverTask；任务执行时已经持有所需上下文，不再依赖 schedule 配置。
+
+### 3.2 数据模型变更
+
+#### 3.2.1 DiscoverTask 字段重命名
+
+```sql
+-- migrations/mariadb/<新版本>_rename_scheduled_id_to_schedule_id.sql
+ALTER TABLE t_discover_task
+  CHANGE COLUMN f_scheduled_id f_schedule_id VARCHAR(64);
+-- （索引 / 外键随列名同步）
+```
+
+Go 实体：
+
+```go
+type DiscoverTask struct {
+    ...
+-   ScheduledId string `json:"scheduled_id"`
++   ScheduleID  string `json:"schedule_id"`
+    ...
+}
+
+type DiscoverTaskQueryParams struct {
+    PaginationQueryParams
+    CatalogID   string
++   ScheduleID  string
+    Status      string
+    TriggerType string
+}
+```
+
+#### 3.2.2 DiscoverSchedule 表（沿用现有 t_scheduled_discover_task）
+
+字段不变（已有 `id / catalog_id / cron_expr / strategies / start_time / end_time / enabled / last_run / next_run / creator / create_time / updater / update_time`），仅 service / handler / 路由层做调整。
+
+是否同时把表重命名为 `t_discover_schedule` 以对齐资源命名？**待团队确认**，本设计倾向"先不改表名"以减小迁移风险，HTTP 层资源名 (`discover-schedules`) 与表名 (`t_scheduled_discover_task`) 之间允许命名差异。
+
+#### 3.2.3 错误码新增
+
+```
+DiscoverSchedule.NotFound
+DiscoverSchedule.InvalidCronExpr
+DiscoverSchedule.InvalidStrategies
+DiscoverSchedule.IdMismatch
+DiscoverSchedule.CatalogMismatch
+DiscoverSchedule.EnabledFieldNotAllowed
+DiscoverSchedule.AlreadyEnabled        # 可选，看幂等策略
+DiscoverSchedule.AlreadyDisabled       # 可选
+```
+
+中英文 i18n 同步补充。
+
+### 3.3 接口定义
+
+OpenAPI yaml 草稿待生成（路径 `adp/docs/api/vega/vega-backend-api/discover-schedule.yaml`、`discover-task.yaml`），格式延续 `connector-type.yaml` / `query.yaml` 的风格：
+
+- OpenAPI 3.1.1
+- 共用 `Error` schema 与 responses 块
+- 内部接口前缀 `/api/vega-backend/in/v1` 在 `info.description` 中统一描述，不重复列出 path
+
+### 3.4 cron 引擎集成
+
+- `Create` / `Update` / `Enable` / `Disable` / `Delete` 均触发 `Scheduler.Reload()`（或局部 add/remove 单条），保证 cron 注册与 DB 状态实时一致。当前实现需 review 是否已经做到。
+- 多实例部署时同一 schedule 会被多副本注册，由 catalog 级互斥（README 已声明"每个 catalog 同一时间只能有一个发现任务在执行"）防重。本次重构不改这一行为。
+
+## 4. 边界情况与风险
+
+| 类型 | 描述 | 应对 |
+|---|---|---|
+| 并发 | schedule.enabled 状态在两次请求间被改 | enable/disable 端点幂等；客户端不需要先读取状态 |
+| 并发 | 删除 schedule 时正好 cron 触发 | 删除时先从 cron 引擎注销，再从 DB 删除；已经在执行的 task 不受影响 |
+| 数据一致性 | DB 删 schedule 但 cron 引擎未刷新 | 启动时 `Scheduler.Start()` 重载所有 enabled schedule；变更时 `Reload()` |
+| 字段重命名 | `scheduled_id` 与 `schedule_id` 双客户端同时调用 | 不做兼容期：本次发布作为破坏性版本；前端 / 调用方一次性切换 |
+| DB 迁移 | 重命名列时锁表 | 表规模评估；数据量大时可拆为"新增列 + 双写 + 切流 + 删旧列"三步迁移（看 DBA 建议） |
+| 向后兼容 | 弃用旧路径会破坏现有客户端 | 与外部依赖方对齐时间窗，通知 + 双发布期；本次设计**不**保留旧路由作 deprecated 别名 |
+| 性能 | `GET /discover-tasks?schedule_id=` 查询性能 | DB 列上加索引（与原 `f_scheduled_id` 索引同步迁移） |
+
+## 5. 替代方案
+
+### 方案 A：保持 catalog 子资源，仅修内部问题
+
+将 `start/stop` 改为 `enable/disable`，路径仍为 `/catalogs/{cid}/scheduled-discover-tasks/{tid}/...`，跨 catalog 列表剥离到 `/scheduled-discover-tasks`。
+
+**优点**：URI 表达"任务从属于 catalog"的归属关系。
+**缺点**：双主键 path 冗余（task_id 已经全局唯一）；同一资源的"列表 vs 单条操作"路径风格分裂；本质上仍是顶层资源被强行嵌套。
+
+**结论**：放弃。归属关系靠资源字段 `catalog_id` 表达即可，不需要 URI 来表达。
+
+### 方案 B：把多份调度合并为 catalog 上的"rules 数组"属性
+
+每个 catalog 上挂一个 `discover_schedule.rules[]` JSON 数组，元素含 cron / strategies / enabled。
+
+**优点**：路径形态最简，仅 `/catalogs/{cid}/discover-schedule`。
+**缺点**：
+
+- 数组元素需要独立的 URI / 状态 / 历史 / 审计，最终被迫在元素上造 `rule_id` 字段，等于把 1:N 模型藏进数组里、丢掉 REST 的所有好处。
+- 并发编辑（两人同时操作不同 rule）会触发数组级 last-write-wins，必须额外引入 ETag。
+- 无法简洁表达"按 rule 反查 task"。
+
+**结论**：放弃。详细论证见前期讨论稿。
+
+### 方案 C：通用 `Schedule` + `target_type/target_id` 抽象
+
+把 schedule 抽成一个能调度任意 target（discover / sync / health-check / ...）的顶层概念。
+
+**优点**：未来扩展性最强。
+**缺点**：业务确认非 discover 的周期任务不会出现，过度抽象会引入没用的多态字段。
+
+**结论**：放弃。
+
+### 最终方案：DiscoverSchedule 顶层独立资源 + 字段命名规范化
+
+详见第 2、3 节。
+
+## 6. 任务拆分
+
+按 [adp/CLAUDE.md](../../../../../CLAUDE.md) 规则 5（单批 ≤ 3 文件原则）拆为 5 批：
+
+- [ ] **批次 1：`scheduled_id` → `schedule_id` 重命名 + DB 迁移**
+  - DB migration 脚本
+  - `interfaces/discover_task.go` 字段重命名 + 新增 `ScheduleID` query 参数
+  - `drivenadapters` SQL 字段映射 / DAO
+  - mock 同步
+  - locale / 错误码不涉及
+
+- [ ] **批次 2：DiscoverSchedule 顶层资源（service + handler + router）**
+  - 新增 `interfaces/discover_schedule_service.go`（或在原 `scheduled_discover_task_service.go` 调整）
+  - 新增 `driveradapters/discover_schedule_handler.go`
+  - 新增 `driveradapters/validate_discover_schedule.go`
+  - router 注册新端点（暂不删旧）
+  - 错误码 + locale
+  - mock 同步
+  - 单元测试（PUT 主键冲突 / enable / disable 等核心路径）
+
+- [ ] **批次 3：discover-tasks 路由形态规范化 + `?schedule_id=` 过滤**
+  - router：`/by-id/{id}` → `/{id}`，`/by-schedule/{sid}` 删除
+  - handler 改造、access SQL 增加 `schedule_id` 过滤
+  - 单元测试
+
+- [ ] **批次 4：弃用旧 scheduled-discover 路由**
+  - router 删除旧路由
+  - handler 中废弃的方法移除
+  - CHANGELOG 标注 BREAKING
+
+- [ ] **批次 5：OpenAPI yaml 草稿生成**
+  - `adp/docs/api/vega/vega-backend-api/discover-schedule.yaml`
+  - `adp/docs/api/vega/vega-backend-api/discover-task.yaml`
+
+每批前按 CLAUDE.md 规则 1 单独描述方案待批准。
+
+## 7. 待团队确认的开放问题
+
+1. **是否同时把 DB 表 `t_scheduled_discover_task` 重命名为 `t_discover_schedule`**？本设计建议先不改，HTTP/Go 层与表名命名差异可接受。
+2. **enable/disable 幂等策略**：对已 enable 的资源再 enable 是返回 204（幂等成功）还是 409 `AlreadyEnabled`？建议 204（幂等）。
+3. **DB 列重命名一次完成 vs 三步迁移**：取决于线上 t_discover_task 数据量与运维窗口，DBA 建议为准。
+4. **是否保留旧路由短期作为 deprecated 别名**？建议不保留（破坏性发布 + 外部对齐），但若有历史合作方需要灰度，可以暂留 1 个版本。

--- a/adp/vega/vega-backend/server/driveradapters/catalog_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/catalog_handler.go
@@ -356,6 +356,21 @@ func (r *restHandler) updateCatalog(c *gin.Context, ctx context.Context, span tr
 		return
 	}
 
+	if req.ID == "" {
+		httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Catalog_InvalidParameter_ID).
+			WithErrorDetails("body field 'id' is required and must equal path parameter")
+		o11y.AddHttpAttrs4HttpError(span, httpErr)
+		rest.ReplyError(c, httpErr)
+		return
+	}
+	if req.ID != id {
+		httpErr := rest.NewHTTPError(ctx, http.StatusConflict, verrors.VegaBackend_Catalog_IDMismatch).
+			WithErrorDetails(fmt.Sprintf("path id %q != body id %q", id, req.ID))
+		o11y.AddHttpAttrs4HttpError(span, httpErr)
+		rest.ReplyError(c, httpErr)
+		return
+	}
+
 	if err := ValidateCatalogRequest(ctx, &req); err != nil {
 		httpErr := err.(*rest.HTTPError)
 		o11y.AddHttpAttrs4HttpError(span, httpErr)
@@ -673,12 +688,19 @@ func (r *restHandler) testConnection(c *gin.Context, ctx context.Context, span t
 		return
 	}
 
-	result, err := r.cs.TestConnection(ctx, catalog)
+	status, err := r.cs.TestConnection(ctx, catalog)
 	if err != nil {
 		httpErr := err.(*rest.HTTPError)
 		o11y.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
 		return
+	}
+
+	// 映射缓存的健康状态为对外契约：
+	// 严格 healthy = success=true，其它（degraded / unhealthy / offline / disabled）= false。
+	result := map[string]any{
+		"success": status.HealthCheckStatus == interfaces.CatalogHealthStatusHealthy,
+		"message": status.HealthCheckResult,
 	}
 
 	logger.Debug("Handler TestConnection Success")

--- a/adp/vega/vega-backend/server/driveradapters/connector_type_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/connector_type_handler.go
@@ -242,14 +242,20 @@ func (r *restHandler) UpdateConnectorType(c *gin.Context) {
 		rest.ReplyError(c, httpErr)
 		return
 	}
-	if req.Type != "" && req.Type != tp {
+	if req.Type == "" {
+		httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_ConnectorType_InvalidParameter_Type).
+			WithErrorDetails("body field 'type' is required and must equal path parameter")
+		o11y.AddHttpAttrs4HttpError(span, httpErr)
+		rest.ReplyError(c, httpErr)
+		return
+	}
+	if req.Type != tp {
 		httpErr := rest.NewHTTPError(ctx, http.StatusConflict, verrors.VegaBackend_ConnectorType_TypeMismatch).
 			WithErrorDetails(fmt.Sprintf("path type %q != body type %q", tp, req.Type))
 		o11y.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
 		return
 	}
-	req.Type = tp
 
 	if err := ValidateConnectorTypeReq(ctx, &req); err != nil {
 		httpErr := err.(*rest.HTTPError)

--- a/adp/vega/vega-backend/server/driveradapters/connector_type_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/connector_type_handler_test.go
@@ -80,16 +80,17 @@ func TestUpdateConnectorType_BodyTypeMatchesPath_OK(t *testing.T) {
 	}
 }
 
-// case 2：请求体省略 type → 跳过冲突，进入正常更新流程
-func TestUpdateConnectorType_BodyTypeOmitted_OK(t *testing.T) {
+// case 2：请求体省略 type → 400 InvalidParameter.Type（K8s 风格严格契约）
+func TestUpdateConnectorType_BodyTypeOmitted_400(t *testing.T) {
 	body := `{"name":"MySQL","mode":"local","category":"table"}`
 	w := putUpdateConnectorType(t, "mysql", body, func(m *mock_interfaces.MockConnectorTypeService) {
-		m.EXPECT().GetByType(gomock.Any(), "mysql").
-			Return(&interfaces.ConnectorType{Type: "mysql", Name: "MySQL", Mode: "local", Category: "table"}, nil)
-		m.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
+		// 校验失败应在调用任何 service 方法前返回，此处无 EXPECT。
 	})
 
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("expected 204, got %d, body=%s", w.Code, w.Body.String())
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d, body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "VegaBackend.ConnectorType.InvalidParameter.Type") {
+		t.Fatalf("expected InvalidParameter.Type error_code, got body=%s", w.Body.String())
 	}
 }

--- a/adp/vega/vega-backend/server/errors/catalog.go
+++ b/adp/vega/vega-backend/server/errors/catalog.go
@@ -12,6 +12,7 @@ const (
 	VegaBackend_Catalog_InvalidParameter                 = "VegaBackend.Catalog.InvalidParameter"
 	VegaBackend_Catalog_InvalidParameter_Type            = "VegaBackend.Catalog.InvalidParameter.Type"
 	VegaBackend_Catalog_InvalidParameter_Name            = "VegaBackend.Catalog.InvalidParameter.Name"
+	VegaBackend_Catalog_InvalidParameter_ID              = "VegaBackend.Catalog.InvalidParameter.ID"
 	VegaBackend_Catalog_InvalidParameter_ConnectorType   = "VegaBackend.Catalog.InvalidParameter.ConnectorType"
 	VegaBackend_Catalog_InvalidParameter_ConnectorConfig = "VegaBackend.Catalog.InvalidParameter.ConnectorConfig"
 	VegaBackend_Catalog_LengthExceeded_Name              = "VegaBackend.Catalog.LengthExceeded.Name"
@@ -21,6 +22,7 @@ const (
 	VegaBackend_Catalog_NotFound   = "VegaBackend.Catalog.NotFound"
 	VegaBackend_Catalog_NameExists = "VegaBackend.Catalog.NameExists"
 	VegaBackend_Catalog_IDExists   = "VegaBackend.Catalog.IDExists"
+	VegaBackend_Catalog_IDMismatch = "VegaBackend.Catalog.IDMismatch"
 	VegaBackend_Catalog_HasAssets  = "VegaBackend.Catalog.HasAssets"
 	VegaBackend_Catalog_IsDisabled = "VegaBackend.Catalog.IsDisabled"
 
@@ -42,6 +44,7 @@ var CatalogErrCodeList = []string{
 	VegaBackend_Catalog_InvalidParameter,
 	VegaBackend_Catalog_InvalidParameter_Type,
 	VegaBackend_Catalog_InvalidParameter_Name,
+	VegaBackend_Catalog_InvalidParameter_ID,
 	VegaBackend_Catalog_InvalidParameter_ConnectorType,
 	VegaBackend_Catalog_InvalidParameter_ConnectorConfig,
 	VegaBackend_Catalog_LengthExceeded_Name,
@@ -49,6 +52,7 @@ var CatalogErrCodeList = []string{
 	VegaBackend_Catalog_NotFound,
 	VegaBackend_Catalog_NameExists,
 	VegaBackend_Catalog_IDExists,
+	VegaBackend_Catalog_IDMismatch,
 	VegaBackend_Catalog_HasAssets,
 	VegaBackend_Catalog_IsDisabled,
 	VegaBackend_Catalog_InternalError,

--- a/adp/vega/vega-backend/server/locale/catalog.en-US.toml
+++ b/adp/vega/vega-backend/server/locale/catalog.en-US.toml
@@ -13,6 +13,11 @@ Description = "Invalid catalog name"
 Solution = "Please check the parameter"
 ErrorLink = "None"
 
+[VegaBackend.Catalog.InvalidParameter.ID]
+Description = "Request body is missing the 'id' field"
+Solution = "Include the 'id' field in the body and make it equal to the path parameter"
+ErrorLink = "None"
+
 [VegaBackend.Catalog.InvalidParameter.ConnectorType]
 Description = "Invalid connector type"
 Solution = "Please check the parameter"
@@ -41,6 +46,11 @@ ErrorLink = "None"
 [VegaBackend.Catalog.NameExists]
 Description = "Catalog name already exists"
 Solution = "Please use a different name"
+ErrorLink = "None"
+
+[VegaBackend.Catalog.IDMismatch]
+Description = "Catalog id in the request body does not match the path"
+Solution = "Make the 'id' field in the body equal to the path parameter"
 ErrorLink = "None"
 
 [VegaBackend.Catalog.IDExists]

--- a/adp/vega/vega-backend/server/locale/catalog.zh-CN.toml
+++ b/adp/vega/vega-backend/server/locale/catalog.zh-CN.toml
@@ -13,6 +13,11 @@ Description = "无效的目录名称"
 Solution = "请检查参数"
 ErrorLink = "暂无"
 
+[VegaBackend.Catalog.InvalidParameter.ID]
+Description = "请求体缺少 id 字段"
+Solution = "请在请求体中携带 id 字段，且与路径参数保持一致"
+ErrorLink = "暂无"
+
 [VegaBackend.Catalog.InvalidParameter.ConnectorType]
 Description = "无效的连接类型"
 Solution = "请检查参数"
@@ -41,6 +46,11 @@ ErrorLink = "暂无"
 [VegaBackend.Catalog.NameExists]
 Description = "目录名称已存在"
 Solution = "请使用其他名称"
+ErrorLink = "暂无"
+
+[VegaBackend.Catalog.IDMismatch]
+Description = "请求体中的目录 id 与路径不一致"
+Solution = "请使请求体中的 id 字段与路径参数保持一致"
 ErrorLink = "暂无"
 
 [VegaBackend.Catalog.IDExists]


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] `catalog_handler.go`：PUT `/catalogs/{id}` 严格校验请求体 `id` 必填，且必须与路径参数一致
  - 缺失 → 400 `VegaBackend.Catalog.InvalidParameter.ID`
  - 不一致 → 409 `VegaBackend.Catalog.IDMismatch`
- [x] catalog 健康检查状态映射对齐：`healthy / degraded / unhealthy / offline / disabled`
- [x] `connector_type_handler.go` 复用相同的 type 严格校验逻辑（与路径参数一致性），并补充测试
- [x] 新增错误码与中英文 locale 文案：`errors/catalog.go`、`locale/catalog.{en-US,zh-CN}.toml`
- [x] 文档：
  - 新增 `adp/docs/api/vega/vega-backend-api/README.md`（API 文件索引与归属约定）
  - 新增 `catalog.yaml`、`connector-type.yaml` OpenAPI 3.1.1 文档
  - 新增设计文档 `discover_schedule_redesign.md`

---

## Why

- Related Issue: #343
- Background:
  - 此前 PUT `/catalogs/{id}` 对请求体 `id` 处理宽松，调用方可能误以为能改主键；统一返回 400 / 409 + 明确错误码让契约更清晰
  - 健康状态枚举此前散落在多处，借此次梳理对齐到统一的 5 态模型，并在 OpenAPI 中固化
  - API 文档此前缺位，本次按"按谁过滤就归谁"的归属原则建立 vega-backend-api 文档骨架

---

## How

- 关键实现点：
  - `catalog_handler.go`：PUT 入口先做请求体 `id` 必填校验（400 InvalidParameter.ID），再做与路径参数一致性校验（409 IDMismatch）；name 冲突仍走 409 NameExists
  - 健康状态字段对齐到 `healthy / degraded / unhealthy / offline / disabled`，OpenAPI 文档与代码同步
  - `connector_type_handler.go` 同步采用一致的 type 严格匹配语义，测试用例覆盖一致 / 不一致路径
  - `errors/catalog.go` 新增 `InvalidParameter.ID`、`IDMismatch` 错误码，i18n 文案补齐
  - 文档：catalog.yaml 覆盖 CRUD、`/health-status`、`/test-connection`；README 明确跨资源便利端点的归属规则
- Breaking changes:
  - **API 契约收紧**：PUT `/catalogs/{id}` 现在要求请求体携带 `id` 且与路径参数完全一致，调用方需同步更新

---

## Testing

- [x] Unit tests passed locally（`connector_type_handler_test.go` 覆盖一致 / 不一致 type 等场景）
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:
- catalog handler 的 ID 校验路径建议补充 handler 级测试（当前 diff 中尚未包含 catalog_handler_test 改动）

---

## Risk & Rollback

- 潜在风险：
  - 调用方若 PUT 时未携带 `id` 或携带错误 `id`，将由原先的"宽松接受"变为 400 / 409 失败，需要前端 / SDK 同步更新
  - 健康状态枚举对齐若未与查询侧 / 前端对齐，可能出现展示空态
- 回滚方案：revert 本 PR 即可恢复原宽松校验与原状态映射；无数据库 schema 变更，无需数据回滚

---

## Additional Notes

- API 文档：
  - `adp/docs/api/vega/vega-backend-api/README.md`
  - `adp/docs/api/vega/vega-backend-api/catalog.yaml`
  - `adp/docs/api/vega/vega-backend-api/connector-type.yaml`
- 设计文档：`adp/docs/design/vega/features/vega-backend/discover_schedule_redesign.md`
- 错误码：`VegaBackend.Catalog.InvalidParameter.ID`、`VegaBackend.Catalog.IDMismatch`、`VegaBackend.Catalog.NameExists`
