### PR TITLE
docs(bkn): 指标 unit_type / unit 枚举补充至 OpenAPI (#400)

### DIFF
--- a/adp/docs/api/bkn/bkn-backend-api/bkn-metrics.yaml
+++ b/adp/docs/api/bkn/bkn-backend-api/bkn-metrics.yaml
@@ -324,6 +324,75 @@ paths:
 
 components:
   schemas:
+    MetricUnitType:
+      type: string
+      description: |
+        指标单位类型。取值须为下列枚举之一，与 bkn-backend `interfaces.ValidMetricUnitTypes` 校验一致。
+      enum:
+        - numUnit
+        - storeUnit
+        - percent
+        - transmissionRate
+        - timeUnit
+        - currencyUnit
+        - percentageUnit
+        - countUnit
+        - weightUnit
+        - ordinalRankUnit
+    MetricUnit:
+      type: string
+      description: |
+        指标度量单位。取值须为下列枚举之一，与 bkn-backend `interfaces.ValidMetricUnits` 校验一致。
+      enum:
+        - none
+        - K
+        - Mil
+        - Bil
+        - Tri
+        - bit
+        - Byte
+        - KB
+        - MB
+        - GB
+        - TB
+        - PB
+        - bps
+        - Kbps
+        - Mbps
+        - μs
+        - ms
+        - s
+        - m
+        - h
+        - day
+        - week
+        - month
+        - year
+        - quarter
+        - Fen
+        - Jiao
+        - CNY
+        - 10K_CNY
+        - 1M_CNY
+        - 100M_CNY
+        - US_Cent
+        - USD
+        - EUR_Cent
+        - '%'
+        - ‰
+        - household
+        - transaction
+        - piece
+        - item
+        - times
+        - man_day
+        - family
+        - hand
+        - sheet
+        - packet
+        - ton
+        - kg
+        - rank
     ListMetrics:
       description: 指标列表（与 ListObjectTypes 同构）
       required:
@@ -557,9 +626,9 @@ components:
           type: string
           description: 展示用颜色（语义色或色值，长度与库表 f_color 一致）
         unit_type:
-          type: string
+          $ref: "#/components/schemas/MetricUnitType"
         unit:
-          type: string
+          $ref: "#/components/schemas/MetricUnit"
         metric_type:
           type: string
           description: 指标类型；当前仅 atomic 允许写入
@@ -604,9 +673,9 @@ components:
         color:
           type: string
         unit_type:
-          type: string
+          $ref: "#/components/schemas/MetricUnitType"
         unit:
-          type: string
+          $ref: "#/components/schemas/MetricUnit"
         metric_type:
           type: string
           enum:
@@ -639,9 +708,9 @@ components:
         color:
           type: string
         unit_type:
-          type: string
+          $ref: "#/components/schemas/MetricUnitType"
         unit:
-          type: string
+          $ref: "#/components/schemas/MetricUnit"
         metric_type:
           type: string
           enum:

--- a/adp/docs/api/bkn/ontology-query-ai/ontology-query.yaml
+++ b/adp/docs/api/bkn/ontology-query-ai/ontology-query.yaml
@@ -3771,6 +3771,73 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/RelationTypePath'
+    MetricUnitType:
+      description: 指标单位类型，与 bkn-backend `interfaces.ValidMetricUnitTypes`（及 bkn-metrics OpenAPI）一致。
+      type: string
+      enum:
+      - numUnit
+      - storeUnit
+      - percent
+      - transmissionRate
+      - timeUnit
+      - currencyUnit
+      - percentageUnit
+      - countUnit
+      - weightUnit
+      - ordinalRankUnit
+    MetricUnit:
+      description: 指标度量单位，与 bkn-backend `interfaces.ValidMetricUnits`（及 bkn-metrics OpenAPI）一致。
+      type: string
+      enum:
+      - none
+      - K
+      - Mil
+      - Bil
+      - Tri
+      - bit
+      - Byte
+      - KB
+      - MB
+      - GB
+      - TB
+      - PB
+      - bps
+      - Kbps
+      - Mbps
+      - μs
+      - ms
+      - s
+      - m
+      - h
+      - day
+      - week
+      - month
+      - year
+      - quarter
+      - Fen
+      - Jiao
+      - CNY
+      - 10K_CNY
+      - 1M_CNY
+      - 100M_CNY
+      - US_Cent
+      - USD
+      - EUR_Cent
+      - '%'
+      - ‰
+      - household
+      - transaction
+      - piece
+      - item
+      - times
+      - man_day
+      - family
+      - hand
+      - sheet
+      - packet
+      - ton
+      - kg
+      - rank
     MetricPropertyValue:
       description: 指标属性值
       required:
@@ -3794,72 +3861,9 @@ components:
       type: object
       properties:
         unit_type:
-          description: 单位类型
-          enum:
-          - numUnit
-          - storeUnit
-          - percent
-          - transmissionRate
-          - timeUnit
-          - currencyUnit
-          - percentageUnit
-          - countUnit
-          - weightUnit
-          - ordinalRankUnit
-          type: string
+          $ref: '#/components/schemas/MetricUnitType'
         unit:
-          description: 度量单位
-          enum:
-          - none
-          - K
-          - Mil
-          - Bil
-          - Tri
-          - bit
-          - Byte
-          - KB
-          - MB
-          - GB
-          - TB
-          - PB
-          - bps
-          - Kbps
-          - Mbps
-          - μs
-          - ms
-          - s
-          - m
-          - h
-          - day
-          - week
-          - month
-          - year
-          - quarter
-          - Fen
-          - Jiao
-          - CNY
-          - 10K_CNY
-          - 1M_CNY
-          - 100M_CNY
-          - US_Cent
-          - USD
-          - EUR_Cent
-          - '%'
-          - ‰
-          - household
-          - transaction
-          - piece
-          - item
-          - times
-          - man_day
-          - family
-          - hand
-          - sheet
-          - packet
-          - ton
-          - kg
-          - rank
-          type: string
+          $ref: '#/components/schemas/MetricUnit'
     ObjectDataResponse:
       description: 节点（对象类）信息
       required:
@@ -5401,9 +5405,9 @@ components:
           items:
             type: string
         unit_type:
-          type: string
+          $ref: '#/components/schemas/MetricUnitType'
         unit:
-          type: string
+          $ref: '#/components/schemas/MetricUnit'
         metric_type:
           type: string
         scope_type:
@@ -5463,9 +5467,9 @@ components:
           type: object
           properties:
             unit_type:
-              type: string
+              $ref: '#/components/schemas/MetricUnitType'
             unit:
-              type: string
+              $ref: '#/components/schemas/MetricUnit'
         datas:
           type: array
           items:


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] **`bkn-metrics.yaml`**：新增组件 schema `MetricUnitType`、`MetricUnit`（与 `interfaces.ValidMetricUnitTypes` / `ValidMetricUnits` 对齐），`MetricDefinition` / `CreateMetricRequest` / `UpdateMetricRequest` 的 `unit_type`、`unit` 改为引用上述枚举。
- [x] **`ontology-query.yaml`**：抽取同名可复用 schema；`MetricModel`、`MetricDryRunConfig`、`MetricData.model` 的 `unit_type` / `unit` 统一引用枚举，避免文档与试算/查询侧不一致。

---

## Why

- Related Issue: [Issue #400](https://github.com/kweaver-ai/kweaver-core/issues/400)
- Background: 创建/校验指标时 `unit_type`、`unit` 在后端有固定允许值，但 OpenAPI 原先未写明枚举；本次仅补充文档与 schema，**不改变 JSON 字段名或通用类型**（仍为字符串及原有键名）。

---

## How

- Key implementation points: OpenAPI 3 `$ref` 复用；枚举与 `adp/bkn/bkn-backend/server/interfaces/metric.go` 保持一致。
- Breaking changes: 无运行时或 API 契约变更；生成客户端可能因 `enum` 更严而产生类型差异，属预期文档对齐。

---

## Testing

- [ ] Unit tests passed locally（文档变更，未跑）
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes: 已对两处 YAML 做 `yaml.safe_load` 解析校验。

---

## Risk & Rollback

- Potential risks: 低；仅文档。
- Rollback plan: revert 本 PR 提交或还原上述两个 YAML 文件。

---

## Additional Notes

- 关联 commit: `e07af8e9`（分支 `fix/400-issue`）