### PR TITLE
fix(deploy): HCE/openEuler install, Docker CE, CNI plugins, CoreDNS wait

### DIFF
--- a/deploy/preflight.sh
+++ b/deploy/preflight.sh
@@ -36,7 +36,7 @@ usage() {
     echo "  -y, --yes            Auto-approve every fix (skip per-fix y/N prompt)"
     echo "  -n, --no             Auto-decline every fix (preview risk text, change nothing)"
     echo "  --fix-allow=LIST     Comma-separated fix names to auto-approve (others are skipped)."
-    echo "                       Names: k3s-uninstall,kubeadm-reset,k8s-pkgs-repo,k8s-bins,containerd-install,helm-v3,"
+    echo "                       Names: k3s-uninstall,kubeadm-reset,k8s-pkgs-repo,k8s-bins,kubernetes-cni,containerd-install,helm-v3,"
     echo "                       docker-disable,chrony,firewalld,ufw,selinux,system-tuning,bridge-sysctl,kernel-limits,nofile-limits,iptables-legacy,etc-hosts,"
     echo "                       onboard-tooling,nodejs-npm,node-22,kweaver-sdk,kweaver-admin"
     echo "  --list-fixes         Run checks then list fixes that would be offered (no changes; requires root)"

--- a/deploy/scripts/lib/preflight_checks.sh
+++ b/deploy/scripts/lib/preflight_checks.sh
@@ -613,6 +613,28 @@ preflight_check_kubeadm_deps() {
     fi
 }
 
+# --- P0: CNI plugins for kubelet pod sandbox (/opt/cni/bin/loopback) -------------
+preflight_check_cni_bin_plugins() {
+    preflight_skip "cni-bin" && return 0
+    if [[ "$(uname -s)" != "Linux" ]]; then
+        preflight_ok "CNI bin plugins (skip on non-Linux)"
+        return
+    fi
+    if _preflight_kube_distro_is_k3s; then
+        preflight_ok "CNI bin plugins: skip (k3s bundles cluster networking)"
+        return
+    fi
+    if ! command -v kubelet &>/dev/null; then
+        preflight_ok "CNI bin plugins: skip (kubelet not installed yet)"
+        return
+    fi
+    if [[ -x /opt/cni/bin/loopback ]]; then
+        preflight_ok "CNI plugins present (/opt/cni/bin/loopback)"
+        return
+    fi
+    preflight_strict_warn_or_fail "kubelet is installed but /opt/cni/bin/loopback is missing (pods fail with FailedCreatePodSandBox loopback; sudo bash ./preflight.sh --fix → kubernetes-cni), or re-run deploy install_kubernetes"
+}
+
 # --- k3s path (KUBE_DISTRO=k3s): curl for installer ----------------------------
 preflight_check_k3s_prereqs() {
     preflight_skip "k3s-prereqs" && return 0
@@ -1753,6 +1775,20 @@ preflight_fix_k8s_bins() {
     fi
 }
 
+preflight_fix_kubernetes_cni() {
+    if ! declare -F _k8s_ensure_cni_bin_plugins &>/dev/null; then
+        preflight_warn "_k8s_ensure_cni_bin_plugins not defined — run deploy/preflight.sh (sources k8s.sh)"
+        return 1
+    fi
+    if _k8s_ensure_cni_bin_plugins; then
+        systemctl restart kubelet 2>/dev/null || true
+        preflight_fixed "Ensured /opt/cni/bin CNI plugins (_k8s_ensure_cni_bin_plugins); kubelet restarted"
+        return 0
+    fi
+    preflight_warn "_k8s_ensure_cni_bin_plugins failed (install kubernetes-cni or add CNI plugins tarball manually)"
+    return 1
+}
+
 # Optional fixes (called from preflight_apply_safe_fixes) --------------------
 preflight_fix_k3s_uninstall() {
     if [[ -x /usr/local/bin/k3s-killall.sh ]]; then
@@ -2076,7 +2112,7 @@ preflight_print_fix_preview() {
     for line in "${PREFLIGHT_FAIL_SNAPSHOT[@]}"; do
         log_info "  * ${line}"
     done
-    log_info "  Suggested fix names: k3s-uninstall (k8s/kubeadm path only), kubeadm-reset, k8s-pkgs-repo (writes apt OR yum/dnf pkgs.k8s.io repo; legacy name k8s-apt-source still works in --fix-allow), k8s-bins, containerd-install, helm-v3, docker-disable (stop/disable docker.service + docker.socket — CRI conflict with k3s or containerd), chrony, firewalld, ufw, selinux, system-tuning, bridge-sysctl, kernel-limits, nofile-limits (writes /etc/security/limits.d + systemd LimitNOFILE drop-ins), iptables-legacy, etc-hosts, onboard-tooling, nodejs-npm, node-22, kweaver-sdk, kweaver-admin (opt-in; bundle onboard-tooling asks if this host will run ./onboard.sh). Default distro is k8s (kubeadm); use --distro=k3s or KUBE_DISTRO=k3s for single-node k3s checks/fixes."
+    log_info "  Suggested fix names: k3s-uninstall (k8s/kubeadm path only), kubeadm-reset, k8s-pkgs-repo (writes apt OR yum/dnf pkgs.k8s.io repo; legacy name k8s-apt-source still works in --fix-allow), k8s-bins, kubernetes-cni (/opt/cni/bin loopback for kubelet pod sandbox), containerd-install, helm-v3, docker-disable (stop/disable docker.service + docker.socket — CRI conflict with k3s or containerd), chrony, firewalld, ufw, selinux, system-tuning, bridge-sysctl, kernel-limits, nofile-limits (writes /etc/security/limits.d + systemd LimitNOFILE drop-ins), iptables-legacy, etc-hosts, onboard-tooling, nodejs-npm, node-22, kweaver-sdk, kweaver-admin (opt-in; bundle onboard-tooling asks if this host will run ./onboard.sh). Default distro is k8s (kubeadm); use --distro=k3s or KUBE_DISTRO=k3s for single-node k3s checks/fixes."
     log_info "------------------------------------------------------------------"
 }
 
@@ -2308,6 +2344,17 @@ preflight_apply_safe_fixes() {
             fi
         else
             log_info "  -> skipping k8s-bins: package manager has no candidate for kubeadm yet (run k8s-pkgs-repo first)"
+        fi
+    fi
+
+    # --- 4c) CNI plugins (/opt/cni/bin) for kubeadm + containerd ----------------
+    if ! _preflight_kube_distro_is_k3s \
+        && command -v kubelet &>/dev/null \
+        && [[ ! -x /opt/cni/bin/loopback ]]; then
+        if preflight_confirm_fix "kubernetes-cni" \
+            "_k8s_ensure_cni_bin_plugins (kubernetes-cni RPM/apt or CNI plugins tarball → /opt/cni/bin)" \
+            "Writes CNI binaries under /opt/cni/bin; restarts kubelet. Required for pod sandboxes when kube* was installed without kubernetes-cni."; then
+            preflight_fix_kubernetes_cni
         fi
     fi
 
@@ -2597,6 +2644,7 @@ preflight_run_all_checks() {
     preflight_check_proxy
     preflight_check_dns
     preflight_check_kubeadm_deps
+    preflight_check_cni_bin_plugins
     preflight_check_k3s_prereqs
     preflight_check_network
     preflight_check_k8s_version

--- a/deploy/scripts/lib/preflight_checks.sh
+++ b/deploy/scripts/lib/preflight_checks.sh
@@ -369,7 +369,7 @@ preflight_check_os() {
     log_info "Checking OS and kernel..."
 
     if [[ ! -f /etc/os-release ]]; then
-        preflight_warn "No /etc/os-release (expected on RHEL/Debian/openEuler; macOS/others: run on Linux target host)"
+        preflight_warn "No /etc/os-release (expected on RHEL/Debian/openEuler/HCE; macOS/others: run on Linux target host)"
         return
     fi
     # shellcheck source=/dev/null
@@ -379,14 +379,16 @@ preflight_check_os() {
     local ok_os="no"
     case "${ID:-}" in
         centos|rhel|almalinux|rocky) [[ "${VERSION_ID%%.*}" -ge 8 ]] 2>/dev/null && ok_os="yes" || true ;;
-        openeuler) [[ "${VERSION_ID%%.*}" -ge 23 ]] 2>/dev/null && ok_os="yes" || true ;;
+        # Huawei Cloud EulerOS: os-release VERSION_ID is product series (e.g. 2.0), not el major
+        hce) [[ "${VERSION_ID%%.*}" -ge 2 ]] 2>/dev/null && ok_os="yes" || true ;;
+        openEuler|openeuler) [[ "${VERSION_ID%%.*}" -ge 23 ]] 2>/dev/null && ok_os="yes" || true ;;
         ubuntu) [[ "${VERSION_ID%%.*}" -ge 22 ]] 2>/dev/null && ok_os="yes" || true ;;
         *) true ;;
     esac
     if [[ "${ok_os}" == "yes" ]]; then
         preflight_ok "OS: ${ID:-unknown} ${VERSION_ID:-} (in supported set)"
     else
-        preflight_warn "OS: ${ID:-unknown} ${VERSION_ID:-} (expected CentOS 8+ / openEuler 23+ / Ubuntu 22.04+); verify before production"
+        preflight_warn "OS: ${ID:-unknown} ${VERSION_ID:-} (expected CentOS 8+ / HCE 2+ / openEuler 23+ / Ubuntu 22.04+); verify before production"
     fi
 
     local kver

--- a/deploy/scripts/services/k8s.sh
+++ b/deploy/scripts/services/k8s.sh
@@ -876,6 +876,64 @@ EOF
     log_info "crictl installed successfully"
 }
 
+# kubernetes-cni (RPM/apt) or containernetworking/plugins tarball provides
+# /opt/cni/bin/{loopback,bridge,...}. If only kubeadm/kubelet were pre-installed,
+# this directory is empty and kubelet fails with: failed to find plugin "loopback".
+_k8s_ensure_cni_bin_plugins() {
+    if [[ -x /opt/cni/bin/loopback ]]; then
+        return 0
+    fi
+
+    log_warn "Missing /opt/cni/bin/loopback — installing CNI plugins for kubelet pod sandbox"
+    detect_package_manager
+
+    if [[ "${PKG_MANAGER}" == "dnf" ]] || [[ "${PKG_MANAGER}" == "yum" ]]; then
+        log_info "Trying package kubernetes-cni..."
+        if [[ "${PKG_MANAGER}" == "dnf" ]]; then
+            dnf install -y --disableexcludes=kubernetes kubernetes-cni 2>/dev/null \
+                || dnf install -y kubernetes-cni \
+                || true
+        else
+            yum install -y --disableexcludes=kubernetes kubernetes-cni 2>/dev/null \
+                || yum install -y kubernetes-cni \
+                || true
+        fi
+    elif [[ "${PKG_MANAGER}" == "apt" ]]; then
+        ${PKG_MANAGER_INSTALL} kubernetes-cni 2>/dev/null || true
+    fi
+
+    if [[ -x /opt/cni/bin/loopback ]]; then
+        log_info "CNI plugins available under /opt/cni/bin"
+        return 0
+    fi
+
+    local v="${CNI_PLUGINS_VERSION:-v1.4.0}"
+    local arch=""
+    case "$(uname -m)" in
+        x86_64|amd64) arch="amd64" ;;
+        aarch64|arm64) arch="arm64" ;;
+        *)
+            log_error "No loopback CNI and unsupported arch for tarball fallback: $(uname -m)"
+            return 1
+            ;;
+    esac
+
+    local tgz="cni-plugins-linux-${arch}-${v}.tgz"
+    local url="https://github.com/containernetworking/plugins/releases/download/${v}/${tgz}"
+    log_info "Fetching ${tgz} into /opt/cni/bin..."
+    mkdir -p /opt/cni/bin
+    if curl -fsSL "${url}" | tar -C /opt/cni/bin -xzf -; then
+        chmod a+x /opt/cni/bin/* 2>/dev/null || true
+        if [[ -x /opt/cni/bin/loopback ]]; then
+            log_info "Installed CNI plugins from containernetworking/plugins ${v}"
+            return 0
+        fi
+    fi
+
+    log_error "Still no /opt/cni/bin/loopback. Install kubernetes-cni (RPM/apt) or unpack CNI plugins there, then restart kubelet."
+    return 1
+}
+
 # Install Kubernetes components (kubeadm, kubelet, kubectl)
 install_kubernetes() {
     log_info "Installing Kubernetes components..."
@@ -923,6 +981,8 @@ EOF
     else
         log_info "Kubernetes components are already installed"
     fi
+
+    _k8s_ensure_cni_bin_plugins || return 1
     
     # Install crictl (always install, even if K8s components already exist)
     install_crictl

--- a/deploy/scripts/services/k8s.sh
+++ b/deploy/scripts/services/k8s.sh
@@ -473,12 +473,16 @@ install_containerd() {
         log_info "Replacing Docker official URLs with Tsinghua mirror..."
         sed -i 's+https://download.docker.com+https://mirrors.tuna.tsinghua.edu.cn/docker-ce+g' /etc/yum.repos.d/docker-ce.repo
         
-        # Fix for openEuler: replace $releasever with 9 in repo file
+        # Fix distros whose $releasever does not match Docker CE repo layout
         if [[ -f /etc/os-release ]]; then
             source /etc/os-release
             if [[ "${ID}" == "openEuler" ]] || [[ "${ID}" == "openeuler" ]]; then
                 log_info "Detected openEuler system, fixing Docker CE repo paths..."
                 sed -i 's|\$releasever|9|g' /etc/yum.repos.d/docker-ce.repo
+            elif [[ "${ID}" == "hce" ]]; then
+                # Huawei Cloud EulerOS 2.x is el8-compatible; Docker mirrors expect 8 not VERSION_ID (e.g. 2.0)
+                log_info "Detected Huawei Cloud EulerOS (hce), fixing Docker CE repo paths for el8..."
+                sed -i 's|\$releasever|8|g' /etc/yum.repos.d/docker-ce.repo
             fi
         fi
         
@@ -568,6 +572,10 @@ install_containerd() {
             
             # Default to 8 if version detection fails
             if [[ -z "${rhel_version}" ]]; then
+                rhel_version="8"
+            fi
+            # HCE VERSION_ID is product series (2.0), not RHEL major; use el8 packages
+            if [[ "${os_id}" == "hce" ]]; then
                 rhel_version="8"
             fi
             

--- a/deploy/scripts/services/k8s.sh
+++ b/deploy/scripts/services/k8s.sh
@@ -330,9 +330,16 @@ install_cni() {
     local dns_attempts=0
     local dns_max_attempts=60
     while [[ ${dns_attempts} -lt ${dns_max_attempts} ]]; do
-        # Count ready pods using simple parsing
-        local ready_count
-        ready_count=$(kubectl get pods -n kube-system -l k8s-app=kube-dns --no-headers 2>/dev/null | grep -c "1/1.*Running" || echo "0")
+        # Count CoreDNS pods fully ready (N/N) and Running. grep -c exits 1 with 0
+        # matches — do not use `|| echo 0` or command substitution captures "0\n0".
+        # CoreDNS may be 1/1 or 2/2 (e.g. readiness sidecar) depending on cluster version.
+        ready_count=$(kubectl get pods -n kube-system -l k8s-app=kube-dns --no-headers 2>/dev/null | awk '
+            $3 == "Running" {
+                n = split($2, r, "/")
+                if (n == 2 && r[1] == r[2] && r[1] ~ /^[0-9]+$/ && r[1] > 0) c++
+            }
+            END { print c + 0 }
+        ')
         
         if [[ ${ready_count} -ge 2 ]]; then
             log_info "CoreDNS is ready (${ready_count} pods running)"

--- a/deploy/scripts/services/k8s.sh
+++ b/deploy/scripts/services/k8s.sh
@@ -440,6 +440,12 @@ _fix_docker_ce_repo_releasever_for_distro() {
     [[ -f /etc/os-release ]] || return 0
     # shellcheck source=/dev/null
     . /etc/os-release
+    local is_hce="no"
+    [[ "${ID:-}" == "hce" ]] && is_hce="yes"
+    if [[ "${is_hce}" == "no" ]] && { [[ "${NAME:-}" == *"Huawei Cloud EulerOS"* ]] || [[ "${PRETTY_NAME:-}" == *"Huawei Cloud EulerOS"* ]]; }; then
+        is_hce="yes"
+    fi
+
     case "${ID:-}" in
         openEuler|openeuler)
             log_info "Pinning Docker CE repo paths for openEuler..."
@@ -452,7 +458,14 @@ _fix_docker_ce_repo_releasever_for_distro() {
             sed -i 's|/linux/centos/2\.[0-9]*/|/linux/centos/8/|g' "${repo_file}"
             sed -i 's|/linux/centos/2/|/linux/centos/8/|g' "${repo_file}"
             ;;
-        *) ;;
+        *)
+            if [[ "${is_hce}" == "yes" ]]; then
+                log_info "Pinning Docker CE repo paths for Huawei Cloud EulerOS (detected via NAME/PRETTY_NAME)..."
+                sed -i 's|\$releasever|8|g' "${repo_file}"
+                sed -i 's|/linux/centos/2\.[0-9]*/|/linux/centos/8/|g' "${repo_file}"
+                sed -i 's|/linux/centos/2/|/linux/centos/8/|g' "${repo_file}"
+            fi
+            ;;
     esac
 }
 
@@ -616,7 +629,19 @@ install_containerd() {
             set +e
             if curl -fsSLo "${rpm_file}" "${rpm_url}"; then
                 log_info "Downloaded RPM successfully, installing..."
-                ${PKG_MANAGER_INSTALL} "${rpm_file}"
+                # dnf still refreshes all *enabled* repos before a local RPM install; a broken
+                # docker-ce-stable (HCE $releasever→2.0) would fail the transaction — disable all
+                # docker-ce* repoids from the repo file while resolving deps from OS base repos.
+                local -a _dce_disable=()
+                if [[ -f /etc/yum.repos.d/docker-ce.repo ]]; then
+                    while IFS= read -r _line || [[ -n "${_line}" ]]; do
+                        if [[ "${_line}" =~ ^\[([^][]+)\] ]]; then
+                            _dce_disable+=( "--disablerepo=${BASH_REMATCH[1]}" )
+                        fi
+                    done < /etc/yum.repos.d/docker-ce.repo
+                fi
+                _fix_docker_ce_repo_releasever_for_distro
+                ${PKG_MANAGER_INSTALL} "${_dce_disable[@]}" --nogpgcheck "${rpm_file}"
                 install_rc=$?
                 rm -f "${rpm_file}"
                 
@@ -641,7 +666,7 @@ install_containerd() {
             log_error ""
             log_info "  Option 1: Download and install RPM directly"
             log_info "    curl -fsSLo /tmp/containerd.io.rpm https://mirrors.tuna.tsinghua.edu.cn/docker-ce/linux/centos/\$(rpm -E %rhel)/\$(uname -m)/stable/Packages/containerd.io-1.6.32-3.1.el\$(rpm -E %rhel).\$(uname -m).rpm"
-            log_info "    dnf install -y /tmp/containerd.io.rpm"
+            log_info "    dnf install -y --disablerepo=docker-ce-stable --disablerepo=docker-ce-test /tmp/containerd.io.rpm"
             log_error ""
             log_info "  Option 2: Install from Aliyun mirror"
             log_info "    dnf config-manager --add-repo http://mirrors.aliyun.com/docker-ce/linux/centos/docker-ce.repo"

--- a/deploy/scripts/services/k8s.sh
+++ b/deploy/scripts/services/k8s.sh
@@ -431,6 +431,31 @@ install_helm() {
     log_info "Helm 3 installed successfully"
 }
 
+# Docker CE .repo uses $releasever in paths. On HCE/openEuler, DNF expands that
+# from /etc/os-release to a product version (e.g. 2.0) instead of el major — Docker
+# mirrors only host centos/8,9,... Pin the .repo file to a valid tree.
+_fix_docker_ce_repo_releasever_for_distro() {
+    local repo_file="/etc/yum.repos.d/docker-ce.repo"
+    [[ -f "${repo_file}" ]] || return 0
+    [[ -f /etc/os-release ]] || return 0
+    # shellcheck source=/dev/null
+    . /etc/os-release
+    case "${ID:-}" in
+        openEuler|openeuler)
+            log_info "Pinning Docker CE repo paths for openEuler..."
+            sed -i 's|\$releasever|9|g' "${repo_file}"
+            ;;
+        hce)
+            log_info "Pinning Docker CE repo paths for Huawei Cloud EulerOS (el8, not VERSION_ID)..."
+            sed -i 's|\$releasever|8|g' "${repo_file}"
+            # If the file was ever expanded or edited to literal HCE VERSION_ID paths, fix those too
+            sed -i 's|/linux/centos/2\.[0-9]*/|/linux/centos/8/|g' "${repo_file}"
+            sed -i 's|/linux/centos/2/|/linux/centos/8/|g' "${repo_file}"
+            ;;
+        *) ;;
+    esac
+}
+
 # Install containerd container runtime
 install_containerd() {
     log_info "Checking containerd installation..."
@@ -472,19 +497,8 @@ install_containerd() {
         # Replace official Docker download URLs with Tsinghua mirror
         log_info "Replacing Docker official URLs with Tsinghua mirror..."
         sed -i 's+https://download.docker.com+https://mirrors.tuna.tsinghua.edu.cn/docker-ce+g' /etc/yum.repos.d/docker-ce.repo
-        
-        # Fix distros whose $releasever does not match Docker CE repo layout
-        if [[ -f /etc/os-release ]]; then
-            source /etc/os-release
-            if [[ "${ID}" == "openEuler" ]] || [[ "${ID}" == "openeuler" ]]; then
-                log_info "Detected openEuler system, fixing Docker CE repo paths..."
-                sed -i 's|\$releasever|9|g' /etc/yum.repos.d/docker-ce.repo
-            elif [[ "${ID}" == "hce" ]]; then
-                # Huawei Cloud EulerOS 2.x is el8-compatible; Docker mirrors expect 8 not VERSION_ID (e.g. 2.0)
-                log_info "Detected Huawei Cloud EulerOS (hce), fixing Docker CE repo paths for el8..."
-                sed -i 's|\$releasever|8|g' /etc/yum.repos.d/docker-ce.repo
-            fi
-        fi
+
+        _fix_docker_ce_repo_releasever_for_distro
         
         # Clean and makecache for the new repo
         ${PKG_MANAGER} clean all
@@ -523,24 +537,27 @@ install_containerd() {
             fi
         fi
         
-        # Configure Docker CE repo if not exists (Aliyun mirror only)
+        # Configure Docker CE repo (create if missing; always pin $releasever for HCE/openEuler)
         if [[ ! -f /etc/yum.repos.d/docker-ce.repo ]]; then
             log_info "Configuring Docker CE yum repo: ${DOCKER_CE_REPO_URL}"
             configure_docker_repo "${DOCKER_CE_REPO_URL}"
-            
-            set +e
-            ${PKG_MANAGER_UPDATE}
-            local update_rc=$?
-            set -e
+        else
+            log_info "Docker CE repo file already exists; applying distro-specific path fixes if needed"
+            _fix_docker_ce_repo_releasever_for_distro
+        fi
 
-            if [[ ${update_rc} -ne 0 ]]; then
-                log_error "Failed to update package metadata with Docker CE repo."
-                log_error "Please ensure network connectivity and try again, or manually install containerd.io package."
-                log_info "You can manually install containerd using one of these methods:"
-                log_info "  1. dnf install -y containerd.io (after configuring Docker repo)"
-                log_info "  2. Download and install RPM: https://mirrors.tuna.tsinghua.edu.cn/docker-ce/linux/centos/"
-                return 1
-            fi
+        set +e
+        ${PKG_MANAGER_UPDATE}
+        local update_rc=$?
+        set -e
+
+        if [[ ${update_rc} -ne 0 ]]; then
+            log_error "Failed to update package metadata with Docker CE repo."
+            log_error "Please ensure network connectivity and try again, or manually install containerd.io package."
+            log_info "You can manually install containerd using one of these methods:"
+            log_info "  1. dnf install -y containerd.io (after configuring Docker repo)"
+            log_info "  2. Download and install RPM: https://mirrors.tuna.tsinghua.edu.cn/docker-ce/linux/centos/"
+            return 1
         fi
 
         # Attempt installation with both base and docker-ce repos for CentOS 7


### PR DESCRIPTION
## Summary
Deploy/preflight hardening for **Huawei Cloud EulerOS (hce)** and **openEuler**, reliable **containerd / Docker CE** installs on RPM hosts, missing **CNI bin** when kube binaries were pre-installed, and a **CoreDNS wait** loop fix.

## Changes
- **preflight**: Recognize `ID=openEuler` (casing) and `ID=hce` (v2+); warn text updated.
- **k8s.sh** (`install_containerd`): Pin Docker CE `\$releasever` for hce (el8) and openEuler; fix **existing** `docker-ce.repo` before `makecache`; use `--disablerepo` for all docker-ce sections when installing a **local** `containerd.io` RPM so dnf does not refresh broken metadata.
- **k8s.sh** (`install_kubernetes`): Add `_k8s_ensure_cni_bin_plugins` so pre-installed kubeadm/kubelet without `kubernetes-cni` still get `/opt/cni/bin/loopback` (package or containernetworking/plugins tarball fallback).
- **preflight**: `preflight_check_cni_bin_plugins`, fix step `kubernetes-cni` calling the same helper; `preflight.sh` help lists the fix name.
- **k8s.sh** (Flannel/CoreDNS wait): Replace `grep -c … || echo 0` with `awk` counting **N/N Running** pods (avoids `0\n0` breaking `[[` arithmetic; supports CoreDNS **2/2**).

## Notes
- **KWEAVER_LIGHTWEIGHT_RESOURCES** was reverted from this branch before opening the PR (net: not included).

## Test plan
- [ ] `bash -n deploy/scripts/services/k8s.sh deploy/scripts/lib/preflight_checks.sh`
- [ ] On **hce**: `preflight.sh --check-only` shows OS OK; `containerd-install` / full k8s path completes after Docker repo fix.
- [ ] Node with kube* but no CNI: `_k8s_ensure_cni_bin_plugins` or preflight `kubernetes-cni` fixes sandbox.