### PR TITLE
fix(bkn-backend): 0.8.0 迁移补齐指标表字段并与代码对齐 (#353)

### DIFF
--- a/adp/bkn/bkn-backend/migrations/mariadb/0.8.0/01-alter-table.sql
+++ b/adp/bkn/bkn-backend/migrations/mariadb/0.8.0/01-alter-table.sql
@@ -21,7 +21,7 @@ ALTER TABLE t_metric_definition
   ADD COLUMN IF NOT EXISTS f_color VARCHAR(40) NOT NULL DEFAULT '' COMMENT '颜色' AFTER f_icon;
 
 ALTER TABLE t_metric_definition
-  ADD COLUMN IF NOT EXISTS f_bkn_raw_content MEDIUMTEXT NOT NULL DEFAULT '' COMMENT 'BKNRawContent' AFTER f_color;
+  ADD COLUMN IF NOT EXISTS f_bkn_raw_content MEDIUMTEXT NULL COMMENT 'BKNRawContent' AFTER f_color;
 
 UPDATE t_metric_definition SET f_bkn_raw_content = '' WHERE f_bkn_raw_content IS NULL;
 

--- a/adp/bkn/bkn-backend/migrations/mariadb/0.8.0/01-alter-table.sql
+++ b/adp/bkn/bkn-backend/migrations/mariadb/0.8.0/01-alter-table.sql
@@ -1,0 +1,29 @@
+-- Copyright The kweaver.ai Authors.
+--
+-- Licensed under the Apache License, Version 2.0.
+-- See the LICENSE file in the project root for details.
+
+-- ==========================================
+-- 0.7.0 → 0.8.0 升级脚本
+-- t_metric_definition：补充 0.7.0 增量建表脚本遗漏的字段
+-- （与 mariadb/0.7.0/init.sql 中指标表定义对齐）
+-- 使用 IF NOT EXISTS：兼容已通过 init.sql 建表的环境（已有这些列）。
+-- ==========================================
+USE kweaver;
+
+ALTER TABLE t_metric_definition
+  ADD COLUMN IF NOT EXISTS f_tags VARCHAR(255) DEFAULT NULL COMMENT '标签' AFTER f_comment;
+
+ALTER TABLE t_metric_definition
+  ADD COLUMN IF NOT EXISTS f_icon VARCHAR(255) NOT NULL DEFAULT '' COMMENT '图标' AFTER f_tags;
+
+ALTER TABLE t_metric_definition
+  ADD COLUMN IF NOT EXISTS f_color VARCHAR(40) NOT NULL DEFAULT '' COMMENT '颜色' AFTER f_icon;
+
+ALTER TABLE t_metric_definition
+  ADD COLUMN IF NOT EXISTS f_bkn_raw_content MEDIUMTEXT NOT NULL DEFAULT '' COMMENT 'BKNRawContent' AFTER f_color;
+
+UPDATE t_metric_definition SET f_bkn_raw_content = '' WHERE f_bkn_raw_content IS NULL;
+
+ALTER TABLE t_metric_definition
+  MODIFY COLUMN f_bkn_raw_content MEDIUMTEXT NOT NULL COMMENT 'BKNRawContent' AFTER f_color;

--- a/adp/bkn/bkn-backend/migrations/mariadb/0.8.0/init.sql
+++ b/adp/bkn/bkn-backend/migrations/mariadb/0.8.0/init.sql
@@ -1,0 +1,279 @@
+-- Copyright The kweaver.ai Authors.
+--
+-- Licensed under the Apache License, Version 2.0.
+-- See the LICENSE file in the project root for details.
+
+USE kweaver;
+
+
+-- 业务知识网络
+CREATE TABLE IF NOT EXISTS t_knowledge_network (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络id',
+  f_name VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络名称',
+  f_tags VARCHAR(255) DEFAULT NULL COMMENT '标签',
+  f_comment TEXT NOT NULL COMMENT '备注',
+  f_icon VARCHAR(255) NOT NULL DEFAULT '' COMMENT '图标',
+  f_color VARCHAR(40) NOT NULL DEFAULT '' COMMENT '颜色',
+  f_bkn_raw_content MEDIUMTEXT NOT NULL COMMENT 'BKNRawContent',
+  f_skill_content MEDIUMTEXT NOT NULL COMMENT 'SkillContent',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT '分支',
+  f_business_domain VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务域',
+  f_creator VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
+  f_creator_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
+  f_create_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+  f_updater VARCHAR(40) NOT NULL DEFAULT '' COMMENT '更新者id',
+  f_updater_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '更新者类型',
+  f_update_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
+  PRIMARY KEY (f_id,f_branch),
+  UNIQUE KEY uk_kn_name (f_name,f_branch)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = '业务知识网络';
+
+
+-- 对象类
+CREATE TABLE IF NOT EXISTS t_object_type (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '对象类id',
+  f_name VARCHAR(40) NOT NULL DEFAULT '' COMMENT '对象类名称',
+  f_tags VARCHAR(255) DEFAULT NULL COMMENT '标签',
+  f_comment TEXT NOT NULL COMMENT '备注',
+  f_icon VARCHAR(255) NOT NULL DEFAULT '' COMMENT '图标',
+  f_color VARCHAR(40) NOT NULL DEFAULT '' COMMENT '颜色',
+  f_bkn_raw_content MEDIUMTEXT NOT NULL COMMENT 'BKNRawContent',
+  f_kn_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络id',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT '分支',
+  f_data_source VARCHAR(255) NOT NULL COMMENT '数据来源，当前只有视图',
+  f_data_properties LONGTEXT DEFAULT NULL COMMENT '数据属性',
+  f_logic_properties MEDIUMTEXT DEFAULT NULL COMMENT '逻辑属性',
+  f_primary_keys VARCHAR(8192) DEFAULT NULL COMMENT '对象类主键',
+  f_display_key VARCHAR(40) NOT NULL DEFAULT '' COMMENT '对象实例的显示属性',
+  f_incremental_key VARCHAR(40) NOT NULL DEFAULT '' COMMENT '对象类增量键',
+  f_creator VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
+  f_creator_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
+  f_create_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+  f_updater VARCHAR(40) NOT NULL DEFAULT '' COMMENT '更新者id',
+  f_updater_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '更新者类型',
+  f_update_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
+  PRIMARY KEY (f_kn_id,f_branch,f_id),
+  UNIQUE KEY uk_object_type_name (f_kn_id,f_branch,f_name)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = '对象类';
+
+
+-- 对象类状态
+CREATE TABLE IF NOT EXISTS t_object_type_status (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '对象类id',
+  f_kn_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络id',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT '分支',
+  f_incremental_key VARCHAR(40) NOT NULL DEFAULT '' COMMENT '对象类增量键',
+  f_incremental_value VARCHAR(40) NOT NULL DEFAULT '' COMMENT '对象类当前增量值',
+  f_index VARCHAR(255) NOT NULL DEFAULT '' COMMENT '索引名称',
+  f_index_available BOOLEAN NOT NULL DEFAULT 0 COMMENT '索引是否可用',
+  f_doc_count BIGINT(20) NOT NULL DEFAULT 0 COMMENT '文档数量',
+  f_storage_size BIGINT(20) NOT NULL DEFAULT 0 COMMENT '存储大小',
+  f_update_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
+  PRIMARY KEY (f_kn_id,f_branch,f_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = '对象类状态';
+
+
+-- 关系类
+CREATE TABLE IF NOT EXISTS t_relation_type (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '关系类id',
+  f_name VARCHAR(40) NOT NULL DEFAULT '' COMMENT '关系类名称',
+  f_tags VARCHAR(255) DEFAULT NULL COMMENT '标签',
+  f_comment TEXT NOT NULL COMMENT '备注',
+  f_icon VARCHAR(255) NOT NULL DEFAULT '' COMMENT '图标',
+  f_color VARCHAR(40) NOT NULL DEFAULT '' COMMENT '颜色',
+  f_bkn_raw_content MEDIUMTEXT NOT NULL COMMENT 'BKNRawContent',
+  f_kn_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络id',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT '分支',
+  f_source_object_type_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '起点对象类',
+  f_target_object_type_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '终点对象类',
+  f_type VARCHAR(40) NOT NULL DEFAULT '' COMMENT '关联类型',
+  f_mapping_rules TEXT DEFAULT NULL COMMENT '关联规则',
+  f_creator VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
+  f_creator_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
+  f_create_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+  f_updater VARCHAR(40) NOT NULL DEFAULT '' COMMENT '更新者id',
+  f_updater_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '更新者类型',
+  f_update_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
+  PRIMARY KEY (f_kn_id,f_branch,f_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = '关系类';
+
+
+-- 行动类
+CREATE TABLE IF NOT EXISTS t_action_type (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '行动类id',
+  f_name VARCHAR(40) NOT NULL DEFAULT '' COMMENT '行动类名称',
+  f_tags VARCHAR(255) DEFAULT NULL COMMENT '标签',
+  f_comment TEXT NOT NULL COMMENT '备注',
+  f_icon VARCHAR(255) NOT NULL DEFAULT '' COMMENT '图标',
+  f_color VARCHAR(40) NOT NULL DEFAULT '' COMMENT '颜色',
+  f_bkn_raw_content MEDIUMTEXT NOT NULL COMMENT 'BKNRawContent',
+  f_kn_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络id',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT '分支',
+  f_action_type VARCHAR(40) NOT NULL DEFAULT '' COMMENT '行动类型',
+  f_object_type_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '对象类',
+  f_condition TEXT DEFAULT NULL COMMENT '行动条件',
+  f_affect TEXT DEFAULT NULL COMMENT '行动影响',
+  f_action_source VARCHAR(255) NOT NULL COMMENT '行动资源',
+  f_parameters TEXT DEFAULT NULL COMMENT '行动参数',
+  f_schedule VARCHAR(255) DEFAULT NULL COMMENT '行动监听',
+  f_creator VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
+  f_creator_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
+  f_create_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+  f_updater VARCHAR(40) NOT NULL DEFAULT '' COMMENT '更新者id',
+  f_updater_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '更新者类型',
+  f_update_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
+  PRIMARY KEY (f_kn_id,f_branch,f_id),
+  UNIQUE KEY uk_action_type_name (f_kn_id,f_branch,f_name)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = '行动类';
+
+
+-- 任务管理
+CREATE TABLE IF NOT EXISTS t_kn_job (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '任务id',
+  f_name VARCHAR(40) NOT NULL DEFAULT '' COMMENT '任务名称',
+  f_kn_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络id',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT '分支',
+  f_job_type VARCHAR(40) NOT NULL DEFAULT '' COMMENT '任务类型',
+  f_job_concept_config MEDIUMTEXT DEFAULT NULL COMMENT '任务概念配置',
+  f_state VARCHAR(40) NOT NULL DEFAULT '' COMMENT '状态',
+  f_state_detail TEXT DEFAULT NULL COMMENT '状态详情',
+  f_creator VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
+  f_creator_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
+  f_create_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+  f_finish_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '完成时间',
+  f_time_cost BIGINT(20) NOT NULL DEFAULT 0 COMMENT '耗时',
+  PRIMARY KEY (f_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = '任务';
+
+
+-- 子任务管理
+CREATE TABLE IF NOT EXISTS t_kn_task (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '子任务id',
+  f_name VARCHAR(40) NOT NULL DEFAULT '' COMMENT '子任务名称',
+  f_job_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '任务id',
+  f_concept_type VARCHAR(40) NOT NULL DEFAULT '' COMMENT '概念类型',
+  f_concept_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '概念id',
+  f_index VARCHAR(255) NOT NULL DEFAULT '' COMMENT '索引名称',
+  f_doc_count BIGINT(20) NOT NULL DEFAULT 0 COMMENT '文档数量',
+  f_state VARCHAR(40) NOT NULL DEFAULT '' COMMENT '状态',
+  f_state_detail TEXT DEFAULT NULL COMMENT '状态详情',
+  f_start_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '开始时间',
+  f_finish_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '完成时间',
+  f_time_cost BIGINT(20) NOT NULL DEFAULT 0 COMMENT '耗时',
+  PRIMARY KEY (f_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = '子任务';
+
+
+-- 概念分组
+CREATE TABLE IF NOT EXISTS t_concept_group (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '概念分组id',
+  f_name VARCHAR(40) NOT NULL DEFAULT '' COMMENT '概念分组名称',
+  f_tags VARCHAR(255) DEFAULT NULL COMMENT '标签',
+  f_comment TEXT NOT NULL COMMENT '备注',
+  f_icon VARCHAR(255) NOT NULL DEFAULT '' COMMENT '图标',
+  f_color VARCHAR(40) NOT NULL DEFAULT '' COMMENT '颜色',
+  f_bkn_raw_content MEDIUMTEXT NOT NULL COMMENT 'BKNRawContent',
+  f_kn_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络id',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT '分支',
+  f_creator VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
+  f_creator_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
+  f_create_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+  f_updater VARCHAR(40) NOT NULL DEFAULT '' COMMENT '更新者id',
+  f_updater_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '更新者类型',
+  f_update_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
+  PRIMARY KEY (f_kn_id,f_branch,f_id),
+  UNIQUE KEY uk_concept_group_name (f_kn_id,f_branch,f_name)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = '概念分组';
+
+
+-- 分组与概念对应表
+CREATE TABLE IF NOT EXISTS t_concept_group_relation (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '主键id',
+  f_kn_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络id',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT '分支',
+  f_group_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '概念分组id',
+  f_concept_type VARCHAR(40) NOT NULL DEFAULT '' COMMENT '概念类型',
+  f_concept_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '概念id',
+  f_create_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+  PRIMARY KEY (f_id),
+  UNIQUE KEY uk_concept_group_relation (f_kn_id,f_branch,f_group_id,f_concept_type,f_concept_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = '分组与概念对应表';
+
+
+-- Action Schedule Management
+-- Supports cron-based scheduled action execution with distributed locking
+CREATE TABLE IF NOT EXISTS t_action_schedule (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT 'Schedule ID',
+  f_name VARCHAR(100) NOT NULL DEFAULT '' COMMENT 'Schedule name',
+  f_kn_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT 'Knowledge network ID',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT 'Branch',
+  f_action_type_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT 'Action type ID to execute',
+  f_cron_expression VARCHAR(100) NOT NULL DEFAULT '' COMMENT 'Standard 5-field cron expression (min hour dom mon dow)',
+  f_instance_identities MEDIUMTEXT DEFAULT NULL COMMENT 'JSON array of target object instance identities',
+  f_dynamic_params MEDIUMTEXT DEFAULT NULL COMMENT 'JSON object of dynamic parameters',
+  f_status VARCHAR(20) NOT NULL DEFAULT 'inactive' COMMENT 'Schedule status: active or inactive',
+  f_last_run_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT 'Last execution timestamp (ms)',
+  f_next_run_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT 'Next scheduled run timestamp (ms)',
+  f_lock_holder VARCHAR(64) DEFAULT NULL COMMENT 'Pod ID holding execution lock (NULL = unlocked)',
+  f_lock_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT 'Lock acquisition timestamp (ms) for timeout detection',
+  f_creator VARCHAR(40) NOT NULL DEFAULT '' COMMENT 'Creator ID',
+  f_creator_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT 'Creator type',
+  f_create_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT 'Create timestamp (ms)',
+  f_updater VARCHAR(40) NOT NULL DEFAULT '' COMMENT 'Updater ID',
+  f_updater_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT 'Updater type',
+  f_update_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT 'Update timestamp (ms)',
+  PRIMARY KEY (f_id),
+  KEY idx_kn_branch (f_kn_id, f_branch),
+  KEY idx_status_next_run (f_status, f_next_run_time),
+  KEY idx_action_type (f_action_type_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = 'Action schedule for cron-based execution';
+
+
+-- Risk Type
+CREATE TABLE IF NOT EXISTS t_risk_type (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '风险类ID',
+  f_name VARCHAR(40) NOT NULL DEFAULT '' COMMENT '风险类名称',
+  f_comment TEXT NOT NULL COMMENT '描述',
+  f_tags VARCHAR(255) DEFAULT NULL COMMENT '标签',
+  f_icon VARCHAR(255) NOT NULL DEFAULT '' COMMENT '图标',
+  f_color VARCHAR(40) NOT NULL DEFAULT '' COMMENT '颜色',
+  f_bkn_raw_content MEDIUMTEXT NOT NULL COMMENT 'BKNRawContent',
+  f_kn_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络ID',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT '分支',
+  f_creator VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
+  f_creator_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
+  f_create_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+  f_updater VARCHAR(40) NOT NULL DEFAULT '' COMMENT '更新者id',
+  f_updater_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '更新者类型',
+  f_update_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
+  PRIMARY KEY (f_kn_id, f_branch, f_id),
+  UNIQUE KEY uk_risk_type_name (f_kn_id, f_branch, f_name)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = '风险类';
+
+CREATE TABLE IF NOT EXISTS t_metric_definition (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '指标ID',
+  f_name VARCHAR(128) NOT NULL DEFAULT '' COMMENT '指标技术名',
+  f_comment TEXT NOT NULL COMMENT '描述',
+  f_tags VARCHAR(255) DEFAULT NULL COMMENT '标签',
+  f_icon VARCHAR(255) NOT NULL DEFAULT '' COMMENT '图标',
+  f_color VARCHAR(40) NOT NULL DEFAULT '' COMMENT '颜色',
+  f_bkn_raw_content MEDIUMTEXT NOT NULL COMMENT 'BKNRawContent',
+  f_kn_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络ID',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT '分支',
+  f_unit_type VARCHAR(64) NOT NULL DEFAULT '' COMMENT '单位类型',
+  f_unit VARCHAR(64) NOT NULL DEFAULT '' COMMENT '单位',
+  f_metric_type VARCHAR(32) NOT NULL DEFAULT 'atomic' COMMENT '指标类型 atomic|derived|composite',
+  f_scope_type VARCHAR(32) NOT NULL DEFAULT 'object_type' COMMENT '统计主体类型',
+  f_scope_ref VARCHAR(40) NOT NULL DEFAULT '' COMMENT '对象类或子图ID',
+  f_time_dimension LONGTEXT DEFAULT NULL COMMENT '时间维度 JSON',
+  f_calculation_formula LONGTEXT NOT NULL COMMENT '计算公式 JSON',
+  f_analysis_dimensions LONGTEXT DEFAULT NULL COMMENT '分析维度 JSON',
+  f_creator VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
+  f_creator_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
+  f_create_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+  f_updater VARCHAR(40) NOT NULL DEFAULT '' COMMENT '更新者id',
+  f_updater_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '更新者类型',
+  f_update_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
+  PRIMARY KEY (f_kn_id, f_branch, f_id),
+  UNIQUE KEY uk_metric_name (f_kn_id, f_branch, f_name)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = 'BKN 指标定义';

--- a/adp/bkn/bkn-backend/server/drivenadapters/metric/metric_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/metric/metric_access.go
@@ -15,6 +15,7 @@ import (
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/kweaver-ai/TelemetrySDK-Go/exporter/v2/ar_trace"
+	libCommon "github.com/kweaver-ai/kweaver-go-lib/common"
 	libdb "github.com/kweaver-ai/kweaver-go-lib/db"
 	"github.com/kweaver-ai/kweaver-go-lib/logger"
 	"go.opentelemetry.io/otel/codes"
@@ -67,6 +68,7 @@ func scanMetricFromRow(scanner interface {
 	metric := &interfaces.MetricDefinition{}
 	var (
 		timeDim, calcFormula, analysisDim sql.NullString
+		tags                              sql.NullString
 	)
 	err := scanner.Scan(
 		&metric.ID,
@@ -74,6 +76,10 @@ func scanMetricFromRow(scanner interface {
 		&metric.Branch,
 		&metric.Name,
 		&metric.Comment,
+		&tags,
+		&metric.Icon,
+		&metric.Color,
+		&metric.BKNRawContent,
 		&metric.UnitType,
 		&metric.Unit,
 		&metric.MetricType,
@@ -94,6 +100,10 @@ func scanMetricFromRow(scanner interface {
 			logger.Errorf("metric row scan error: %v", err)
 		}
 		return nil, err
+	}
+
+	if tags.Valid {
+		metric.Tags = libCommon.TagString2TagSlice(tags.String)
 	}
 
 	if timeDim.Valid && timeDim.String != "" {
@@ -126,6 +136,7 @@ func (ma *metricAccess) CreateMetric(ctx context.Context, tx *sql.Tx, def *inter
 	td := jsonOrNull(def.TimeDimension)
 	cf := jsonOrNull(def.CalculationFormula)
 	ad := jsonOrNull(def.AnalysisDimensions)
+	tagsStr := libCommon.TagSlice2TagString(def.Tags)
 
 	sqlStr, vals, err := sq.Insert(METRIC_TABLE_NAME).
 		Columns(
@@ -134,6 +145,10 @@ func (ma *metricAccess) CreateMetric(ctx context.Context, tx *sql.Tx, def *inter
 			"f_branch",
 			"f_name",
 			"f_comment",
+			"f_tags",
+			"f_icon",
+			"f_color",
+			"f_bkn_raw_content",
 			"f_unit_type",
 			"f_unit",
 			"f_metric_type",
@@ -155,6 +170,10 @@ func (ma *metricAccess) CreateMetric(ctx context.Context, tx *sql.Tx, def *inter
 			def.Branch,
 			def.Name,
 			def.Comment,
+			tagsStr,
+			def.Icon,
+			def.Color,
+			def.BKNRawContent,
 			def.UnitType,
 			def.Unit,
 			def.MetricType,
@@ -255,6 +274,10 @@ func metricSelectColumns() []string {
 		"f_branch",
 		"f_name",
 		"f_comment",
+		"f_tags",
+		"f_icon",
+		"f_color",
+		"f_bkn_raw_content",
 		"f_unit_type",
 		"f_unit",
 		"f_metric_type",
@@ -447,6 +470,10 @@ func (ma *metricAccess) UpdateMetric(ctx context.Context, tx *sql.Tx, metric *in
 
 	data := map[string]any{
 		"f_comment":             metric.Comment,
+		"f_tags":                libCommon.TagSlice2TagString(metric.Tags),
+		"f_icon":                metric.Icon,
+		"f_color":               metric.Color,
+		"f_bkn_raw_content":     metric.BKNRawContent,
 		"f_unit_type":           metric.UnitType,
 		"f_unit":                metric.Unit,
 		"f_metric_type":         metric.MetricType,

--- a/adp/bkn/bkn-backend/server/drivenadapters/metric/metric_access_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/metric/metric_access_test.go
@@ -34,11 +34,13 @@ func TestMetricAccess_CreateMetric(t *testing.T) {
 		defer cleanup()
 
 		def := &interfaces.MetricDefinition{
-			ID:         "mid1",
-			KnID:       "kn1",
-			Branch:     interfaces.MAIN_BRANCH,
-			Name:       "m1",
-			Comment:    "",
+			ID:     "mid1",
+			KnID:   "kn1",
+			Branch: interfaces.MAIN_BRANCH,
+			Name:   "m1",
+			CommonInfo: interfaces.CommonInfo{
+				Comment: "c",
+			},
 			UnitType:   "",
 			Unit:       "",
 			MetricType: interfaces.MetricTypeAtomic,
@@ -75,7 +77,7 @@ func TestMetricAccess_GetMetricByID(t *testing.T) {
 
 		cols := metricSelectColumns()
 		rows := sqlmock.NewRows(cols).
-			AddRow("mid1", "kn1", interfaces.MAIN_BRANCH, "m1", "", "", "", interfaces.MetricTypeAtomic,
+			AddRow("mid1", "kn1", interfaces.MAIN_BRANCH, "m1", "", "", "", "", "", "", "", interfaces.MetricTypeAtomic,
 				interfaces.ScopeTypeObjectType, "ot1", nil, `{"aggregation":{"property":"x","aggr":"count"}}`, nil,
 				"u1", "user", int64(1), "u1", "user", int64(1))
 
@@ -100,7 +102,7 @@ func TestMetricAccess_GetMetricByID_timeDimensionLegacyFieldJSON(t *testing.T) {
 
 		cols := metricSelectColumns()
 		rows := sqlmock.NewRows(cols).
-			AddRow("mid1", "kn1", interfaces.MAIN_BRANCH, "m1", "", "", "", interfaces.MetricTypeAtomic,
+			AddRow("mid1", "kn1", interfaces.MAIN_BRANCH, "m1", "", "", "", "", "", "", "", interfaces.MetricTypeAtomic,
 				interfaces.ScopeTypeObjectType, "ot1", `{"field":"@timestamp","default_range_policy":"last_1h"}`,
 				`{"aggregation":{"property":"x","aggr":"count"}}`, nil,
 				"u1", "user", int64(1), "u1", "user", int64(1))
@@ -193,10 +195,10 @@ func TestMetricAccess_GetMetricsByIDs(t *testing.T) {
 
 		cols := metricSelectColumns()
 		rows := sqlmock.NewRows(cols).
-			AddRow("mid1", "kn1", interfaces.MAIN_BRANCH, "m1", "", "", "", interfaces.MetricTypeAtomic,
+			AddRow("mid1", "kn1", interfaces.MAIN_BRANCH, "m1", "", "", "", "", "", "", "", interfaces.MetricTypeAtomic,
 				interfaces.ScopeTypeObjectType, "ot1", nil, `{"aggregation":{"property":"x","aggr":"count"}}`, nil,
 				"u1", "user", int64(1), "u1", "user", int64(1)).
-			AddRow("mid2", "kn1", interfaces.MAIN_BRANCH, "m2", "", "", "", interfaces.MetricTypeAtomic,
+			AddRow("mid2", "kn1", interfaces.MAIN_BRANCH, "m2", "", "", "", "", "", "", "", interfaces.MetricTypeAtomic,
 				interfaces.ScopeTypeObjectType, "ot1", nil, `{"aggregation":{"property":"y","aggr":"sum"}}`, nil,
 				"u1", "user", int64(1), "u1", "user", int64(1))
 
@@ -228,10 +230,12 @@ func TestMetricAccess_UpdateMetric(t *testing.T) {
 		defer cleanup()
 
 		m := &interfaces.MetricDefinition{
-			ID:         "mid1",
-			KnID:       "kn1",
-			Branch:     interfaces.MAIN_BRANCH,
-			Comment:    "c2",
+			ID:     "mid1",
+			KnID:   "kn1",
+			Branch: interfaces.MAIN_BRANCH,
+			CommonInfo: interfaces.CommonInfo{
+				Comment: "c2",
+			},
 			UnitType:   "numUnit",
 			Unit:       "none",
 			MetricType: interfaces.MetricTypeAtomic,
@@ -245,7 +249,7 @@ func TestMetricAccess_UpdateMetric(t *testing.T) {
 		mock.ExpectBegin()
 		tx, err := ma.db.Begin()
 		So(err, ShouldBeNil)
-		mock.ExpectExec("UPDATE "+METRIC_TABLE_NAME).
+		mock.ExpectExec("UPDATE " + METRIC_TABLE_NAME).
 			WillReturnResult(sqlmock.NewResult(0, 1)) // RowsAffected 1
 		err = ma.UpdateMetric(context.Background(), tx, m)
 		So(err, ShouldBeNil)
@@ -284,7 +288,7 @@ func TestMetricAccess_ListMetrics_and_GetMetricsTotal(t *testing.T) {
 
 		cols := metricSelectColumns()
 		rows := sqlmock.NewRows(cols).
-			AddRow("mid1", "kn1", interfaces.MAIN_BRANCH, "m1", "", "", "", interfaces.MetricTypeAtomic,
+			AddRow("mid1", "kn1", interfaces.MAIN_BRANCH, "m1", "", "", "", "", "", "", "", interfaces.MetricTypeAtomic,
 				interfaces.ScopeTypeObjectType, "ot1", nil, `{"aggregation":{"property":"x","aggr":"count"}}`, nil,
 				"u1", "user", int64(1), "u1", "user", int64(1))
 

--- a/adp/bkn/bkn-backend/server/driveradapters/metric_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/metric_handler.go
@@ -457,7 +457,7 @@ func (r *restHandler) UpdateMetric(c *gin.Context, vis hydra.Visitor) {
 	req.KnID = knID
 	req.Branch = branch
 
-	if err := ValidateUpdateMetricRequest(ctx, &req, strictMode); err != nil {
+	if err := ValidateMetricRequest(ctx, &req, strictMode); err != nil {
 		var httpErr *rest.HTTPError
 		if errors.As(err, &httpErr) {
 			rest.ReplyError(c, httpErr)

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_metric.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_metric.go
@@ -102,9 +102,6 @@ func ValidateMetricRequest(ctx context.Context, metric *interfaces.MetricDefinit
 
 // ValidateUpdateMetricRequest 校验 PUT 更新指标请求体：允许等价于 "{}" 的空 body（名称与各字段均可省略，由路由覆盖 id/kn_id/branch）。
 func ValidateUpdateMetricRequest(ctx context.Context, metric *interfaces.MetricDefinition, strictMode bool) error {
-	if metric == nil || metricUpdatePayloadEmpty(metric) {
-		return nil
-	}
 	if err := validateID(ctx, strings.TrimSpace(metric.ID)); err != nil {
 		return err
 	}
@@ -135,41 +132,6 @@ func ValidateUpdateMetricRequest(ctx context.Context, metric *interfaces.MetricD
 		return err
 	}
 	return nil
-}
-
-// metricUpdatePayloadEmpty 判断 JSON 是否未携带任何可更新的业务字段（忽略 id/kn_id/branch 等由路由写入的字段）。
-func metricUpdatePayloadEmpty(m *interfaces.MetricDefinition) bool {
-	if strings.TrimSpace(m.Name) != "" {
-		return false
-	}
-	if strings.TrimSpace(m.Comment) != "" {
-		return false
-	}
-	if len(m.Tags) > 0 {
-		return false
-	}
-	if strings.TrimSpace(m.Icon) != "" || strings.TrimSpace(m.Color) != "" {
-		return false
-	}
-	if strings.TrimSpace(m.UnitType) != "" || strings.TrimSpace(m.Unit) != "" {
-		return false
-	}
-	if strings.TrimSpace(m.MetricType) != "" {
-		return false
-	}
-	if strings.TrimSpace(m.ScopeType) != "" || strings.TrimSpace(m.ScopeRef) != "" {
-		return false
-	}
-	if timeDimensionPresent(m.TimeDimension) {
-		return false
-	}
-	if m.CalculationFormula != nil && !metricCalculationFormulaEmpty(m.CalculationFormula) {
-		return false
-	}
-	if len(m.AnalysisDimensions) > 0 {
-		return false
-	}
-	return true
 }
 
 func validateMetricTypeUpdate(ctx context.Context, metricType string, strictMode bool) error {

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_metric.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_metric.go
@@ -148,6 +148,9 @@ func metricUpdatePayloadEmpty(m *interfaces.MetricDefinition) bool {
 	if len(m.Tags) > 0 {
 		return false
 	}
+	if strings.TrimSpace(m.Icon) != "" || strings.TrimSpace(m.Color) != "" {
+		return false
+	}
 	if strings.TrimSpace(m.UnitType) != "" || strings.TrimSpace(m.Unit) != "" {
 		return false
 	}

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_metric.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_metric.go
@@ -91,7 +91,7 @@ func ValidateMetricRequest(ctx context.Context, metric *interfaces.MetricDefinit
 	if err := validateMetricTimeDimensionBody(ctx, metric.TimeDimension, strictMode); err != nil {
 		return err
 	}
-	if err := validateMetricCalculationFormulaBody(ctx, metric.CalculationFormula, strictMode); err != nil {
+	if err := validateMetricCalculationFormula(ctx, metric.CalculationFormula, strictMode); err != nil {
 		return err
 	}
 	if err := validateMetricAnalysisDimensionsBody(ctx, metric.AnalysisDimensions, strictMode); err != nil {
@@ -100,113 +100,53 @@ func ValidateMetricRequest(ctx context.Context, metric *interfaces.MetricDefinit
 	return nil
 }
 
-// ValidateUpdateMetricRequest 校验 PUT 更新指标请求体：允许等价于 "{}" 的空 body（名称与各字段均可省略，由路由覆盖 id/kn_id/branch）。
-func ValidateUpdateMetricRequest(ctx context.Context, metric *interfaces.MetricDefinition, strictMode bool) error {
-	if err := validateID(ctx, strings.TrimSpace(metric.ID)); err != nil {
-		return err
+func validateMetricCalculationFormula(ctx context.Context, f *interfaces.MetricCalculationFormula, strictMode bool) error {
+	if f == nil {
+		if strictMode {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_Metric_InvalidParameter).
+				WithErrorDetails("calculation_formula is required in strict mode")
+		}
+		return nil
 	}
-	if name := strings.TrimSpace(metric.Name); name != "" {
-		if err := validateObjectName(ctx, name, interfaces.MODULE_TYPE_METRIC); err != nil {
+	if f.Condition != nil {
+		if err := validateMetricCond(ctx, f.Condition); err != nil {
 			return err
 		}
 	}
-	if err := ValidateTags(ctx, metric.Tags); err != nil {
+	if err := validateMetricAggregation(ctx, &f.Aggregation, strictMode); err != nil {
 		return err
 	}
-	if err := validateMetricTypeUpdate(ctx, strings.TrimSpace(metric.MetricType), strictMode); err != nil {
-		return err
-	}
-	if err := validateMetricUnitsUpdate(ctx, strings.TrimSpace(metric.UnitType), strings.TrimSpace(metric.Unit), strictMode); err != nil {
-		return err
-	}
-	if err := validateMetricScopeBodyUpdate(ctx, strings.TrimSpace(metric.ScopeType), strings.TrimSpace(metric.ScopeRef), strictMode); err != nil {
-		return err
-	}
-	if err := validateMetricTimeDimensionBody(ctx, metric.TimeDimension, strictMode); err != nil {
-		return err
-	}
-	if err := validateMetricCalculationFormulaBodyUpdate(ctx, metric.CalculationFormula, strictMode); err != nil {
-		return err
-	}
-	if err := validateMetricAnalysisDimensionsBody(ctx, metric.AnalysisDimensions, strictMode); err != nil {
-		return err
-	}
-	return nil
-}
-
-func validateMetricTypeUpdate(ctx context.Context, metricType string, strictMode bool) error {
-	if metricType == "" {
-		return nil
-	}
-	if strictMode {
-		if metricType != interfaces.MetricTypeAtomic {
-			return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_Metric_InvalidMetricType)
-		}
-		return nil
-	}
-	if _, ok := validMetricTypesEnum[metricType]; !ok {
-		return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_Metric_InvalidParameter).
-			WithErrorDetails("metric_type must be one of atomic, derived, composite")
-	}
-	return nil
-}
-
-func validateMetricUnitsUpdate(ctx context.Context, unitType string, unit string, strictMode bool) error {
-	if unitType == "" && unit == "" {
-		return nil
-	}
-	if strictMode {
-		if unitType == "" || unit == "" {
+	for i := range f.GroupBy {
+		p := strings.TrimSpace(f.GroupBy[i].Property)
+		if p == "" {
 			return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_Metric_InvalidParameter).
-				WithErrorDetails("unit_type and unit are required in strict mode when either is provided")
+				WithErrorDetails(fmt.Sprintf("calculation_formula.group_by[%d].property is required", i))
+		}
+		if err := ValidatePropertyName(ctx, p); err != nil {
+			return err
 		}
 	}
-	if unitType != "" {
-		if _, ok := interfaces.ValidMetricUnitTypes[unitType]; !ok {
+	for i := range f.OrderBy {
+		p := strings.TrimSpace(f.OrderBy[i].Property)
+		if p == "" {
 			return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_Metric_InvalidParameter).
-				WithErrorDetails(fmt.Sprintf("invalid unit_type %q, expected one of %v", unitType, interfaces.ValidMetricUnitTypesArr))
+				WithErrorDetails(fmt.Sprintf("calculation_formula.order_by[%d].property is required", i))
+		}
+		if err := ValidatePropertyName(ctx, p); err != nil {
+			return err
+		}
+		d := strings.TrimSpace(f.OrderBy[i].Direction)
+		if d != "" && d != interfaces.MetricOrderDirectionAsc && d != interfaces.MetricOrderDirectionDesc {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_Metric_InvalidParameter).
+				WithErrorDetails("calculation_formula.order_by direction must be asc or desc")
 		}
 	}
-	if unit != "" {
-		if _, ok := interfaces.ValidMetricUnits[unit]; !ok {
-			return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_Metric_InvalidParameter).
-				WithErrorDetails(fmt.Sprintf("invalid unit %q, expected one of %v", unit, interfaces.ValidMetricUnitsArr))
+	if f.Having != nil {
+		if err := validateMetricHaving(ctx, f.Having); err != nil {
+			return err
 		}
 	}
 	return nil
-}
-
-func validateMetricScopeBodyUpdate(ctx context.Context, scopeType, scopeRef string, strictMode bool) error {
-	if scopeType == "" && scopeRef == "" {
-		return nil
-	}
-	if strictMode {
-		if scopeType == "" || scopeRef == "" {
-			return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_Metric_InvalidParameter).
-				WithErrorDetails("scope_type and scope_ref are required in strict mode when scope is provided")
-		}
-		if scopeType != interfaces.ScopeTypeObjectType {
-			return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_Metric_InvalidParameter).
-				WithErrorDetails("only scope_type object_type is supported for metrics")
-		}
-		return nil
-	}
-	if scopeType != interfaces.ScopeTypeObjectType {
-		return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_Metric_InvalidParameter).
-			WithErrorDetails("only scope_type object_type is supported for metrics")
-	}
-	if scopeRef == "" {
-		return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_Metric_InvalidParameter).
-			WithErrorDetails("scope_ref is required when scope is provided")
-	}
-	return nil
-}
-
-func validateMetricCalculationFormulaBodyUpdate(ctx context.Context, f *interfaces.MetricCalculationFormula, strictMode bool) error {
-	if f == nil || metricCalculationFormulaEmpty(f) {
-		return nil
-	}
-	return validateMetricCalculationFormulaBody(ctx, f, strictMode)
 }
 
 func validateMetricType(ctx context.Context, metricType string, strictMode bool) error {
@@ -324,78 +264,6 @@ func validateMetricAnalysisDimensionsBody(ctx context.Context, ads []interfaces.
 			if err := validateObjectName(ctx, ads[i].DisplayName, interfaces.MODULE_TYPE_METRIC); err != nil {
 				return err
 			}
-		}
-	}
-	return nil
-}
-
-func metricCalculationFormulaEmpty(f *interfaces.MetricCalculationFormula) bool {
-	if f == nil {
-		return true
-	}
-	if f.Condition != nil {
-		return false
-	}
-	if strings.TrimSpace(f.Aggregation.Property) != "" || strings.TrimSpace(f.Aggregation.Aggr) != "" {
-		return false
-	}
-	if len(f.GroupBy) > 0 || len(f.OrderBy) > 0 || f.Having != nil {
-		return false
-	}
-	return true
-}
-
-func validateMetricCalculationFormulaBody(ctx context.Context, f *interfaces.MetricCalculationFormula, strictMode bool) error {
-	if f == nil {
-		if strictMode {
-			return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_Metric_InvalidParameter).
-				WithErrorDetails("calculation_formula is required in strict mode")
-		}
-		return nil
-	}
-	if strictMode && metricCalculationFormulaEmpty(f) {
-		return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_Metric_InvalidParameter).
-			WithErrorDetails("calculation_formula is required in strict mode")
-	}
-	if !strictMode && metricCalculationFormulaEmpty(f) {
-		return nil
-	}
-	if f.Condition != nil {
-		if err := validateMetricCond(ctx, f.Condition); err != nil {
-			return err
-		}
-	}
-	if err := validateMetricAggregation(ctx, &f.Aggregation, strictMode); err != nil {
-		return err
-	}
-	for i := range f.GroupBy {
-		p := strings.TrimSpace(f.GroupBy[i].Property)
-		if p == "" {
-			return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_Metric_InvalidParameter).
-				WithErrorDetails(fmt.Sprintf("calculation_formula.group_by[%d].property is required", i))
-		}
-		if err := ValidatePropertyName(ctx, p); err != nil {
-			return err
-		}
-	}
-	for i := range f.OrderBy {
-		p := strings.TrimSpace(f.OrderBy[i].Property)
-		if p == "" {
-			return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_Metric_InvalidParameter).
-				WithErrorDetails(fmt.Sprintf("calculation_formula.order_by[%d].property is required", i))
-		}
-		if err := ValidatePropertyName(ctx, p); err != nil {
-			return err
-		}
-		d := strings.TrimSpace(f.OrderBy[i].Direction)
-		if d != "" && d != interfaces.MetricOrderDirectionAsc && d != interfaces.MetricOrderDirectionDesc {
-			return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_Metric_InvalidParameter).
-				WithErrorDetails("calculation_formula.order_by direction must be asc or desc")
-		}
-	}
-	if f.Having != nil {
-		if err := validateMetricHaving(ctx, f.Having); err != nil {
-			return err
 		}
 	}
 	return nil

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_metric_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_metric_test.go
@@ -7,11 +7,11 @@ package driveradapters
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"testing"
 
 	"github.com/kweaver-ai/kweaver-go-lib/rest"
+	. "github.com/smartystreets/goconvey/convey"
 
 	"bkn-backend/interfaces"
 )
@@ -30,97 +30,70 @@ func validStrictCreateMetric() *interfaces.MetricDefinition {
 	}
 }
 
-func TestValidateMetricRequest(t *testing.T) {
-	ctx := context.Background()
-	t.Run("subgraph scope rejected", func(t *testing.T) {
-		r := validStrictCreateMetric()
-		r.ScopeType = interfaces.ScopeTypeSubgraph
-		err := ValidateMetricRequest(ctx, r, true)
-		if err == nil {
-			t.Fatal("expected error")
-		}
-		var he *rest.HTTPError
-		if !errors.As(err, &he) || he.HTTPCode != http.StatusBadRequest {
-			t.Fatalf("got %v", err)
-		}
-	})
-	t.Run("empty scope_ref strict", func(t *testing.T) {
-		r := validStrictCreateMetric()
-		r.ScopeRef = "   "
-		err := ValidateMetricRequest(ctx, r, true)
-		if err == nil {
-			t.Fatal("expected error")
-		}
-	})
-	t.Run("strict non atomic metric_type", func(t *testing.T) {
-		r := validStrictCreateMetric()
-		r.MetricType = interfaces.MetricTypeDerived
-		err := ValidateMetricRequest(ctx, r, true)
-		if err == nil {
-			t.Fatal("expected error")
-		}
-	})
-	t.Run("missing aggregation", func(t *testing.T) {
-		r := validStrictCreateMetric()
-		r.CalculationFormula.Aggregation.Property = ""
-		err := ValidateMetricRequest(ctx, r, true)
-		if err == nil {
-			t.Fatal("expected error")
-		}
-	})
-	t.Run("ok strict", func(t *testing.T) {
-		r := validStrictCreateMetric()
-		if err := ValidateMetricRequest(ctx, r, true); err != nil {
-			t.Fatal(err)
-		}
-	})
-	t.Run("non strict empty scope allowed", func(t *testing.T) {
-		r := validStrictCreateMetric()
-		r.ScopeType = ""
-		r.ScopeRef = ""
-		r.UnitType = ""
-		r.Unit = ""
-		r.MetricType = ""
-		r.CalculationFormula = &interfaces.MetricCalculationFormula{}
-		if err := ValidateMetricRequest(ctx, r, false); err != nil {
-			t.Fatal(err)
-		}
+func Test_ValidateMetricRequest(t *testing.T) {
+	Convey("Test ValidateMetricRequest\n", t, func() {
+		ctx := context.Background()
+
+		Convey("Failed with subgraph scope in strict mode\n", func() {
+			r := validStrictCreateMetric()
+			r.ScopeType = interfaces.ScopeTypeSubgraph
+			err := ValidateMetricRequest(ctx, r, true)
+			So(err, ShouldNotBeNil)
+			httpErr := err.(*rest.HTTPError)
+			So(httpErr.HTTPCode, ShouldEqual, http.StatusBadRequest)
+		})
+
+		Convey("Failed with empty scope_ref in strict mode\n", func() {
+			r := validStrictCreateMetric()
+			r.ScopeRef = "   "
+			err := ValidateMetricRequest(ctx, r, true)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Failed with non-atomic metric_type in strict mode\n", func() {
+			r := validStrictCreateMetric()
+			r.MetricType = interfaces.MetricTypeDerived
+			err := ValidateMetricRequest(ctx, r, true)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Failed with missing aggregation property in strict mode\n", func() {
+			r := validStrictCreateMetric()
+			r.CalculationFormula.Aggregation.Property = ""
+			err := ValidateMetricRequest(ctx, r, true)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Success with valid payload in strict mode\n", func() {
+			r := validStrictCreateMetric()
+			err := ValidateMetricRequest(ctx, r, true)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Success with minimal fields in non-strict mode\n", func() {
+			r := validStrictCreateMetric()
+			r.ScopeType = ""
+			r.ScopeRef = ""
+			r.UnitType = ""
+			r.Unit = ""
+			r.MetricType = ""
+			// 非 strict：formula 可省略；若提供 calculation_formula，aggregation.property 与 aggr 仍须齐全。
+			r.CalculationFormula = nil
+			err := ValidateMetricRequest(ctx, r, false)
+			So(err, ShouldBeNil)
+		})
 	})
 }
 
-func TestValidateMetricRequests_duplicateName(t *testing.T) {
-	ctx := context.Background()
-	e := validStrictCreateMetric()
-	e.Name = "dup"
-	err := ValidateMetricRequests(ctx, []*interfaces.MetricDefinition{e, e}, true, interfaces.ImportMode_Normal)
-	if err == nil {
-		t.Fatal("expected duplicate error")
-	}
-}
+func Test_ValidateMetricRequests(t *testing.T) {
+	Convey("Test ValidateMetricRequests\n", t, func() {
+		ctx := context.Background()
 
-func TestValidateUpdateMetricRequest(t *testing.T) {
-	ctx := context.Background()
-	t.Run("calculation_formula partial invalid", func(t *testing.T) {
-		req := &interfaces.MetricDefinition{
-			CalculationFormula: &interfaces.MetricCalculationFormula{
-				Aggregation: interfaces.MetricAggregation{Property: "", Aggr: "sum"},
-			},
-		}
-		err := ValidateUpdateMetricRequest(ctx, req, true)
-		if err == nil {
-			t.Fatal("expected error")
-		}
-	})
-	t.Run("ok empty body", func(t *testing.T) {
-		if err := ValidateUpdateMetricRequest(ctx, &interfaces.MetricDefinition{}, true); err != nil {
-			t.Fatal(err)
-		}
-	})
-	t.Run("ok only route metadata", func(t *testing.T) {
-		if err := ValidateUpdateMetricRequest(ctx, &interfaces.MetricDefinition{
-			ID: "mid", KnID: "kn1", Branch: "main",
-		}, true); err != nil {
-			t.Fatal(err)
-		}
+		Convey("Failed with duplicate metric name in batch\n", func() {
+			e := validStrictCreateMetric()
+			e.Name = "dup"
+			err := ValidateMetricRequests(ctx, []*interfaces.MetricDefinition{e, e}, true, interfaces.ImportMode_Normal)
+			So(err, ShouldNotBeNil)
+		})
 	})
 }

--- a/adp/bkn/bkn-backend/server/interfaces/metric.go
+++ b/adp/bkn/bkn-backend/server/interfaces/metric.go
@@ -251,12 +251,12 @@ type MetricAnalysisDimension struct {
 
 // MetricDefinition is the persisted metric entity (DESIGN §3.2.1, bkn-metrics.yaml MetricDefinition).
 type MetricDefinition struct {
-	ID      string   `json:"id" mapstructure:"id"`
-	KnID    string   `json:"kn_id" mapstructure:"kn_id"`
-	Branch  string   `json:"branch,omitempty" mapstructure:"branch"`
-	Name    string   `json:"name" mapstructure:"name"`
-	Comment string   `json:"comment,omitempty" mapstructure:"comment"`
-	Tags    []string `json:"tags,omitempty" mapstructure:"tags"`
+	ID     string `json:"id" mapstructure:"id"`
+	Name   string `json:"name" mapstructure:"name"`
+	KnID   string `json:"kn_id" mapstructure:"kn_id"`
+	Branch string `json:"branch,omitempty" mapstructure:"branch"`
+
+	CommonInfo `mapstructure:",squash"`
 
 	UnitType           string                    `json:"unit_type,omitempty" mapstructure:"unit_type"`
 	Unit               string                    `json:"unit,omitempty" mapstructure:"unit"`
@@ -275,9 +275,6 @@ type MetricDefinition struct {
 
 	Vector []float32 `json:"_vector,omitempty"`
 	Score  *float64  `json:"_score,omitempty"`
-
-	// BKNRawContent is used only for concept index embedding text (not returned in API JSON).
-	BKNRawContent string `json:"-" mapstructure:"-"`
 }
 
 // ReqMetrics is the batch-create body for POST .../metrics with x-http-method-override: POST (bkn-metrics.yaml ReqMetrics).

--- a/adp/bkn/bkn-backend/server/logics/metric/metric_service.go
+++ b/adp/bkn/bkn-backend/server/logics/metric/metric_service.go
@@ -66,11 +66,6 @@ func NewMetricService(appSetting *common.AppSetting) interfaces.MetricService {
 	return metricServiceInst
 }
 
-func buildMetricBKNRawContent(def *interfaces.MetricDefinition) string {
-	cf, _ := json.Marshal(def.CalculationFormula)
-	return strings.Join([]string{def.Name, def.Comment, string(cf)}, "\n")
-}
-
 func (ms *metricService) InsertDatasetData(ctx context.Context, metrics []*interfaces.MetricDefinition) error {
 	ctx, span := ar_trace.Tracer.Start(ctx, "metric index write")
 	defer span.End()
@@ -82,8 +77,11 @@ func (ms *metricService) InsertDatasetData(ctx context.Context, metrics []*inter
 	if ms.appSetting.ServerSetting.DefaultSmallModelEnabled && ms.mfa != nil {
 		words := make([]string, 0, len(metrics))
 		for _, m := range metrics {
-			m.BKNRawContent = buildMetricBKNRawContent(m)
-			words = append(words, m.BKNRawContent)
+			arr := []string{m.Name}
+			arr = append(arr, m.Tags...)
+			arr = append(arr, m.Comment, m.BKNRawContent)
+			word := strings.Join(arr, "\n")
+			words = append(words, word)
 		}
 		dftModel, err := ms.mfa.GetDefaultModel(ctx)
 		if err != nil {
@@ -107,9 +105,6 @@ func (ms *metricService) InsertDatasetData(ctx context.Context, metrics []*inter
 
 	documents := make([]map[string]any, 0, len(metrics))
 	for _, def := range metrics {
-		if def.BKNRawContent == "" {
-			def.BKNRawContent = buildMetricBKNRawContent(def)
-		}
 		docid := interfaces.GenerateConceptDocuemtnID(def.KnID, interfaces.MODULE_TYPE_METRIC, def.ID, def.Branch)
 		def.ModuleType = interfaces.MODULE_TYPE_METRIC
 
@@ -216,7 +211,9 @@ func (ms *metricService) CreateMetrics(ctx context.Context, tx *sql.Tx, entries 
 			}
 		}
 
-		m.BKNRawContent = buildMetricBKNRawContent(m)
+		// todo: Persist empty BKN raw content until metric serialization is available in BKN SDK.
+		// objectType.BKNRawContent = bknsdk.SerializeObjectType(bknObj)
+		m.BKNRawContent = ""
 	}
 
 	var creates []*interfaces.MetricDefinition
@@ -492,6 +489,10 @@ func (ms *metricService) UpdateMetric(ctx context.Context, tx *sql.Tx, req *inte
 		req.Updater = ctx.Value(interfaces.ACCOUNT_INFO_KEY).(interfaces.AccountInfo)
 	}
 	req.UpdateTime = time.Now().UnixMilli()
+
+	// todo: Persist empty BKN raw content until metric serialization is available in BKN SDK.
+	// objectType.BKNRawContent = bknsdk.SerializeObjectType(bknObj)
+	req.BKNRawContent = ""
 
 	err = ms.ma.UpdateMetric(ctx, tx, req)
 	if err != nil {

--- a/adp/bkn/bkn-backend/server/logics/metric/metric_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/metric/metric_service_test.go
@@ -313,11 +313,13 @@ func Test_metricService_UpdateMetric(t *testing.T) {
 			So(errBegin, ShouldBeNil)
 
 			req := &interfaces.MetricDefinition{
-				ID:      "mid1",
-				KnID:    "kn1",
-				Branch:  interfaces.MAIN_BRANCH,
-				Name:    "n1",
-				Comment: "c",
+				ID:     "mid1",
+				KnID:   "kn1",
+				Branch: interfaces.MAIN_BRANCH,
+				Name:   "n1",
+				CommonInfo: interfaces.CommonInfo{
+					Comment: "c",
+				},
 				CalculationFormula: &interfaces.MetricCalculationFormula{
 					Aggregation: interfaces.MetricAggregation{Property: "p", Aggr: interfaces.MetricAggrSum},
 				},
@@ -514,12 +516,12 @@ func Test_metricService_SearchMetrics(t *testing.T) {
 			cga.EXPECT().GetConceptIDsByConceptGroupIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{"ot_keep"}, nil)
 
 			inDoc := map[string]any{
-				"id":         "metric_drop",
-				"kn_id":      "kn1",
-				"branch":     interfaces.MAIN_BRANCH,
+				"id":          "metric_drop",
+				"kn_id":       "kn1",
+				"branch":      interfaces.MAIN_BRANCH,
 				"module_type": interfaces.MODULE_TYPE_METRIC,
-				"name":       "x",
-				"scope_ref":  "ot_other",
+				"name":        "x",
+				"scope_ref":   "ot_other",
 			}
 			keepDoc := map[string]any{
 				"id":          "metric_keep",

--- a/adp/bkn/bkn-backend/server/worker/concept_syncer.go
+++ b/adp/bkn/bkn-backend/server/worker/concept_syncer.go
@@ -7,7 +7,6 @@ package worker
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"runtime/debug"
 	"strings"
@@ -910,11 +909,6 @@ func (cs *ConceptSyncer) insertDatasetDataForRiskTypes(ctx context.Context, risk
 	return nil
 }
 
-func buildMetricBKNRawContent(def *interfaces.MetricDefinition) string {
-	cf, _ := json.Marshal(def.CalculationFormula)
-	return strings.Join([]string{def.Name, def.Comment, string(cf)}, "\n")
-}
-
 func (cs *ConceptSyncer) insertDatasetDataForMetrics(ctx context.Context, metrics []*interfaces.MetricDefinition) error {
 	if len(metrics) == 0 {
 		return nil
@@ -923,8 +917,11 @@ func (cs *ConceptSyncer) insertDatasetDataForMetrics(ctx context.Context, metric
 	if cs.appSetting.ServerSetting.DefaultSmallModelEnabled {
 		words := make([]string, 0, len(metrics))
 		for _, m := range metrics {
-			m.BKNRawContent = buildMetricBKNRawContent(m)
-			words = append(words, m.BKNRawContent)
+			arr := []string{m.Name}
+			arr = append(arr, m.Tags...)
+			arr = append(arr, m.Comment, m.BKNRawContent)
+			word := strings.Join(arr, "\n")
+			words = append(words, word)
 		}
 
 		dftModel, err := cs.mfa.GetDefaultModel(ctx)
@@ -948,9 +945,6 @@ func (cs *ConceptSyncer) insertDatasetDataForMetrics(ctx context.Context, metric
 
 	documents := make([]map[string]any, 0, len(metrics))
 	for _, def := range metrics {
-		if def.BKNRawContent == "" {
-			def.BKNRawContent = buildMetricBKNRawContent(def)
-		}
 		docid := interfaces.GenerateConceptDocuemtnID(def.KnID, interfaces.MODULE_TYPE_METRIC, def.ID, def.Branch)
 		def.ModuleType = interfaces.MODULE_TYPE_METRIC
 

--- a/adp/docs/api/bkn/bkn-backend-api/bkn-metrics.yaml
+++ b/adp/docs/api/bkn/bkn-backend-api/bkn-metrics.yaml
@@ -545,6 +545,17 @@ components:
           type: string
         comment:
           type: string
+        tags:
+          type: array
+          items:
+            type: string
+          description: 标签（与对象类 / 关系类展示一致）
+        icon:
+          type: string
+          description: 展示用图标标识
+        color:
+          type: string
+          description: 展示用颜色（语义色或色值，长度与库表 f_color 一致）
         unit_type:
           type: string
         unit:
@@ -584,6 +595,14 @@ components:
           type: string
         comment:
           type: string
+        tags:
+          type: array
+          items:
+            type: string
+        icon:
+          type: string
+        color:
+          type: string
         unit_type:
           type: string
         unit:
@@ -610,6 +629,14 @@ components:
       type: object
       properties:
         comment:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        icon:
+          type: string
+        color:
           type: string
         unit_type:
           type: string


### PR DESCRIPTION
# Pull Request

## What Changed

在 **MariaDB 0.8.0** 中为 `t_metric_definition` 补齐与 0.7.0 init 设计及实体表一致的字段，并贯通后端模型、校验、仓储与同步逻辑。

- [x] 新增 `mariadb/0.8.0/01-alter-table.sql`：对现有库追加 `f_tags`、`f_icon`、`f_color`、`f_bkn_raw_content`（`ADD COLUMN IF NOT EXISTS`，兼容已通过 init 建表的环境）。
- [x] 增补 `mariadb/0.8.0/init.sql`，使新建环境指标表结构与上述字段对齐。
- [x] 更新 `metric` 驱动适配层、接口 DTO、`metric_service`、指标校验与 `concept_syncer` 中的字段读写逻辑。
- [x] 同步 `adp/docs/api/bkn/bkn-backend-api/bkn-metrics.yaml` 中与指标相关的 OpenAPI 定义。
- [x] 调整/补充 `metric_access_test`、`metric_service_test` 等与上述字段相关的单测断言。

---

## Why

- Related Issue: [Issue #353](https://github.com/kweaver-ai/kweaver-core/issues/353)
- Related Feature:
- Background: 0.7.0 增量脚本中指标定义表缺少 `f_tags`、`f_icon`、`f_color`、`f_bkn_raw_content`，与整体设计及其他概念表不一致，需在 **0.8.0** 迁移中补足并使应用层与库表一致。

---

## How

- Key implementation points:
  - 升级路径使用 MariaDB `ADD COLUMN IF NOT EXISTS`，避免重复执行报错；对 `f_bkn_raw_content` 通过 `UPDATE` + `MODIFY` 收紧为 `NOT NULL`。
  - Go 侧在 DAO、领域模型、HTTP 校验与 Worker 同步链路上统一补齐四列的序列化与持久化。
- Breaking changes (API, config, database, etc.):

  - **数据库**：自 0.8.0 起 `t_metric_definition` 对上述列有明确约束；已由迁移脚本兼容旧库（补列）。
  - **API**：OpenAPI 中指标相关模型增加可选/展示字段时请与运行时行为对照（见 `bkn-metrics.yaml` 变更）。

---

## Testing

- [ ] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes: 建议在 `adp/bkn/bkn-backend` 下按需执行涉及 `metric` 包的单测（如 `go test ./server/drivenadapters/metric/... ./server/logics/metric/...`），并按团队流程在 CI 上确认全绿。

---

## Risk & Rollback

- Potential risks:
  - 若生产环境 MariaDB 版本不支持 `ADD COLUMN IF NOT EXISTS`，需按运维规范改为兼容写法或先核对版本。
  - 极大数据量表上连续 `ALTER` 可能带来锁表/耗时，宜在低峰执行并观察。
- Rollback plan:
  - 回滚应用版本前需评估是否已写入新列数据；列级回滚通常需单独变更脚本，不建议在生产直接 `DROP COLUMN` 除非业务确认无依赖。

---

## Additional Notes

- 本次 PR 对应分支：`fix/353-issue`；合并目标：`main`。
- 与 Issue #353 验收项对齐：0.8.0 迁移执行后指标表结构与代码/模型一致，升级无报错。
