### PR TITLE
fix(bkn-backend): 间接关系 BackingDataSource 为空空指针修复；列表接口移除 group_id (#333)

### DIFF
--- a/adp/bkn/bkn-backend/server/driveradapters/action_type_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/action_type_handler.go
@@ -660,7 +660,6 @@ func (r *restHandler) ListActionTypes(c *gin.Context, visitor hydra.Visitor) {
 	// 获取分页参数
 	namePattern := c.Query("name_pattern")
 	tag := c.Query("tag")
-	groupID := c.Query("group_id")
 	objectTypeID := c.Query("object_type_id")
 	actionType := c.Query("action_type")
 	offset := c.DefaultQuery("offset", interfaces.DEFAULT_OFFEST)
@@ -693,7 +692,6 @@ func (r *restHandler) ListActionTypes(c *gin.Context, visitor hydra.Visitor) {
 		Tag:         tag,
 		Branch:      branch,
 		KNID:        knID,
-		GroupID:     groupID,
 		ActionType:  actionType,
 	}
 	if objectTypeID != "" {

--- a/adp/bkn/bkn-backend/server/driveradapters/metric_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/metric_handler.go
@@ -295,7 +295,6 @@ func (r *restHandler) ListMetrics(c *gin.Context, vis hydra.Visitor) {
 
 	namePattern := c.Query("name_pattern")
 	tag := strings.Trim(c.Query("tag"), " ")
-	groupID := c.Query("group_id")
 	offset := c.DefaultQuery("offset", interfaces.DEFAULT_OFFEST)
 	limit := c.DefaultQuery("limit", interfaces.DEFAULT_LIMIT)
 	sort := c.DefaultQuery("sort", "update_time")
@@ -316,7 +315,6 @@ func (r *restHandler) ListMetrics(c *gin.Context, vis hydra.Visitor) {
 		},
 		NamePattern: namePattern,
 		Tag:         tag,
-		GroupID:     groupID,
 		Branch:      branch,
 		KNID:        knID,
 	}

--- a/adp/bkn/bkn-backend/server/driveradapters/object_type_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/object_type_handler.go
@@ -870,7 +870,6 @@ func (r *restHandler) ListObjectTypes(c *gin.Context, visitor hydra.Visitor) {
 	// 获取分页参数
 	namePattern := c.Query("name_pattern")
 	tag := c.Query("tag")
-	groupID := c.Query("group_id")
 	offset := c.DefaultQuery("offset", interfaces.DEFAULT_OFFEST)
 	limit := c.DefaultQuery("limit", interfaces.DEFAULT_LIMIT)
 	sort := c.DefaultQuery("sort", "update_time")
@@ -901,7 +900,6 @@ func (r *restHandler) ListObjectTypes(c *gin.Context, visitor hydra.Visitor) {
 		Tag:         tag,
 		Branch:      branch,
 		KNID:        knID,
-		CGroupID:    groupID,
 	}
 	parameter.Sort = pageParam.Sort
 	parameter.Direction = pageParam.Direction

--- a/adp/bkn/bkn-backend/server/driveradapters/relation_type_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/relation_type_handler.go
@@ -638,7 +638,6 @@ func (r *restHandler) ListRelationTypes(c *gin.Context, visitor hydra.Visitor) {
 	// 获取分页参数
 	namePattern := c.Query("name_pattern")
 	tag := c.Query("tag")
-	groupID := c.Query("group_id")
 	sourceObjectTypeIDs := c.QueryArray("source_object_type_id")
 	targetObjectTypeIDs := c.QueryArray("target_object_type_id")
 	boundObjectTypeIDs := c.QueryArray("bound_object_type_id")
@@ -673,7 +672,6 @@ func (r *restHandler) ListRelationTypes(c *gin.Context, visitor hydra.Visitor) {
 		Tag:         tag,
 		Branch:      branch,
 		KNID:        knID,
-		GroupID:     groupID,
 	}
 
 	// 不为空时，赋值

--- a/adp/bkn/bkn-backend/server/interfaces/action_type.go
+++ b/adp/bkn/bkn-backend/server/interfaces/action_type.go
@@ -143,7 +143,6 @@ type ActionTypesQueryParams struct {
 	Tag           string
 	Branch        string
 	KNID          string
-	GroupID       string
 	ObjectTypeIDs []string
 	ActionType    string
 }

--- a/adp/bkn/bkn-backend/server/interfaces/metric.go
+++ b/adp/bkn/bkn-backend/server/interfaces/metric.go
@@ -290,7 +290,6 @@ type MetricsListQueryParams struct {
 	PaginationQueryParameters
 	NamePattern string
 	Tag         string
-	GroupID     string
 	Branch      string
 	KNID        string
 	ScopeType   string

--- a/adp/bkn/bkn-backend/server/interfaces/object_type.go
+++ b/adp/bkn/bkn-backend/server/interfaces/object_type.go
@@ -206,7 +206,6 @@ type ObjectTypesQueryParams struct {
 	Tag         string
 	Branch      string
 	KNID        string
-	CGroupID    string
 	OTIDS       []string // 按对象类id过滤
 }
 

--- a/adp/bkn/bkn-backend/server/interfaces/relation_type.go
+++ b/adp/bkn/bkn-backend/server/interfaces/relation_type.go
@@ -79,7 +79,6 @@ type RelationTypesQueryParams struct {
 	Tag                 string
 	Branch              string
 	KNID                string
-	GroupID             string
 	SourceObjectTypeIDs []string
 	TargetObjectTypeIDs []string
 	BoundObjectTypeIDs  []string

--- a/adp/bkn/bkn-backend/server/logics/bkn_convert.go
+++ b/adp/bkn/bkn-backend/server/logics/bkn_convert.go
@@ -266,12 +266,13 @@ func ToADPRelationType(knID string, branch string, bknRel *bknsdk.BknRelationTyp
 			relType.MappingRules = mappings
 
 		case *bknsdk.InDirectMappingRule:
-			indirect := &interfaces.InDirectMapping{
-				BackingDataSource: &interfaces.ResourceInfo{
+			indirect := &interfaces.InDirectMapping{}
+			if rules.BackingDataSource != nil {
+				indirect.BackingDataSource = &interfaces.ResourceInfo{
 					Type: rules.BackingDataSource.Type,
 					ID:   rules.BackingDataSource.ID,
 					Name: rules.BackingDataSource.Name,
-				},
+				}
 			}
 			for _, rule := range rules.SourceMappingRules {
 				indirect.SourceMappingRules = append(indirect.SourceMappingRules, interfaces.Mapping{
@@ -334,12 +335,13 @@ func ToBKNRelationType(adpRel *interfaces.RelationType) *bknsdk.BknRelationType 
 			bknRel.MappingRules = mappingRules
 
 		case *interfaces.InDirectMapping:
-			indirectRules := &bknsdk.InDirectMappingRule{
-				BackingDataSource: &bknsdk.ResourceInfo{
+			indirectRules := &bknsdk.InDirectMappingRule{}
+			if rules.BackingDataSource != nil {
+				indirectRules.BackingDataSource = &bknsdk.ResourceInfo{
 					Type: rules.BackingDataSource.Type,
 					ID:   rules.BackingDataSource.ID,
 					Name: rules.BackingDataSource.Name,
-				},
+				}
 			}
 			for _, rule := range rules.SourceMappingRules {
 				indirectRules.SourceMappingRules = append(indirectRules.SourceMappingRules, bknsdk.MappingRule{

--- a/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
@@ -427,43 +427,48 @@ func (rts *relationTypeService) GetRelationTypesByIDs(ctx context.Context, knID 
 		case interfaces.RELATION_TYPE_DATA_VIEW:
 			// 查视图或 vega Resource，翻译名称和桥梁字段显示名
 			mappingRules := relationType.MappingRules.(*interfaces.InDirectMapping)
-			backingType := mappingRules.BackingDataSource.Type
+			var backingType string
+			if mappingRules.BackingDataSource != nil {
+				backingType = mappingRules.BackingDataSource.Type
+			}
 			if backingType == "" {
 				backingType = interfaces.DATA_SOURCE_TYPE_DATA_VIEW
 			}
 			var fieldsMap map[string]*interfaces.ViewField
-			switch backingType {
-			case interfaces.DATA_SOURCE_TYPE_RESOURCE:
-				res, err := rts.vba.GetResourceByID(ctx, mappingRules.BackingDataSource.ID)
-				if err != nil {
-					return []*interfaces.RelationType{}, rest.NewHTTPError(ctx, http.StatusInternalServerError,
-						berrors.BknBackend_RelationType_InternalError_GetDataViewByIDFailed).
-						WithErrorDetails(err.Error())
-				}
-				if res == nil {
-					o11y.Warn(ctx, fmt.Sprintf("Relation type [%s]'s backing vega Resource %s not found", relationType.RTID, mappingRules.BackingDataSource.ID))
-					if sourceObj == nil && targetObj == nil {
-						continue
+			if mappingRules.BackingDataSource != nil && mappingRules.BackingDataSource.ID != "" {
+				switch backingType {
+				case interfaces.DATA_SOURCE_TYPE_RESOURCE:
+					res, err := rts.vba.GetResourceByID(ctx, mappingRules.BackingDataSource.ID)
+					if err != nil {
+						return []*interfaces.RelationType{}, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+							berrors.BknBackend_RelationType_InternalError_GetDataViewByIDFailed).
+							WithErrorDetails(err.Error())
 					}
-				} else {
-					relationType.MappingRules.(*interfaces.InDirectMapping).BackingDataSource.Name = res.Name
-					fieldsMap = logics.VegaResourceSchemaToFieldsMap(res)
-				}
-			default:
-				dataView, err := rts.dva.GetDataViewByID(ctx, mappingRules.BackingDataSource.ID)
-				if err != nil {
-					return []*interfaces.RelationType{}, rest.NewHTTPError(ctx, http.StatusInternalServerError,
-						berrors.BknBackend_RelationType_InternalError_GetDataViewByIDFailed).
-						WithErrorDetails(err.Error())
-				}
-				if dataView == nil {
-					o11y.Warn(ctx, fmt.Sprintf("Relation type [%s]'s Backing Data view %s not found", relationType.RTID, mappingRules.BackingDataSource.ID))
-					if sourceObj == nil && targetObj == nil {
-						continue
+					if res == nil {
+						o11y.Warn(ctx, fmt.Sprintf("Relation type [%s]'s backing vega Resource %s not found", relationType.RTID, mappingRules.BackingDataSource.ID))
+						if sourceObj == nil && targetObj == nil {
+							continue
+						}
+					} else {
+						relationType.MappingRules.(*interfaces.InDirectMapping).BackingDataSource.Name = res.Name
+						fieldsMap = logics.VegaResourceSchemaToFieldsMap(res)
 					}
-				} else {
-					relationType.MappingRules.(*interfaces.InDirectMapping).BackingDataSource.Name = dataView.ViewName
-					fieldsMap = dataView.FieldsMap
+				default:
+					dataView, err := rts.dva.GetDataViewByID(ctx, mappingRules.BackingDataSource.ID)
+					if err != nil {
+						return []*interfaces.RelationType{}, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+							berrors.BknBackend_RelationType_InternalError_GetDataViewByIDFailed).
+							WithErrorDetails(err.Error())
+					}
+					if dataView == nil {
+						o11y.Warn(ctx, fmt.Sprintf("Relation type [%s]'s Backing Data view %s not found", relationType.RTID, mappingRules.BackingDataSource.ID))
+						if sourceObj == nil && targetObj == nil {
+							continue
+						}
+					} else {
+						relationType.MappingRules.(*interfaces.InDirectMapping).BackingDataSource.Name = dataView.ViewName
+						fieldsMap = dataView.FieldsMap
+					}
 				}
 			}
 

--- a/adp/docs/api/bkn/bkn-backend-api/action-type.yaml
+++ b/adp/docs/api/bkn/bkn-backend-api/action-type.yaml
@@ -56,11 +56,6 @@ paths:
           schema:
             type: string
           in: query
-        - name: group_id
-          description: 按概念分组过滤
-          schema:
-            type: string
-          in: query
         - name: action_type
           description: 行动类型
           schema:

--- a/adp/docs/api/bkn/bkn-backend-api/bkn-metrics.yaml
+++ b/adp/docs/api/bkn/bkn-backend-api/bkn-metrics.yaml
@@ -58,11 +58,6 @@ paths:
           schema:
             type: string
           in: query
-        - name: group_id
-          description: 按概念分组过滤
-          schema:
-            type: string
-          in: query
         - name: branch
           description: 分支，不填则使用 main 分支
           schema:

--- a/adp/docs/api/bkn/bkn-backend-api/object-type.yaml
+++ b/adp/docs/api/bkn/bkn-backend-api/object-type.yaml
@@ -56,11 +56,6 @@ paths:
           schema:
             type: string
           in: query
-        - name: group_id
-          description: 按概念分组过滤
-          schema:
-            type: string
-          in: query
       responses:
         "200":
           content:

--- a/adp/docs/api/bkn/bkn-backend-api/relation-type.yaml
+++ b/adp/docs/api/bkn/bkn-backend-api/relation-type.yaml
@@ -56,11 +56,6 @@ paths:
           schema:
             type: string
           in: query
-        - name: group_id
-          description: 按概念分组过滤
-          schema:
-            type: string
-          in: query
         - name: source_object_type_id
           description: 起点对象类ID
           schema:


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] bkn-backend：`bkn_convert.go` 中间接映射（`InDirectMapping` / `InDirectMappingRule`）在 `BackingDataSource` 为空时不再构造/解引用空指针
- [x] bkn-backend：`relation_type_service.GetRelationTypesByIDs` 在 DATA_VIEW + 间接映射路径上对 `BackingDataSource` 做空值与 ID 校验后再调用资源/数据视图服务
- [x] OpenAPI 与列表 Handler：从关系类、对象类、动作类、指标的列表接口移除 `group_id` 查询参数；对应 `interfaces` 查询结构体字段同步删除

---

## Why

- Related Issue: [Issue #333](https://github.com/kweaver-ai/kweaver-core/issues/333)
- Related Feature: N/A
- Background: 间接关系映射场景下 `backing_data_source` 可能缺省，旧逻辑在转换与按 ID 批量查询关系类时会因空指针崩溃。本分支同时使列表相关 OpenAPI 与实现不再暴露已移除的 `group_id` 过滤参数。

---

## How

- Key implementation points:
  - ADP ↔ BKN 双向转换：仅当 `BackingDataSource != nil` 时再填充 `ResourceInfo`
  - 服务层：`backingType` 默认为数据视图类型；仅当 `BackingDataSource` 非空且 `ID` 非空时进入 Resource / DataView 分支
- Breaking changes (API, config, database, etc.):
  - **HTTP 列表接口**：`GET` 列表查询不再支持 `group_id` 参数（OpenAPI 与各 `List*Types` handler 已对齐）

---

## Testing

- [ ] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes: 建议在本地或 CI 跑通 bkn-backend 相关测试后勾选。

---

## Risk & Rollback

- Potential risks: 若有调用方仍依赖 `group_id` 筛选列表，需在业务侧改用其他过滤方式或另行约定
- Rollback plan: 回退合并本 PR 的提交即可恢复旧行为

---

## Additional Notes

Diff 摘要（相对 `main`）：

- `bkn_convert.go`、`relation_type_service.go`：间接映射空 `BackingDataSource` 安全处理
- `*_handler.go`、`interfaces/*.go`、`adp/docs/api/bkn/bkn-backend-api/*.yaml`：移除列表 `group_id` 参数及相关结构字段
