### PR TITLE
[fix] 调整/resources/{id}/data calendar_interval传参定义，时间戳接收条件默认毫秒级

### DIFF
--- a/adp/docs/api/vega/vega-backend/resource.yaml
+++ b/adp/docs/api/vega/vega-backend/resource.yaml
@@ -856,24 +856,104 @@ paths:
 definitions:
   interfaces.ResourceDataQueryParams:
     properties:
-      filter_condition: {}
+      filter_condition:
+        description: 过滤条件，支持多种操作符（==, !=, >, >=, <, <=, in, not_in, range, out_range, contain, not_contain, like, not_like, prefix, not_prefix, null, not_null, empty, not_empty, exist, not_exist, match, match_phrase, multi_match, before, current, knn_vector等）
+        type: object
       limit:
-        description: 返回结果的最大数量。对于AnyShare知识库类资源，limit不能大于100
+        description: 返回结果的最大数量。对于AnyShare知识库类资源，limit不能大于100。默认值为10，取值范围为[1, 10000]
         type: integer
+        minimum: 1
+        maximum: 10000
+        default: 10
       need_total:
         description: 是否返回总数。对于AnyShare知识库类资源，只有第一页(offset=0)会返回
         type: boolean
+        default: false
       offset:
+        description: 分页偏移量，用于指定从第几条数据开始返回
         type: integer
+        minimum: 0
+        default: 0
       output_fields:
         description: 指定输出的字段列表
         items:
           type: string
         type: array
       sort:
+        description: 排序字段列表
         items:
           $ref: common.yaml#/definitions/interfaces.SortField
         type: array
+      query_type:
+        description: 查询类型
+        type: string
+      aggregation:
+        description: 聚合度量配置，用于对指定字段进行聚合计算
+        type: object
+        properties:
+          property:
+            description: 被聚合的资源字段名
+            type: string
+          aggr:
+            description: 聚合函数，支持：count, count_distinct, sum, max, min, avg
+            type: string
+            enum:
+            - count
+            - count_distinct
+            - sum
+            - max
+            - min
+            - avg
+          alias:
+            description: 聚合结果的别名
+            type: string
+      group_by:
+        description: 分组维度列表
+        type: array
+        items:
+          type: object
+          properties:
+            property:
+              description: 分组维度字段名
+              type: string
+            description:
+              description: 维度描述（仅用于文档或调试）
+              type: string
+            calendar_interval:
+              description: date_histogram的calendar_interval参数，用于时间字段的分组，支持：minute, hour, day, week, month, quarter, year
+              type: string
+              enum:
+              - minute
+              - hour
+              - day
+              - week
+              - month
+              - quarter
+              - year
+      having:
+        description: 对聚合结果进行过滤的条件（HAVING子句）
+        type: object
+        properties:
+          field:
+            description: 聚合结果字段，固定为"__value"或"count(*)"
+            type: string
+          operation:
+            description: 过滤操作符，支持：==, !=, >, >=, <, <=, in, not_in, range, out_range
+            type: string
+            enum:
+            - "=="
+            - "!="
+            - ">"
+            - ">="
+            - "<"
+            - "<="
+            - in
+            - not_in
+            - range
+            - out_range
+          value:
+            description: 过滤值
+            type: object
     type: object
   interfaces.ResourceRequest:
     properties:

--- a/adp/vega/vega-backend/server/driveradapters/validate_resource_data.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_resource_data.go
@@ -211,6 +211,24 @@ func isAggregateQuery(params *interfaces.ResourceDataQueryParams) bool {
 	return params.Aggregation != nil || len(params.GroupBy) > 0 || params.Having != nil
 }
 
+// validateCalendarInterval 校验 calendar_interval 是否为有效的枚举值
+// 允许的值包括：minute, hour, day, week, month, quarter, year
+func validateCalendarInterval(ctx context.Context, calendarInterval string) error {
+	switch calendarInterval {
+	case interfaces.CALENDAR_UNIT_MINUTE,
+		interfaces.CALENDAR_UNIT_HOUR,
+		interfaces.CALENDAR_UNIT_DAY,
+		interfaces.CALENDAR_UNIT_WEEK,
+		interfaces.CALENDAR_UNIT_MONTH,
+		interfaces.CALENDAR_UNIT_QUARTER,
+		interfaces.CALENDAR_UNIT_YEAR:
+		return nil
+	default:
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_CalendarInterval).
+			WithErrorDetails(fmt.Sprintf("Invalid calendar_interval value: %s, must be one of: minute, hour, day, week, month, quarter, year", calendarInterval))
+	}
+}
+
 // validateAggregateParams 校验聚合查询参数
 func validateAggregateParams(ctx context.Context, params *interfaces.ResourceDataQueryParams) error {
 	// 校验aggregation
@@ -235,6 +253,13 @@ func validateAggregateParams(ctx context.Context, params *interfaces.ResourceDat
 		if groupByItem.Property == "" {
 			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_GroupBy).
 				WithErrorDetails("GroupBy property cannot be empty")
+		}
+		// 校验calendar_interval
+		if groupByItem.CalendarInterval != "" {
+			err := validateCalendarInterval(ctx, groupByItem.CalendarInterval)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/adp/vega/vega-backend/server/errors/resource.go
+++ b/adp/vega/vega-backend/server/errors/resource.go
@@ -19,6 +19,7 @@ const (
 	VegaBackend_InvalidParameter_GroupBy            = "VegaBackend.InvalidParameter.GroupBy"
 	VegaBackend_InvalidParameter_OrderBy            = "VegaBackend.InvalidParameter.OrderBy"
 	VegaBackend_InvalidParameter_Having             = "VegaBackend.InvalidParameter.Having"
+	VegaBackend_InvalidParameter_CalendarInterval   = "VegaBackend.InvalidParameter.CalendarInterval"
 
 	// 403 Forbidden
 	VegaBackend_Resource_NotFound        = "VegaBackend.Resource.NotFound"
@@ -51,6 +52,7 @@ var ResourceErrCodeList = []string{
 	VegaBackend_InvalidParameter_GroupBy,
 	VegaBackend_InvalidParameter_OrderBy,
 	VegaBackend_InvalidParameter_Having,
+	VegaBackend_InvalidParameter_CalendarInterval,
 	VegaBackend_Resource_NotFound,
 	VegaBackend_Resource_NameExists,
 	VegaBackend_Resource_IDExists,

--- a/adp/vega/vega-backend/server/interfaces/resource_data.go
+++ b/adp/vega/vega-backend/server/interfaces/resource_data.go
@@ -16,14 +16,14 @@ const (
 
 	DEFAULT_DATA_LIMIT = 10
 
-	// 日历间隔常量
-	CALENDAR_STEP_MINUTE  = "1m"
-	CALENDAR_STEP_HOUR    = "1h"
-	CALENDAR_STEP_DAY     = "1d"
-	CALENDAR_STEP_WEEK    = "1w"
-	CALENDAR_STEP_MONTH   = "1M"
-	CALENDAR_STEP_QUARTER = "1q"
-	CALENDAR_STEP_YEAR    = "1y"
+	// 日历间隔常量 - 参照OpenSearch的calendar_interval枚举定义
+	CALENDAR_UNIT_MINUTE  = "minute"
+	CALENDAR_UNIT_HOUR    = "hour"
+	CALENDAR_UNIT_DAY     = "day"
+	CALENDAR_UNIT_WEEK    = "week"
+	CALENDAR_UNIT_MONTH   = "month"
+	CALENDAR_UNIT_QUARTER = "quarter"
+	CALENDAR_UNIT_YEAR    = "year"
 )
 
 // SortField represents a field to sort by.
@@ -43,7 +43,7 @@ type Aggregation struct {
 type GroupByItem struct {
 	Property         string `json:"property"`                    // 分组维度
 	Description      string `json:"description,omitempty"`       // 仅文档/调试
-	CalendarInterval string `json:"calendar_interval,omitempty"` // date_histogram 的 calendar_interval 参数，如 "1d", "1w", "1M", "1y" 等
+	CalendarInterval string `json:"calendar_interval,omitempty"` // date_histogram 的 calendar_interval 参数，支持：minute, hour, day, week, month, quarter, year
 }
 
 // HavingClause represents a HAVING clause for aggregation filtering.

--- a/adp/vega/vega-backend/server/locale/errorcode.en-US.toml
+++ b/adp/vega/vega-backend/server/locale/errorcode.en-US.toml
@@ -63,6 +63,11 @@ Description = "Invalid having parameter"
 Solution = "Please check the having parameter"
 ErrorLink = "None"
 
+[VegaBackend.InvalidParameter.CalendarInterval]
+Description = "Invalid calendar interval parameter"
+Solution = "Calendar interval must be one of: minute, hour, day, week, month, quarter, year"
+ErrorLink = "None"
+
 [VegaBackend.InvalidParameter.Direction]
 Description = "Invalid direction parameter"
 Solution = "Please check the parameter"

--- a/adp/vega/vega-backend/server/locale/errorcode.zh-CN.toml
+++ b/adp/vega/vega-backend/server/locale/errorcode.zh-CN.toml
@@ -63,6 +63,11 @@ Description = "无效的Having参数"
 Solution = "请检查Having参数"
 ErrorLink = "暂无"
 
+[VegaBackend.InvalidParameter.CalendarInterval]
+Description = "无效的日历间隔参数"
+Solution = "日历间隔必须是 minute, hour, day, week, month, quarter, year 之一"
+ErrorLink = "暂无"
+
 [VegaBackend.InvalidParameter.Direction]
 Description = "无效的排序方向参数"
 Solution = "请检查参数"

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb_condition.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb_condition.go
@@ -525,8 +525,8 @@ func (c *MariaDBConnector) ConvertFilterConditionBetween(ctx context.Context, co
 
 		// 使用SqlExpr构建完整的WHERE条件表达式
 		return sq.Expr(
-			quoteColumnName(cond.Lfield.OriginalName)+" >= FROM_UNIXTIME(?/1000000) AND "+
-				quoteColumnName(cond.Lfield.OriginalName)+" <= FROM_UNIXTIME(?/1000000)",
+			quoteColumnName(cond.Lfield.OriginalName)+" >= FROM_UNIXTIME(?/1000) AND "+
+				quoteColumnName(cond.Lfield.OriginalName)+" <= FROM_UNIXTIME(?/1000)",
 			lowerTs, upperTs,
 		), nil
 	}

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb_query.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb_query.go
@@ -353,26 +353,25 @@ func formatInValues(value any) string {
 }
 
 // buildDateFormat 根据 calendar_interval 构建 date_format 表达式
+// 支持 OpenSearch 的 calendar_interval 枚举值：minute, hour, day, week, month, quarter, year
+// 注意：calendar_interval 的有效性已经在 validate_resource_data.go 中的 validateCalendarInterval 方法中验证过
 func (c *MariaDBConnector) buildDateFormat(alias, dateField, calendarInterval string) string {
 	var dateFmt string
 	switch calendarInterval {
-	case interfaces.CALENDAR_STEP_MINUTE:
+	case interfaces.CALENDAR_UNIT_MINUTE:
 		dateFmt = fmt.Sprintf(`date_format(%s,'%s')`, dateField, `%Y-%m-%d %H:%i`)
-	case interfaces.CALENDAR_STEP_HOUR:
+	case interfaces.CALENDAR_UNIT_HOUR:
 		dateFmt = fmt.Sprintf(`date_format(%s,'%s')`, dateField, `%Y-%m-%d %H`)
-	case interfaces.CALENDAR_STEP_DAY:
+	case interfaces.CALENDAR_UNIT_DAY:
 		dateFmt = fmt.Sprintf(`date_format(%s,'%s')`, dateField, `%Y-%m-%d`)
-	case interfaces.CALENDAR_STEP_WEEK:
+	case interfaces.CALENDAR_UNIT_WEEK:
 		dateFmt = fmt.Sprintf(`date_format(%s,'%s')`, dateField, `%x-%v`)
-	case interfaces.CALENDAR_STEP_MONTH:
+	case interfaces.CALENDAR_UNIT_MONTH:
 		dateFmt = fmt.Sprintf(`date_format(%s,'%s')`, dateField, `%Y-%m`)
-	case interfaces.CALENDAR_STEP_QUARTER:
+	case interfaces.CALENDAR_UNIT_QUARTER:
 		dateFmt = fmt.Sprintf(`format('%%d-Q%%d',year(%s),quarter(%s))`, dateField, dateField)
-	case interfaces.CALENDAR_STEP_YEAR:
+	case interfaces.CALENDAR_UNIT_YEAR:
 		dateFmt = fmt.Sprintf(`date_format(%s,'%s')`, dateField, `%Y`)
-	default:
-		// 默认按天分组
-		dateFmt = fmt.Sprintf(`date_format(%s,'%s')`, dateField, `%Y-%m-%d`)
 	}
 	return dateFmt
 }

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql_condition.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql_condition.go
@@ -514,8 +514,8 @@ func (c *PostgresqlConnector) ConvertFilterConditionBetween(ctx context.Context,
 
 		// 使用SqlExpr构建完整的WHERE条件表达式
 		return sq.Expr(
-			quoteColumnName(cond.Lfield.OriginalName)+" >= to_timestamp(?/1000000) AND "+
-				quoteColumnName(cond.Lfield.OriginalName)+" <= to_timestamp(?/1000000)",
+			quoteColumnName(cond.Lfield.OriginalName)+" >= to_timestamp(?/1000) AND "+
+				quoteColumnName(cond.Lfield.OriginalName)+" <= to_timestamp(?/1000)",
 			lowerTs, upperTs,
 		), nil
 	}

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql_ident.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql_ident.go
@@ -41,14 +41,3 @@ func quoteColumnName(name string) string {
 	}
 	return pgQuoteIdent(strings.TrimSpace(name))
 }
-
-// qualifyFieldForSQL 将 "alias.col" 转为带引号的限定名（用于 SELECT/ORDER BY/JOIN ON）。
-func qualifyFieldForSQL(field string) string {
-	field = strings.TrimSpace(field)
-	if idx := strings.Index(field, "."); idx >= 0 {
-		alias := field[:idx]
-		col := field[idx+1:]
-		return pgQuoteIdent(strings.TrimSpace(alias)) + "." + pgQuoteIdent(strings.TrimSpace(col))
-	}
-	return pgQuoteIdent(field)
-}


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [✅️] 调整/resources/{id}/data calendar_interval传参枚举限制，只支持minute, hour, day, week, month, quarter, year
- [✅️] 调整/resources/{id}/data 过滤条件中时间戳数值处理，默认毫秒级

---

## Why

- Related Issue: [Issue #334 ](link-to-issue)
- Background:
   - calendar_interval传参枚举与BKN服务对应接口保持一致
   - 时间戳数值处理异常，接口默认传参毫秒级
---

## How

- Key implementation points:
   - 调整/resources/{id}/data calendar_interval传参枚举限制，只支持minute, hour, day, week, month, quarter, year
   - 调整/resources/{id}/data 过滤条件中时间戳数值处理，默认毫秒级
