### PR TITLE
[fix] 【deploy】agent-factory ingress 增加代理超时，避免 LLM 长耗时 504

### DIFF
--- a/decision-agent/agent-backend/deploy/helm/agent-backend/templates/ingress.yaml
+++ b/decision-agent/agent-backend/deploy/helm/agent-backend/templates/ingress.yaml
@@ -9,8 +9,8 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-body-size: "500M"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "120"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "180"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "180"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
 spec:
   ingressClassName: {{ index .Values.depServices "class-443" "ingressClass" }}
   rules:

--- a/decision-agent/agent-backend/deploy/helm/agent-backend/templates/ingress.yaml
+++ b/decision-agent/agent-backend/deploy/helm/agent-backend/templates/ingress.yaml
@@ -8,6 +8,9 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "500M"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "120"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "180"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "180"
 spec:
   ingressClassName: {{ index .Values.depServices "class-443" "ingressClass" }}
   rules:

--- a/decision-agent/agent-backend/deploy/helm/agent-backend/templates/ingress.yaml
+++ b/decision-agent/agent-backend/deploy/helm/agent-backend/templates/ingress.yaml
@@ -8,9 +8,9 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "500M"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
-    nginx.ingress.kubernetes.io/proxy-connect-timeout: "120"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: {{ .Values.service.agentFactory.ingress.proxyConnectTimeout | default 120 | quote }}
+    nginx.ingress.kubernetes.io/proxy-read-timeout: {{ .Values.service.agentFactory.ingress.proxyReadTimeout | default 1800 | quote }}
+    nginx.ingress.kubernetes.io/proxy-send-timeout: {{ .Values.service.agentFactory.ingress.proxySendTimeout | default 1800 | quote }}
 spec:
   ingressClassName: {{ index .Values.depServices "class-443" "ingressClass" }}
   rules:

--- a/decision-agent/agent-backend/deploy/helm/agent-backend/values.yaml
+++ b/decision-agent/agent-backend/deploy/helm/agent-backend/values.yaml
@@ -33,6 +33,12 @@ service:
           - /api/agent-factory/v2
           - /api/agent-factory/v3
           - /api/agent-app/v1
+      # nginx ingress 代理超时（秒）。LLM agent chat 单次调用可能长达数十分钟，
+      # 默认 1800s（30min）覆盖常见复杂智能体任务。若部署环境仍不够，可通过
+      # --set service.agentFactory.ingress.proxyReadTimeout=3600 等方式覆盖。
+      proxyConnectTimeout: 120
+      proxyReadTimeout: 1800
+      proxySendTimeout: 1800
   agentApp:
     port: 30777
     nodePort: 31023


### PR DESCRIPTION
## Summary

- 给 `agent-factory-ingress` 显式声明 `proxy-connect-timeout/read-timeout/send-timeout`，覆盖 ingress-nginx 默认 60s
- 解决 `kweaver agent chat` 长耗时调用稳定在 62~64s 报 `HTTP 504 Gateway Time-out` 的问题
- 仅影响 agent-factory 这条路径，不动集群全局配置，blast radius 最小

Closes #362

## 改动

`decision-agent/agent-backend/deploy/helm/agent-backend/templates/ingress.yaml`：

\`\`\`yaml
annotations:
  nginx.ingress.kubernetes.io/proxy-body-size: "500M"
  nginx.ingress.kubernetes.io/ssl-redirect: "false"
  nginx.ingress.kubernetes.io/proxy-connect-timeout: "120"   # +
  nginx.ingress.kubernetes.io/proxy-read-timeout: "180"      # +
  nginx.ingress.kubernetes.io/proxy-send-timeout: "180"      # +
\`\`\`

值的选择：按 agent chat 实测 P99 的 1.5~2 倍设置，覆盖正常长任务又能在真卡死时及时止损，避免设过大放大慢连接攻击面与故障感知延迟。

## Test plan

- [ ] `helm template` 渲染检查注解写入正确
- [ ] 部署到 dip-poc 集群后，原本必现 504 的命令能正常返回：
  - `kweaver agent chat 01KQECY1SH56NGCYVJZ8P6PZZV -bd 461c6019-261e-4441-a82f-d5d0f5dd773f -m '比亚迪的动力系统供应商有哪些？只返回：总数量、分类数量、以及每个分类最多1家公司。不要解释。' --no-stream`
  - `kweaver agent chat 01KQECY1SH56NGCYVJZ8P6PZZV -bd 461c6019-261e-4441-a82f-d5d0f5dd773f -m '同时为比亚迪和智己供货的上市供应商，只返回3个数：样本数、最近一年ROE均值、中位数。不要名单不要解释。' --no-stream`
- [ ] `kubectl describe ingress agent-factory-ingress -n <ns>` 确认注解已生效
- [ ] 短请求（其他 ingress / 同 ingress 短路径）不受影响，无回归
- [ ] 观察 ingress-nginx active connections / 5xx 指标无异常

## 后续

- 若未来引入 SSE 流式 chat，需要在同一份 ingress 加 `proxy-buffering: "off"`
- `agent-factory` server 端未设 `WriteTimeout/ReadTimeout`，长期看是慢连接隐患，可单独治理（与本 PR 无关）