### PR TITLE
fix: 统一 catalog/resource 路由参数名

### DIFF
--- a/adp/vega/vega-backend/server/driveradapters/catalog_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/catalog_handler.go
@@ -270,7 +270,7 @@ func (r *restHandler) getCatalogs(c *gin.Context, ctx context.Context, span trac
 
 	o11y.AddHttpAttrs4API(span, o11y.GetAttrsByGinCtx(c))
 
-	ids := strings.Split(c.Param("ids"), ",")
+	ids := strings.Split(c.Param("id"), ",")
 
 	catalogs, err := r.cs.GetByIDs(ctx, ids)
 	if err != nil {
@@ -509,7 +509,7 @@ func (r *restHandler) deleteCatalogs(c *gin.Context, ctx context.Context, span t
 
 	o11y.AddHttpAttrs4API(span, o11y.GetAttrsByGinCtx(c))
 
-	ids := strings.Split(c.Param("ids"), ",")
+	ids := strings.Split(c.Param("id"), ",")
 
 	// Check if ids exists
 	for _, id := range ids {

--- a/adp/vega/vega-backend/server/driveradapters/resource_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_handler.go
@@ -272,7 +272,7 @@ func (r *restHandler) getResources(c *gin.Context, ctx context.Context, span tra
 
 	o11y.AddHttpAttrs4API(span, o11y.GetAttrsByGinCtx(c))
 
-	ids := strings.Split(c.Param("ids"), ",")
+	ids := strings.Split(c.Param("id"), ",")
 
 	resources, err := r.rs.GetByIDs(ctx, ids)
 	if err != nil {
@@ -444,7 +444,7 @@ func (r *restHandler) deleteResources(c *gin.Context, ctx context.Context, span 
 
 	o11y.AddHttpAttrs4API(span, o11y.GetAttrsByGinCtx(c))
 
-	rawIDs := strings.Split(c.Param("ids"), ",")
+	rawIDs := strings.Split(c.Param("id"), ",")
 	ignoreMissing := strings.EqualFold(c.Query("ignore_missing"), "true")
 
 	// Pre-validate existence; collect ids to delete based on ignore_missing.

--- a/adp/vega/vega-backend/server/driveradapters/router.go
+++ b/adp/vega/vega-backend/server/driveradapters/router.go
@@ -97,8 +97,8 @@ func (r *restHandler) RegisterPublic(engine *gin.Engine) {
 			catalogs.GET("/:id/health-status", r.GetCatalogHealthStatusByEx)
 			catalogs.POST("/:id/test-connection", r.TestConnectionByEx)
 			catalogs.POST("/:id/discover", r.DiscoverCatalogResourcesByEx)
-			catalogs.GET("/:ids", r.GetCatalogsByEx)
-			catalogs.DELETE("/:ids", r.DeleteCatalogsByEx)
+			catalogs.GET("/:id", r.GetCatalogsByEx)
+			catalogs.DELETE("/:id", r.DeleteCatalogsByEx)
 		}
 
 		// DiscoverTask APIs - External
@@ -131,9 +131,9 @@ func (r *restHandler) RegisterPublic(engine *gin.Engine) {
 			resources.GET("/:id/data/:doc_id", r.GetResourceDataDocByEx)
 			resources.PUT("/:id/data/:doc_id", r.verifyJsonContentType(), r.PutResourceDataDocByEx)
 			resources.DELETE("/:id/data/:doc_ids", r.DeleteResourceDataByEx)
-			resources.GET("/:ids", r.GetResourcesByEx) // ids为资源ID，多个资源ID逗号分隔
+			resources.GET("/:id", r.GetResourcesByEx) // id为资源ID，多个资源ID逗号分隔
 			resources.PUT("/:id", r.verifyJsonContentType(), r.UpdateResourceByEx)
-			resources.DELETE("/:ids", r.DeleteResourcesByEx) // ids为资源ID，多个资源ID逗号分隔
+			resources.DELETE("/:id", r.DeleteResourcesByEx) // id为资源ID，多个资源ID逗号分隔
 			resources.POST("/query", r.verifyJsonContentType(), r.RawQueryByEx)
 		}
 
@@ -173,8 +173,8 @@ func (r *restHandler) RegisterPublic(engine *gin.Engine) {
 			catalogs.GET("/:id/health-status", r.GetCatalogHealthStatusByIn)
 			catalogs.POST("/:id/test-connection", r.TestConnectionByIn)
 			catalogs.POST("/:id/discover", r.DiscoverCatalogResourcesByIn)
-			catalogs.GET("/:ids", r.GetCatalogsByIn)
-			catalogs.DELETE("/:ids", r.DeleteCatalogsByIn)
+			catalogs.GET("/:id", r.GetCatalogsByIn)
+			catalogs.DELETE("/:id", r.DeleteCatalogsByIn)
 
 		}
 
@@ -208,9 +208,9 @@ func (r *restHandler) RegisterPublic(engine *gin.Engine) {
 			resources.GET("/:id/data/:doc_id", r.GetResourceDataDocByIn)
 			resources.PUT("/:id/data/:doc_id", r.verifyJsonContentType(), r.PutResourceDataDocByIn)
 			resources.DELETE("/:id/data/:doc_ids", r.DeleteResourceDataByIn)
-			resources.GET("/:ids", r.GetResourcesByIn) // ids为资源ID，多个资源ID逗号分隔
+			resources.GET("/:id", r.GetResourcesByIn) // id为资源ID，多个资源ID逗号分隔
 			resources.PUT("/:id", r.verifyJsonContentType(), r.UpdateResourceByIn)
-			resources.DELETE("/:ids", r.DeleteResourcesByIn) // ids为资源ID，多个资源ID逗号分隔
+			resources.DELETE("/:id", r.DeleteResourcesByIn) // id为资源ID，多个资源ID逗号分隔
 			resources.POST("/query", r.verifyJsonContentType(), r.RawQueryByIn)
 		}
 


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Updated catalog batch get/delete routes from `/:ids` to `/:id`
- [x] Updated resource batch get/delete routes from `/:ids` to `/:id`
- [x] Updated catalog/resource handlers to read `c.Param("id")` consistently
- [x] Updated route comments to clarify that `id` supports comma-separated multiple IDs

---

## Why

- Related Issue: #407
- Related Feature: Catalog and resource REST APIs
- Background: Several catalog and resource routes used the path parameter name `:ids`, while the API convention and nearby single-resource routes use `:id`. This change keeps route definitions, handler parameter reads, and comments consistent while preserving comma-separated multi-ID behavior.

---

## How

- Key implementation points:
  - Changed external and internal catalog GET/DELETE routes to use `/:id`
  - Changed external and internal resource GET/DELETE routes to use `/:id`
  - Replaced `c.Param("ids")` with `c.Param("id")` in catalog and resource handlers
  - Kept existing `strings.Split(..., ",")` behavior for multi-ID requests
- Breaking changes (API, config, database, etc.): Path parameter naming is normalized to `id`; the URL shape and comma-separated multi-ID behavior remain unchanged.

---

## Testing

- [ ] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- Not run locally; PR content update only.

---

## Risk & Rollback

- Potential risks: Low. The URL pattern shape remains the same, but any code depending specifically on Gin's internal parameter name `ids` would need to use `id`.
- Rollback plan: Revert this PR to restore the previous `:ids` route parameter names and handler lookups.

---

## Additional Notes

- Updated files:
  - `adp/vega/vega-backend/server/driveradapters/catalog_handler.go`
  - `adp/vega/vega-backend/server/driveradapters/resource_handler.go`
  - `adp/vega/vega-backend/server/driveradapters/router.go`
