### PR TITLE
fix(execution-factory): 内部 API 导入内置组件时跳过 IsInternal 校验并修复 upsert 未写入问题

### DIFF
--- a/adp/context-loader/agent-retrieval/server/bootstrap/tool_dependencies/context_loader_toolset.adp
+++ b/adp/context-loader/agent-retrieval/server/bootstrap/tool_dependencies/context_loader_toolset.adp
@@ -9,7 +9,7 @@
         "status": "published",
         "category_type": "data_query",
         "category_name": "数据查询",
-        "is_internal": false,
+        "is_internal": true,
         "source": "custom",
         "tools": [
           {

--- a/adp/context-loader/agent-retrieval/server/bootstrap/tool_dependencies/execution_factory_tools.adp
+++ b/adp/context-loader/agent-retrieval/server/bootstrap/tool_dependencies/execution_factory_tools.adp
@@ -9,7 +9,7 @@
         "status": "published",
         "category_type": "other_category",
         "category_name": "未分类",
-        "is_internal": false,
+        "is_internal": true,
         "source": "custom",
         "tools": [
           {

--- a/adp/execution-factory/operator-integration/server/dbaccess/toolbox.go
+++ b/adp/execution-factory/operator-integration/server/dbaccess/toolbox.go
@@ -101,6 +101,7 @@ func (b *toolboxDB) UpdateToolBox(ctx context.Context, tx *sql.Tx, toolbox *mode
 		"f_description":  toolbox.Description,
 		"f_svc_url":      toolbox.ServerURL,
 		"f_category":     toolbox.Category,
+		"f_is_internal":  toolbox.IsInternal,
 		"f_update_user":  toolbox.UpdateUser,
 		"f_update_time":  toolbox.UpdateTime,
 		"f_release_user": toolbox.ReleaseUser,

--- a/adp/execution-factory/operator-integration/server/dbaccess/toolbox.go
+++ b/adp/execution-factory/operator-integration/server/dbaccess/toolbox.go
@@ -7,12 +7,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/common/ormhelper"
 	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/config"
 	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/db"
 	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/interfaces/model"
 	"github.com/kweaver-ai/proton-rds-sdk-go/sqlx"
-	"github.com/google/uuid"
 	"github.com/pkg/errors"
 )
 

--- a/adp/execution-factory/operator-integration/server/logics/operator/impex.go
+++ b/adp/execution-factory/operator-integration/server/logics/operator/impex.go
@@ -356,7 +356,6 @@ func (m *operatorManager) importCheck(ctx context.Context, item *interfaces.Oper
 	if err != nil {
 		return
 	}
-	item.IsInternal = false
 	if item.OperatorInfo == nil {
 		item.OperatorInfo = &interfaces.OperatorInfo{}
 		err = defaults.Set(item.OperatorInfo)
@@ -465,7 +464,7 @@ func (m *operatorManager) importCheck(ctx context.Context, item *interfaces.Oper
 		UpdateUser:      userID,
 		UpdateTime:      time.Now().UnixNano(),
 		IsDataSource:    isDataSource,
-		IsInternal:      false,
+		IsInternal:      item.IsInternal,
 	}
 	metadataDB.SetCreateInfo(userID)
 	metadataDB.SetUpdateInfo(userID)

--- a/adp/execution-factory/operator-integration/server/logics/operator/impex.go
+++ b/adp/execution-factory/operator-integration/server/logics/operator/impex.go
@@ -93,7 +93,7 @@ func (m *operatorManager) importPostProcess(ctx context.Context, createMap, upda
 		if accessor != nil {
 			err := m.AuthService.CreateOwnerPolicy(ctx, accessor, &interfaces.AuthResource{
 				ID:   operatorDB.OperatorID,
-				Type: string(interfaces.AuthResourceTypeOperator),
+				Type: interfaces.AuthResourceTypeOperator.String(),
 				Name: operatorDB.Name,
 				})
 			if err != nil {
@@ -120,6 +120,17 @@ func (m *operatorManager) importPostProcess(ctx context.Context, createMap, upda
 					})
 				}()
 			}
+			// 内置组件：创建全员授权策略（public_access + execute）
+			if operatorDB.IsInternal {
+				policyErr := m.AuthService.CreateIntCompPolicyForAllUsers(ctx, &interfaces.AuthResource{
+					ID:   operatorDB.OperatorID,
+					Type: interfaces.AuthResourceTypeOperator.String(),
+					Name: operatorDB.Name,
+				})
+				if policyErr != nil {
+					m.Logger.WithContext(ctx).Warnf("[importPostProcess] CreateIntCompPolicyForAllUsers err:%v", policyErr)
+				}
+			}
 	}
 	// 更新算子
 	for _, operatorDB := range updateMap {
@@ -127,11 +138,22 @@ func (m *operatorManager) importPostProcess(ctx context.Context, createMap, upda
 		authResource := &interfaces.AuthResource{
 			ID:   operatorDB.OperatorID,
 			Name: operatorDB.Name,
-			Type: string(interfaces.AuthResourceTypeOperator),
+			Type: interfaces.AuthResourceTypeOperator.String(),
 		}
 		err := m.AuthService.NotifyResourceChange(ctx, authResource)
 		if err != nil {
 			m.Logger.WithContext(ctx).Warnf("[importPostProcess] NotifyResourceChange err :%v", err)
+		}
+		// 内置组件：创建全员授权策略（public_access + execute）
+		if operatorDB.IsInternal {
+			policyErr := m.AuthService.CreateIntCompPolicyForAllUsers(ctx, &interfaces.AuthResource{
+				ID:   operatorDB.OperatorID,
+				Type: interfaces.AuthResourceTypeOperator.String(),
+				Name: operatorDB.Name,
+			})
+			if policyErr != nil {
+				m.Logger.WithContext(ctx).Warnf("[importPostProcess] CreateIntCompPolicyForAllUsers err:%v", policyErr)
+			}
 		}
 		// 记录设计日志及后续通知（内部调用不记录）
 		if accessor != nil {

--- a/adp/execution-factory/operator-integration/server/logics/operator/impex.go
+++ b/adp/execution-factory/operator-integration/server/logics/operator/impex.go
@@ -300,6 +300,7 @@ func (m *operatorManager) updateOperatorConfig(ctx context.Context, tx *sql.Tx, 
 	operatorDB.Source = newOperatorDB.Source
 	operatorDB.ExecuteControl = newOperatorDB.ExecuteControl
 	operatorDB.ExtendInfo = newOperatorDB.ExtendInfo
+	operatorDB.IsInternal = newOperatorDB.IsInternal
 	operatorDB.UpdateUser = newOperatorDB.CreateUser
 	operatorDB.UpdateTime = time.Now().UnixNano()
 	operatorDB.MetadataType = newOperatorDB.MetadataType

--- a/adp/execution-factory/operator-integration/server/logics/operator/impex.go
+++ b/adp/execution-factory/operator-integration/server/logics/operator/impex.go
@@ -204,12 +204,12 @@ func (m *operatorManager) batchImportOperatorMetadata(ctx context.Context, tx *s
 			if err != nil {
 				return
 			}
-		}
-		// 内置算子不允许更新
-		if operatorDB.IsInternal {
-			err = errors.NewHTTPError(ctx, http.StatusForbidden, errors.ErrExtCommonInternalComponentNotAllowed,
-				fmt.Sprintf("internal operator %v not allowed to update", operatorDB.OperatorID), operatorDB.Name)
-			return
+			// 内置算子不允许更新
+			if operatorDB.IsInternal {
+				err = errors.NewHTTPError(ctx, http.StatusForbidden, errors.ErrExtCommonInternalComponentNotAllowed,
+					fmt.Sprintf("internal operator %v not allowed to update", operatorDB.OperatorID), operatorDB.Name)
+				return
+			}
 		}
 		updateMap[operatorDB.OperatorID] = operatorDB
 	}

--- a/adp/execution-factory/operator-integration/server/logics/operator/impex.go
+++ b/adp/execution-factory/operator-integration/server/logics/operator/impex.go
@@ -62,12 +62,15 @@ func (m *operatorManager) Import(ctx context.Context, tx *sql.Tx, mode interface
 	if err != nil {
 		return
 	}
-	accessor, err := m.AuthService.GetAccessor(ctx, userID)
-	if err != nil {
-		return
-	}
+	var accessor *interfaces.AuthAccessor
+	if icommon.IsPublicAPIFromCtx(ctx) {
+		accessor, err = m.AuthService.GetAccessor(ctx, userID)
+		if err != nil {
+			return
+		}
+		}
 	// 导入算子元数据
-	createMap, updateMap, err := m.batchImportOperatorMetadata(ctx, tx, data.Configs, operatorList, accessor)
+	createMap, updateMap, err := m.batchImportOperatorMetadata(ctx, tx, data.Configs, operatorList, accessor, userID)
 	if err != nil {
 		return
 	}
@@ -86,33 +89,37 @@ func (m *operatorManager) importPostProcess(ctx context.Context, createMap, upda
 			return
 		}
 
-		// 触发新建策略，创建人默认拥有对当前资源的所有操作权限
-		err := m.AuthService.CreateOwnerPolicy(ctx, accessor, &interfaces.AuthResource{
-			ID:   operatorDB.OperatorID,
-			Type: string(interfaces.AuthResourceTypeOperator),
-			Name: operatorDB.Name,
-		})
-		if err != nil {
-			m.Logger.WithContext(ctx).Warnf("[importPostProcess] CreateOwnerPolicy err :%v", err)
-		}
-		// 记录设计日志及后续通知
-		go func() {
-			accountAuthContext, ok := icommon.GetAccountAuthContextFromCtx(ctx)
-			if !ok {
-				m.Logger.WithContext(ctx).Warnf("[importPostProcess] GetAccountAuthContextFromCtx err :%v", err)
-				return
+		// 触发新建策略，创建人默认拥有对当前资源的所有操作权限（内部调用不创建）
+		if accessor != nil {
+			err := m.AuthService.CreateOwnerPolicy(ctx, accessor, &interfaces.AuthResource{
+				ID:   operatorDB.OperatorID,
+				Type: string(interfaces.AuthResourceTypeOperator),
+				Name: operatorDB.Name,
+				})
+			if err != nil {
+				m.Logger.WithContext(ctx).Warnf("[importPostProcess] CreateOwnerPolicy err :%v", err)
+				}
 			}
-			m.AuditLog.Logger(ctx, &metric.AuditLogBuilderParams{
-				TokenInfo: accountAuthContext.TokenInfo,
-				Accessor:  accessor,
-				Operation: metric.AuditLogOperationCreate,
-				Object: &metric.AuditLogObject{
-					Type: metric.AuditLogObjectOperator,
-					ID:   operatorDB.OperatorID,
-					Name: operatorDB.Name,
-				},
-			})
-		}()
+		// 记录设计日志及后续通知（内部调用不记录）
+		if accessor != nil {
+			go func() {
+				accountAuthContext, ok := icommon.GetAccountAuthContextFromCtx(ctx)
+				if !ok {
+					m.Logger.WithContext(ctx).Warnf("[importPostProcess] GetAccountAuthContextFromCtx err :%v", err)
+					return
+					}
+				m.AuditLog.Logger(ctx, &metric.AuditLogBuilderParams{
+					TokenInfo: accountAuthContext.TokenInfo,
+					Accessor:  accessor,
+					Operation: metric.AuditLogOperationCreate,
+					Object: &metric.AuditLogObject{
+						Type: metric.AuditLogObjectOperator,
+						ID:   operatorDB.OperatorID,
+						Name: operatorDB.Name,
+						},
+					})
+				}()
+			}
 	}
 	// 更新算子
 	for _, operatorDB := range updateMap {
@@ -126,24 +133,26 @@ func (m *operatorManager) importPostProcess(ctx context.Context, createMap, upda
 		if err != nil {
 			m.Logger.WithContext(ctx).Warnf("[importPostProcess] NotifyResourceChange err :%v", err)
 		}
-		// 记录设计日志及后续通知
-		go func() {
-			accountAuthContext, ok := icommon.GetAccountAuthContextFromCtx(ctx)
-			if !ok {
-				m.Logger.WithContext(ctx).Warnf("[importPostProcess] GetAccountAuthContextFromCtx err :%v", err)
-				return
+		// 记录设计日志及后续通知（内部调用不记录）
+		if accessor != nil {
+			go func() {
+				accountAuthContext, ok := icommon.GetAccountAuthContextFromCtx(ctx)
+				if !ok {
+					m.Logger.WithContext(ctx).Warnf("[importPostProcess] GetAccountAuthContextFromCtx err :%v", err)
+					return
+					}
+				m.AuditLog.Logger(ctx, &metric.AuditLogBuilderParams{
+					TokenInfo: accountAuthContext.TokenInfo,
+					Accessor:  accessor,
+					Operation: metric.AuditLogOperationEdit,
+					Object: &metric.AuditLogObject{
+						Type: metric.AuditLogObjectOperator,
+						ID:   operatorDB.OperatorID,
+						Name: operatorDB.Name,
+						},
+					})
+				}()
 			}
-			m.AuditLog.Logger(ctx, &metric.AuditLogBuilderParams{
-				TokenInfo: accountAuthContext.TokenInfo,
-				Accessor:  accessor,
-				Operation: metric.AuditLogOperationEdit,
-				Object: &metric.AuditLogObject{
-					Type: metric.AuditLogObjectOperator,
-					ID:   operatorDB.OperatorID,
-					Name: operatorDB.Name,
-				},
-			})
-		}()
 	}
 	return nil
 }
@@ -183,16 +192,18 @@ func (m *operatorManager) importPreCheck(ctx context.Context, mode interfaces.Im
 
 // 批量导入算子元数据
 func (m *operatorManager) batchImportOperatorMetadata(ctx context.Context, tx *sql.Tx, items []*interfaces.OperatorImpexItem, needUpdateOperatorList []*model.OperatorRegisterDB,
-	accessor *interfaces.AuthAccessor) (createMap, updateMap map[string]*model.OperatorRegisterDB, err error) {
+	accessor *interfaces.AuthAccessor, userID string) (createMap, updateMap map[string]*model.OperatorRegisterDB, err error) {
 	// 需要新增的算子列表
 	createMap = map[string]*model.OperatorRegisterDB{}
 	// 需要更新的算子列表
 	updateMap = map[string]*model.OperatorRegisterDB{}
 	for _, operatorDB := range needUpdateOperatorList {
-		// 检查算子编辑权限
-		err = m.AuthService.CheckModifyPermission(ctx, accessor, operatorDB.OperatorID, interfaces.AuthResourceTypeOperator)
-		if err != nil {
-			return
+		// 检查算子编辑权限（内部调用不鉴权）
+		if icommon.IsPublicAPIFromCtx(ctx) {
+			err = m.AuthService.CheckModifyPermission(ctx, accessor, operatorDB.OperatorID, interfaces.AuthResourceTypeOperator)
+			if err != nil {
+				return
+			}
 		}
 		// 内置算子不允许更新
 		if operatorDB.IsInternal {
@@ -206,7 +217,11 @@ func (m *operatorManager) batchImportOperatorMetadata(ctx context.Context, tx *s
 		// 参数预备检查
 		var newOperatorDB *model.OperatorRegisterDB
 		var newMetadataDB interfaces.IMetadataDB
-		newOperatorDB, newMetadataDB, err = m.importCheck(ctx, operatorItem, accessor.ID)
+		uid := userID
+		if accessor != nil {
+			uid = accessor.ID
+		}
+		newOperatorDB, newMetadataDB, err = m.importCheck(ctx, operatorItem, uid)
 		if err != nil {
 			return
 		}

--- a/adp/execution-factory/operator-integration/server/logics/operator/impex.go
+++ b/adp/execution-factory/operator-integration/server/logics/operator/impex.go
@@ -164,7 +164,7 @@ func (m *operatorManager) importPreCheck(ctx context.Context, mode interfaces.Im
 	for _, operatorItem := range items {
 		operatorIDs = append(operatorIDs, operatorItem.OperatorID)
 		// 内置算子不允许导入
-		if operatorItem.IsInternal {
+		if icommon.IsPublicAPIFromCtx(ctx) && operatorItem.IsInternal {
 			err = errors.NewHTTPError(ctx, http.StatusForbidden, errors.ErrExtCommonInternalComponentNotAllowed,
 				fmt.Sprintf("internal operator %v not allowed to import", operatorItem.OperatorID), operatorItem.OperatorName)
 			return

--- a/adp/execution-factory/operator-integration/server/logics/operator/impex.go
+++ b/adp/execution-factory/operator-integration/server/logics/operator/impex.go
@@ -68,7 +68,7 @@ func (m *operatorManager) Import(ctx context.Context, tx *sql.Tx, mode interface
 		if err != nil {
 			return
 		}
-		}
+	}
 	// 导入算子元数据
 	createMap, updateMap, err := m.batchImportOperatorMetadata(ctx, tx, data.Configs, operatorList, accessor, userID)
 	if err != nil {
@@ -95,11 +95,11 @@ func (m *operatorManager) importPostProcess(ctx context.Context, createMap, upda
 				ID:   operatorDB.OperatorID,
 				Type: interfaces.AuthResourceTypeOperator.String(),
 				Name: operatorDB.Name,
-				})
+			})
 			if err != nil {
 				m.Logger.WithContext(ctx).Warnf("[importPostProcess] CreateOwnerPolicy err :%v", err)
-				}
 			}
+		}
 		// 记录设计日志及后续通知（内部调用不记录）
 		if accessor != nil {
 			go func() {
@@ -107,7 +107,7 @@ func (m *operatorManager) importPostProcess(ctx context.Context, createMap, upda
 				if !ok {
 					m.Logger.WithContext(ctx).Warnf("[importPostProcess] GetAccountAuthContextFromCtx err :%v", err)
 					return
-					}
+				}
 				m.AuditLog.Logger(ctx, &metric.AuditLogBuilderParams{
 					TokenInfo: accountAuthContext.TokenInfo,
 					Accessor:  accessor,
@@ -116,21 +116,22 @@ func (m *operatorManager) importPostProcess(ctx context.Context, createMap, upda
 						Type: metric.AuditLogObjectOperator,
 						ID:   operatorDB.OperatorID,
 						Name: operatorDB.Name,
-						},
-					})
-				}()
-			}
-			// 内置组件：创建全员授权策略（public_access + execute）
-			if operatorDB.IsInternal {
-				policyErr := m.AuthService.CreateIntCompPolicyForAllUsers(ctx, &interfaces.AuthResource{
-					ID:   operatorDB.OperatorID,
-					Type: interfaces.AuthResourceTypeOperator.String(),
-					Name: operatorDB.Name,
+					},
 				})
-				if policyErr != nil {
-					m.Logger.WithContext(ctx).Warnf("[importPostProcess] CreateIntCompPolicyForAllUsers err:%v", policyErr)
-				}
+			}()
+		}
+		// 内置组件：创建全员授权策略（public_access + execute）
+		if operatorDB.IsInternal {
+			err = m.AuthService.CreateIntCompPolicyForAllUsers(ctx, &interfaces.AuthResource{
+				ID:   operatorDB.OperatorID,
+				Type: interfaces.AuthResourceTypeOperator.String(),
+				Name: operatorDB.Name,
+			})
+			if err != nil {
+				m.Logger.WithContext(ctx).Warnf("[importPostProcess] CreateIntCompPolicyForAllUsers err:%v", err)
+				return
 			}
+		}
 	}
 	// 更新算子
 	for _, operatorDB := range updateMap {
@@ -162,7 +163,7 @@ func (m *operatorManager) importPostProcess(ctx context.Context, createMap, upda
 				if !ok {
 					m.Logger.WithContext(ctx).Warnf("[importPostProcess] GetAccountAuthContextFromCtx err :%v", err)
 					return
-					}
+				}
 				m.AuditLog.Logger(ctx, &metric.AuditLogBuilderParams{
 					TokenInfo: accountAuthContext.TokenInfo,
 					Accessor:  accessor,
@@ -171,10 +172,10 @@ func (m *operatorManager) importPostProcess(ctx context.Context, createMap, upda
 						Type: metric.AuditLogObjectOperator,
 						ID:   operatorDB.OperatorID,
 						Name: operatorDB.Name,
-						},
-					})
-				}()
-			}
+					},
+				})
+			}()
+		}
 	}
 	return nil
 }

--- a/adp/execution-factory/operator-integration/server/logics/operator/impex_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/operator/impex_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	myErr "github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/errors"
 	icommon "github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/common"
+	myErr "github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/errors"
 	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/logger"
 	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/interfaces"
 	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/interfaces/model"

--- a/adp/execution-factory/operator-integration/server/logics/operator/impex_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/operator/impex_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	myErr "github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/errors"
+	icommon "github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/common"
 	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/logger"
 	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/interfaces"
 	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/interfaces/model"
@@ -75,6 +76,7 @@ func TestImport(t *testing.T) {
 		}
 		operatorDB := &model.OperatorRegisterDB{OperatorID: "1"}
 		accessor := &interfaces.AuthAccessor{}
+		publicCtx := icommon.SetPublicAPIToCtx(context.TODO(), true)
 		Convey("导入校验: 导入数据为空", func() {
 			err := operator.Import(context.TODO(), &sql.Tx{}, interfaces.ImportTypeCreate, nil, "")
 			So(err, ShouldNotBeNil)
@@ -126,7 +128,7 @@ func TestImport(t *testing.T) {
 				gomock.Any()).Return(true, operatorDB, nil)
 			mockDBOperatorManager.EXPECT().SelectByOperatorIDs(gomock.Any(), gomock.Any()).Return([]*model.OperatorRegisterDB{operatorDB}, nil)
 			mockAuthService.EXPECT().GetAccessor(gomock.Any(), gomock.Any()).Return(nil, mocks.MockFuncErr("GetAccessor"))
-			err := operator.Import(context.TODO(), &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
+			err := operator.Import(publicCtx, &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
 			So(err, ShouldNotBeNil)
 		})
 		Convey("无算子编辑权限", func() {
@@ -135,7 +137,7 @@ func TestImport(t *testing.T) {
 			mockDBOperatorManager.EXPECT().SelectByOperatorIDs(gomock.Any(), gomock.Any()).Return([]*model.OperatorRegisterDB{operatorDB}, nil)
 			mockAuthService.EXPECT().GetAccessor(gomock.Any(), gomock.Any()).Return(accessor, nil)
 			mockAuthService.EXPECT().CheckModifyPermission(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mocks.MockFuncErr("CheckModifyPermission"))
-			err := operator.Import(context.TODO(), &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
+			err := operator.Import(publicCtx, &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
 			So(err, ShouldNotBeNil)
 		})
 		Convey("内置算子不允许编辑", func() {
@@ -147,7 +149,7 @@ func TestImport(t *testing.T) {
 			}}, nil)
 			mockAuthService.EXPECT().GetAccessor(gomock.Any(), gomock.Any()).Return(accessor, nil)
 			mockAuthService.EXPECT().CheckModifyPermission(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			err := operator.Import(context.TODO(), &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
+			err := operator.Import(publicCtx, &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
 			So(err, ShouldNotBeNil)
 			httpErr, ok := err.(*myErr.HTTPError)
 			So(ok, ShouldBeTrue)
@@ -161,7 +163,7 @@ func TestImport(t *testing.T) {
 			mockValidator.EXPECT().ValidateOperatorName(gomock.Any(), gomock.Any()).Return(mocks.MockFuncErr("ValidateOperatorName")).Times(1)
 			mockAuthService.EXPECT().GetAccessor(gomock.Any(), gomock.Any()).Return(accessor, nil)
 			mockAuthService.EXPECT().CheckModifyPermission(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			err := operator.Import(context.TODO(), &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
+			err := operator.Import(publicCtx, &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
 			So(err, ShouldNotBeNil)
 		})
 		Convey("导入检查: 异步算子数据源", func() {
@@ -176,7 +178,7 @@ func TestImport(t *testing.T) {
 			mockAuthService.EXPECT().GetAccessor(gomock.Any(), gomock.Any()).Return(accessor, nil)
 			mockAuthService.EXPECT().CheckModifyPermission(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			mockValidator.EXPECT().ValidateOperatorName(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-			err := operator.Import(context.TODO(), &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
+			err := operator.Import(publicCtx, &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
 			So(err, ShouldNotBeNil)
 			httpErr, ok := err.(*myErr.HTTPError)
 			So(ok, ShouldBeTrue)
@@ -191,7 +193,7 @@ func TestImport(t *testing.T) {
 			mockAuthService.EXPECT().CheckModifyPermission(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			mockCategoryManager.EXPECT().CheckCategory(gomock.Any()).Return(false)
 			mockValidator.EXPECT().ValidateOperatorName(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-			err := operator.Import(context.TODO(), &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
+			err := operator.Import(publicCtx, &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
 			So(err, ShouldNotBeNil)
 			httpErr, ok := err.(*myErr.HTTPError)
 			So(ok, ShouldBeTrue)
@@ -206,7 +208,7 @@ func TestImport(t *testing.T) {
 			mockAuthService.EXPECT().CheckModifyPermission(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			mockCategoryManager.EXPECT().CheckCategory(gomock.Any()).Return(false)
 			mockValidator.EXPECT().ValidateOperatorName(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-			err := operator.Import(context.TODO(), &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
+			err := operator.Import(publicCtx, &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
 			So(err, ShouldNotBeNil)
 			httpErr, ok := err.(*myErr.HTTPError)
 			So(ok, ShouldBeTrue)
@@ -221,7 +223,7 @@ func TestImport(t *testing.T) {
 			mockAuthService.EXPECT().GetAccessor(gomock.Any(), gomock.Any()).Return(accessor, nil)
 			mockAuthService.EXPECT().CheckModifyPermission(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			mockCategoryManager.EXPECT().CheckCategory(gomock.Any()).Return(false)
-			err := operator.Import(context.TODO(), &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
+			err := operator.Import(publicCtx, &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
 			So(err, ShouldNotBeNil)
 			httpErr, ok := err.(*myErr.HTTPError)
 			So(ok, ShouldBeTrue)
@@ -236,7 +238,7 @@ func TestImport(t *testing.T) {
 			mockAuthService.EXPECT().GetAccessor(gomock.Any(), gomock.Any()).Return(accessor, nil)
 			mockAuthService.EXPECT().CheckModifyPermission(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			mockCategoryManager.EXPECT().CheckCategory(gomock.Any()).Return(false)
-			err := operator.Import(context.TODO(), &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
+			err := operator.Import(publicCtx, &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
 			So(err, ShouldNotBeNil)
 			httpErr, ok := err.(*myErr.HTTPError)
 			So(ok, ShouldBeTrue)
@@ -254,7 +256,7 @@ func TestImport(t *testing.T) {
 			mockValidator.EXPECT().ValidateOperatorDesc(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockValidator.EXPECT().ValidatorStruct(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockCategoryManager.EXPECT().CheckCategory(gomock.Any()).Return(false)
-			err := operator.Import(context.TODO(), &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
+			err := operator.Import(publicCtx, &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
 			So(err, ShouldNotBeNil)
 			httpErr, ok := err.(*myErr.HTTPError)
 			So(ok, ShouldBeTrue)
@@ -273,7 +275,7 @@ func TestImport(t *testing.T) {
 			mockValidator.EXPECT().ValidatorStruct(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			// mockMetadataService.EXPECT().RegisterMetadata(gomock.Any(), gomock.Any(), gomock.Any()).Return("", mocks.MockFuncErr("RegisterMetadata")).Times(1)
 			// mockDBAPIMetadataManager.EXPECT().InsertAPIMetadata(gomock.Any(), gomock.Any(), gomock.Any()).Return("", mocks.MockFuncErr("InsertAPIMetadata")).Times(1)
-			err := operator.Import(context.TODO(), &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
+			err := operator.Import(publicCtx, &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
 			So(err, ShouldNotBeNil)
 			fmt.Println(err)
 			httpErr, ok := err.(*myErr.HTTPError)
@@ -294,7 +296,7 @@ func TestImport(t *testing.T) {
 			mockValidator.EXPECT().ValidatorStruct(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockMetadataService.EXPECT().RegisterMetadata(gomock.Any(), gomock.Any(), gomock.Any()).Return("", mocks.MockFuncErr("RegisterMetadata")).Times(1)
 			// mockDBAPIMetadataManager.EXPECT().InsertAPIMetadata(gomock.Any(), gomock.Any(), gomock.Any()).Return("", mocks.MockFuncErr("InsertAPIMetadata")).Times(1)
-			err := operator.Import(context.TODO(), &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
+			err := operator.Import(publicCtx, &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
 			So(err, ShouldNotBeNil)
 			fmt.Println(err)
 			// httpErr, ok := err.(*myErr.HTTPError)
@@ -315,7 +317,7 @@ func TestImport(t *testing.T) {
 			mockValidator.EXPECT().ValidatorStruct(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockMetadataService.EXPECT().RegisterMetadata(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil).Times(1)
 			mockDBOperatorManager.EXPECT().UpdateByOperatorID(gomock.Any(), gomock.Any(), gomock.Any()).Return(mocks.MockFuncErr("UpdateByOperatorID")).Times(1)
-			err := operator.Import(context.TODO(), &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
+			err := operator.Import(publicCtx, &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
 			So(err, ShouldNotBeNil)
 			httpErr, ok := err.(*myErr.HTTPError)
 			So(ok, ShouldBeTrue)
@@ -334,7 +336,7 @@ func TestImport(t *testing.T) {
 		// 	mockDBOperatorManager.EXPECT().UpdateByOperatorID(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		// 	mockAuthService.EXPECT().NotifyResourceChange(gomock.Any(), gomock.Any()).Return(mocks.MockFuncErr("NotifyResourceChange"))
 		// 	mockAuditLog.EXPECT().Logger(gomock.Any(), gomock.Any())
-		// 	err := operator.Import(context.TODO(), &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
+		// 	err := operator.Import(publicCtx, &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
 		// 	So(err, ShouldBeNil)
 		// 	time.Sleep(100 * time.Millisecond)
 		// })
@@ -351,7 +353,7 @@ func TestImport(t *testing.T) {
 		// 	mockDBOperatorManager.EXPECT().UpdateByOperatorID(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		// 	mockAuthService.EXPECT().NotifyResourceChange(gomock.Any(), gomock.Any()).Return(nil)
 		// 	mockAuditLog.EXPECT().Logger(gomock.Any(), gomock.Any())
-		// 	err := operator.Import(context.TODO(), &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
+		// 	err := operator.Import(publicCtx, &sql.Tx{}, interfaces.ImportTypeUpsert, importData, "")
 		// 	So(err, ShouldBeNil)
 		// 	time.Sleep(100 * time.Millisecond)
 		// })

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/impex.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/impex.go
@@ -34,13 +34,16 @@ func (s *ToolServiceImpl) Import(ctx context.Context, tx *sql.Tx, mode interface
 	if err != nil {
 		return
 	}
-	accessor, err := s.AuthService.GetAccessor(ctx, userID)
-	if err != nil {
-		s.Logger.WithContext(ctx).Warnf("[Import] GetAccessor err:%v", err)
-		return
+	var accessor *interfaces.AuthAccessor
+	if icommon.IsPublicAPIFromCtx(ctx) {
+		accessor, err = s.AuthService.GetAccessor(ctx, userID)
+		if err != nil {
+			s.Logger.WithContext(ctx).Warnf("[Import] GetAccessor err:%v", err)
+			return
+		}
 	}
 	// 导入工具箱、工具信息
-	createMap, updateMap, err := s.batchImportToolBoxMetadata(ctx, tx, data.Toolbox.Configs, waitUpdataBoxList, accessor)
+	createMap, updateMap, err := s.batchImportToolBoxMetadata(ctx, tx, data.Toolbox.Configs, waitUpdataBoxList, accessor, userID)
 	if err != nil {
 		s.Logger.WithContext(ctx).Warnf("[Import] batchImportToolBoxMetadata err:%v", err)
 		return
@@ -72,33 +75,37 @@ func (s *ToolServiceImpl) importPostProcess(ctx context.Context, createBoxMap, u
 			return
 		}
 
-		// 触发新建策略，创建人默认拥有对当前资源的所有操作权限
-		err := s.AuthService.CreateOwnerPolicy(ctx, accessor, &interfaces.AuthResource{
-			ID:   boxDB.BoxID,
-			Type: string(interfaces.AuthResourceTypeToolBox),
-			Name: boxDB.Name,
-		})
-		if err != nil {
-			s.Logger.WithContext(ctx).Errorf("[importPostProcess] CreateOwnerPolicy err:%v", err)
-		}
-		// 记录设计日志及后续通知
-		go func() {
-			accountAuthContext, ok := common.GetAccountAuthContextFromCtx(ctx)
-			if !ok {
-				s.Logger.WithContext(ctx).Warnf("[importPostProcess] GetAccountAuthContextFromCtx err :%v", err)
-				return
-			}
-			s.AuditLog.Logger(ctx, &metric.AuditLogBuilderParams{
-				TokenInfo: accountAuthContext.TokenInfo,
-				Accessor:  accessor,
-				Operation: metric.AuditLogOperationCreate,
-				Object: &metric.AuditLogObject{
-					Type: metric.AuditLogObjectTool,
-					ID:   boxDB.BoxID,
-					Name: boxDB.Name,
-				},
+		// 触发新建策略，创建人默认拥有对当前资源的所有操作权限（内部调用不创建）
+		if accessor != nil {
+			err := s.AuthService.CreateOwnerPolicy(ctx, accessor, &interfaces.AuthResource{
+				ID:   boxDB.BoxID,
+				Type: string(interfaces.AuthResourceTypeToolBox),
+				Name: boxDB.Name,
 			})
-		}()
+			if err != nil {
+				s.Logger.WithContext(ctx).Errorf("[importPostProcess] CreateOwnerPolicy err:%v", err)
+			}
+		}
+		// 记录设计日志及后续通知（内部调用不记录）
+		if accessor != nil {
+			go func() {
+				accountAuthContext, ok := common.GetAccountAuthContextFromCtx(ctx)
+				if !ok {
+					s.Logger.WithContext(ctx).Warnf("[importPostProcess] GetAccountAuthContextFromCtx err :%v", err)
+					return
+				}
+				s.AuditLog.Logger(ctx, &metric.AuditLogBuilderParams{
+					TokenInfo: accountAuthContext.TokenInfo,
+					Accessor:  accessor,
+					Operation: metric.AuditLogOperationCreate,
+					Object: &metric.AuditLogObject{
+						Type: metric.AuditLogObjectTool,
+						ID:   boxDB.BoxID,
+						Name: boxDB.Name,
+					},
+				})
+			}()
+		}
 	}
 	// 更新工具箱
 	for _, boxDB := range updateBoxMap {
@@ -112,24 +119,26 @@ func (s *ToolServiceImpl) importPostProcess(ctx context.Context, createBoxMap, u
 		if err != nil {
 			s.Logger.WithContext(ctx).Errorf("[importPostProcess] NotifyResourceChange err:%v", err)
 		}
-		// 记录设计日志及后续通知
-		go func() {
-			accountAuthContext, ok := common.GetAccountAuthContextFromCtx(ctx)
-			if !ok {
-				s.Logger.WithContext(ctx).Warnf("[importPostProcess] GetAccountAuthContextFromCtx err :%v", err)
-				return
-			}
-			s.AuditLog.Logger(ctx, &metric.AuditLogBuilderParams{
-				TokenInfo: accountAuthContext.TokenInfo,
-				Accessor:  accessor,
-				Operation: metric.AuditLogOperationEdit,
-				Object: &metric.AuditLogObject{
-					Type: metric.AuditLogObjectTool,
-					ID:   boxDB.BoxID,
-					Name: boxDB.Name,
-				},
-			})
-		}()
+		// 记录设计日志及后续通知（内部调用不记录）
+		if accessor != nil {
+			go func() {
+				accountAuthContext, ok := common.GetAccountAuthContextFromCtx(ctx)
+				if !ok {
+					s.Logger.WithContext(ctx).Warnf("[importPostProcess] GetAccountAuthContextFromCtx err :%v", err)
+					return
+				}
+				s.AuditLog.Logger(ctx, &metric.AuditLogBuilderParams{
+					TokenInfo: accountAuthContext.TokenInfo,
+					Accessor:  accessor,
+					Operation: metric.AuditLogOperationEdit,
+					Object: &metric.AuditLogObject{
+						Type: metric.AuditLogObjectTool,
+						ID:   boxDB.BoxID,
+						Name: boxDB.Name,
+					},
+				})
+			}()
+		}
 	}
 	return nil
 }
@@ -168,17 +177,24 @@ func (s *ToolServiceImpl) importPreCheck(ctx context.Context, mode interfaces.Im
 
 // 批量导入工具箱及工具元数据
 func (s *ToolServiceImpl) batchImportToolBoxMetadata(ctx context.Context, tx *sql.Tx, items []*interfaces.ToolBoxImpexItem, waitUpdataBoxList []*model.ToolboxDB,
-	accessor *interfaces.AuthAccessor) (createBoxMap, updateBoxMap map[string]*model.ToolboxDB, err error) {
+	accessor *interfaces.AuthAccessor, userID string) (createBoxMap, updateBoxMap map[string]*model.ToolboxDB, err error) {
 	// 收集需要新增的ToolBox
 	createBoxMap = map[string]*model.ToolboxDB{}
 	// 收集需要更新的工具ToolBox
 	updateBoxMap = map[string]*model.ToolboxDB{}
+	// 获取用户ID（内部调用使用传入 userID）
+	uid := userID
+	if accessor != nil {
+		uid = accessor.ID
+	}
 	// 检查是否有更新权限，并收集需要更新的工具箱
 	for _, boxDB := range waitUpdataBoxList {
-		// 检查工具箱编辑权限
-		err = s.AuthService.CheckModifyPermission(ctx, accessor, boxDB.BoxID, interfaces.AuthResourceTypeToolBox)
-		if err != nil {
-			return
+		// 检查工具箱编辑权限（内部调用不鉴权）
+		if icommon.IsPublicAPIFromCtx(ctx) {
+			err = s.AuthService.CheckModifyPermission(ctx, accessor, boxDB.BoxID, interfaces.AuthResourceTypeToolBox)
+			if err != nil {
+				return
+			}
 		}
 		// 内置工具箱不能编辑
 		if boxDB.IsInternal {
@@ -191,12 +207,12 @@ func (s *ToolServiceImpl) batchImportToolBoxMetadata(ctx context.Context, tx *sq
 	// 遍历导入项，根据是否存在工具箱ID判断是新增还是更新
 	for _, item := range items {
 		if boxDB, ok := updateBoxMap[item.BoxID]; ok {
-			err = s.importByUpsert(ctx, tx, boxDB, item, accessor.ID)
+			err = s.importByUpsert(ctx, tx, boxDB, item, uid)
 			if err != nil {
 				return
 			}
 		} else {
-			boxDB, err = s.importByCreate(ctx, tx, item, accessor.ID)
+			boxDB, err = s.importByCreate(ctx, tx, item, uid)
 			if err != nil {
 				return
 			}

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/impex.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/impex.go
@@ -108,13 +108,14 @@ func (s *ToolServiceImpl) importPostProcess(ctx context.Context, createBoxMap, u
 		}
 		// 内置组件：创建全员授权策略（public_access + execute）
 		if boxDB.IsInternal {
-			policyErr := s.AuthService.CreateIntCompPolicyForAllUsers(ctx, &interfaces.AuthResource{
+			err = s.AuthService.CreateIntCompPolicyForAllUsers(ctx, &interfaces.AuthResource{
 				ID:   boxDB.BoxID,
 				Type: interfaces.AuthResourceTypeToolBox.String(),
 				Name: boxDB.Name,
 			})
-			if policyErr != nil {
-				s.Logger.WithContext(ctx).Errorf("[importPostProcess] CreateIntCompPolicyForAllUsers err:%v", policyErr)
+			if err != nil {
+				s.Logger.WithContext(ctx).Errorf("[importPostProcess] CreateIntCompPolicyForAllUsers err:%v", err)
+				return
 			}
 		}
 	}

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/impex.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/impex.go
@@ -149,7 +149,7 @@ func (s *ToolServiceImpl) importPreCheck(ctx context.Context, mode interfaces.Im
 	boxIDs := []string{}
 	for _, item := range items {
 		boxIDs = append(boxIDs, item.BoxID)
-		if item.IsInternal {
+		if icommon.IsPublicAPIFromCtx(ctx) && item.IsInternal {
 			err = errors.NewHTTPError(ctx, http.StatusForbidden, errors.ErrExtCommonInternalComponentNotAllowed,
 				fmt.Sprintf("internal toolbox %v not allowed to import", item.BoxID), item.BoxName)
 			return

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/impex.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/impex.go
@@ -238,7 +238,7 @@ func (s *ToolServiceImpl) importByCreate(ctx context.Context, tx *sql.Tx, item *
 		ServerURL:    item.BoxSvcURL,
 		Category:     item.CategoryType,
 		Status:       item.Status.String(),
-		IsInternal:   false,
+		IsInternal:   item.IsInternal,
 		CreateTime:   time.Now().UnixNano(),
 		CreateUser:   userID,
 		UpdateUser:   userID,

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/impex.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/impex.go
@@ -195,12 +195,12 @@ func (s *ToolServiceImpl) batchImportToolBoxMetadata(ctx context.Context, tx *sq
 			if err != nil {
 				return
 			}
-		}
-		// 内置工具箱不能编辑
-		if boxDB.IsInternal {
-			err = errors.NewHTTPError(ctx, http.StatusForbidden, errors.ErrExtCommonInternalComponentNotAllowed,
-				fmt.Sprintf("internal toolbox %v not allowed to update", boxDB.BoxID), boxDB.Name)
-			return
+			// 内置工具箱不能编辑
+			if boxDB.IsInternal {
+				err = errors.NewHTTPError(ctx, http.StatusForbidden, errors.ErrExtCommonInternalComponentNotAllowed,
+					fmt.Sprintf("internal toolbox %v not allowed to update", boxDB.BoxID), boxDB.Name)
+				return
+			}
 		}
 		updateBoxMap[boxDB.BoxID] = boxDB
 	}

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/impex.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/impex.go
@@ -79,7 +79,7 @@ func (s *ToolServiceImpl) importPostProcess(ctx context.Context, createBoxMap, u
 		if accessor != nil {
 			err := s.AuthService.CreateOwnerPolicy(ctx, accessor, &interfaces.AuthResource{
 				ID:   boxDB.BoxID,
-				Type: string(interfaces.AuthResourceTypeToolBox),
+				Type: interfaces.AuthResourceTypeToolBox.String(),
 				Name: boxDB.Name,
 			})
 			if err != nil {
@@ -106,6 +106,17 @@ func (s *ToolServiceImpl) importPostProcess(ctx context.Context, createBoxMap, u
 				})
 			}()
 		}
+		// 内置组件：创建全员授权策略（public_access + execute）
+		if boxDB.IsInternal {
+			policyErr := s.AuthService.CreateIntCompPolicyForAllUsers(ctx, &interfaces.AuthResource{
+				ID:   boxDB.BoxID,
+				Type: interfaces.AuthResourceTypeToolBox.String(),
+				Name: boxDB.Name,
+			})
+			if policyErr != nil {
+				s.Logger.WithContext(ctx).Errorf("[importPostProcess] CreateIntCompPolicyForAllUsers err:%v", policyErr)
+			}
+		}
 	}
 	// 更新工具箱
 	for _, boxDB := range updateBoxMap {
@@ -113,11 +124,22 @@ func (s *ToolServiceImpl) importPostProcess(ctx context.Context, createBoxMap, u
 		authResource := &interfaces.AuthResource{
 			ID:   boxDB.BoxID,
 			Name: boxDB.Name,
-			Type: string(interfaces.AuthResourceTypeToolBox),
+			Type: interfaces.AuthResourceTypeToolBox.String(),
 		}
 		err := s.AuthService.NotifyResourceChange(ctx, authResource)
 		if err != nil {
 			s.Logger.WithContext(ctx).Errorf("[importPostProcess] NotifyResourceChange err:%v", err)
+		}
+		// 内置组件：创建全员授权策略（public_access + execute）
+		if boxDB.IsInternal {
+			policyErr := s.AuthService.CreateIntCompPolicyForAllUsers(ctx, &interfaces.AuthResource{
+				ID:   boxDB.BoxID,
+				Type: interfaces.AuthResourceTypeToolBox.String(),
+				Name: boxDB.Name,
+			})
+			if policyErr != nil {
+				s.Logger.WithContext(ctx).Errorf("[importPostProcess] CreateIntCompPolicyForAllUsers err:%v", policyErr)
+			}
 		}
 		// 记录设计日志及后续通知（内部调用不记录）
 		if accessor != nil {

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/impex.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/impex.go
@@ -320,6 +320,7 @@ func (s *ToolServiceImpl) importByUpsert(ctx context.Context, tx *sql.Tx, toolBo
 	toolBoxDB.Description = item.BoxDesc
 	toolBoxDB.ServerURL = item.BoxSvcURL
 	toolBoxDB.Category = item.CategoryType
+	toolBoxDB.IsInternal = item.IsInternal
 	toolBoxDB.UpdateTime = time.Now().UnixNano()
 	toolBoxDB.UpdateUser = userID
 	toolBoxDB.Status = item.Status.String()

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/impex_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/impex_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	myErr "github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/errors"
 	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/common"
+	myErr "github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/errors"
 	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/logger"
 	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/interfaces"
 	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/interfaces/model"

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/impex_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/impex_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	myErr "github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/errors"
+	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/common"
 	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/logger"
 	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/interfaces"
 	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/interfaces/model"
@@ -65,6 +66,7 @@ func TestImport(t *testing.T) {
 			},
 		}
 		accessor := &interfaces.AuthAccessor{}
+		publicCtx := common.SetPublicAPIToCtx(context.TODO(), true)
 		toolInfo := interfaces.ToolInfo{
 			Name:         "tool_a",
 			Description:  "tool_desc_a",
@@ -133,7 +135,7 @@ func TestImport(t *testing.T) {
 			mockToolBoxDB.EXPECT().SelectToolBoxByName(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil, nil)
 			mockToolBoxDB.EXPECT().SelectListByBoxIDs(gomock.Any(), gomock.Any()).Return([]*model.ToolboxDB{}, nil)
 			mockAuthService.EXPECT().GetAccessor(gomock.Any(), gomock.Any()).Return(nil, mocks.MockFuncErr("GetAccessor"))
-			err := toolbox.Import(context.TODO(), nil, interfaces.ImportTypeCreate, importData, "")
+			err := toolbox.Import(publicCtx, nil, interfaces.ImportTypeCreate, importData, "")
 			So(err, ShouldNotBeNil)
 		})
 		Convey("创建模式: 批量导入工具箱及工具元数据", func() {
@@ -144,7 +146,7 @@ func TestImport(t *testing.T) {
 				importData.Toolbox.Configs[0].BoxName = " BoxName"
 				mockValidator.EXPECT().ValidatorToolBoxName(gomock.Any(), gomock.Any()).Return(mocks.MockFuncErr("ValidatorToolBoxName"))
 				mockValidator.EXPECT().ValidatorStruct(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-				err := toolbox.Import(context.TODO(), nil, interfaces.ImportTypeCreate, importData, "")
+				err := toolbox.Import(publicCtx, nil, interfaces.ImportTypeCreate, importData, "")
 				So(err, ShouldNotBeNil)
 			})
 			Convey("校验导入的工具箱信息: 工具箱desc不合法", func() {
@@ -152,7 +154,7 @@ func TestImport(t *testing.T) {
 				mockValidator.EXPECT().ValidatorStruct(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockValidator.EXPECT().ValidatorToolBoxName(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockValidator.EXPECT().ValidatorToolBoxDesc(gomock.Any(), gomock.Any()).Return(mocks.MockFuncErr("ValidatorToolBoxDesc")).Times(1)
-				err := toolbox.Import(context.TODO(), nil, interfaces.ImportTypeCreate, importData, "")
+				err := toolbox.Import(publicCtx, nil, interfaces.ImportTypeCreate, importData, "")
 				So(err, ShouldNotBeNil)
 			})
 			Convey("校验导入的工具箱信息: 工具名字不合法", func() {
@@ -168,7 +170,7 @@ func TestImport(t *testing.T) {
 				mockValidator.EXPECT().ValidatorToolBoxDesc(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockValidator.EXPECT().ValidatorToolName(gomock.Any(), gomock.Any()).Return(mocks.MockFuncErr("ValidatorToolName")).Times(1)
 				mockCategoryManager.EXPECT().CheckCategory(gomock.Any()).Return(false)
-				err := toolbox.Import(context.TODO(), nil, interfaces.ImportTypeCreate, importData, "")
+				err := toolbox.Import(publicCtx, nil, interfaces.ImportTypeCreate, importData, "")
 				So(err, ShouldNotBeNil)
 			})
 			Convey("校验导入的工具箱信息: 工具Desc不合法", func() {
@@ -185,7 +187,7 @@ func TestImport(t *testing.T) {
 				mockValidator.EXPECT().ValidatorToolName(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockValidator.EXPECT().ValidatorToolDesc(gomock.Any(), gomock.Any()).Return(mocks.MockFuncErr("ValidatorToolDesc")).Times(1)
 				mockCategoryManager.EXPECT().CheckCategory(gomock.Any()).Return(false)
-				err := toolbox.Import(context.TODO(), nil, interfaces.ImportTypeCreate, importData, "")
+				err := toolbox.Import(publicCtx, nil, interfaces.ImportTypeCreate, importData, "")
 				So(err, ShouldNotBeNil)
 			})
 			Convey("校验导入的工具箱信息: 工具元数据为空", func() {
@@ -202,7 +204,7 @@ func TestImport(t *testing.T) {
 				mockValidator.EXPECT().ValidatorToolName(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockValidator.EXPECT().ValidatorToolDesc(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockCategoryManager.EXPECT().CheckCategory(gomock.Any()).Return(false)
-				err := toolbox.Import(context.TODO(), nil, interfaces.ImportTypeCreate, importData, "")
+				err := toolbox.Import(publicCtx, nil, interfaces.ImportTypeCreate, importData, "")
 				So(err, ShouldNotBeNil)
 				httpErr, ok := err.(*myErr.HTTPError)
 				So(ok, ShouldBeTrue)
@@ -222,7 +224,7 @@ func TestImport(t *testing.T) {
 			// 	mockValidator.EXPECT().ValidatorToolName(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			// 	mockValidator.EXPECT().ValidatorToolDesc(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			// 	mockCategoryManager.EXPECT().CheckCategory(gomock.Any()).Return(false)
-			// 	err := toolbox.Import(context.TODO(), nil, interfaces.ImportTypeCreate, importData, "")
+			// 	err := toolbox.Import(publicCtx, nil, interfaces.ImportTypeCreate, importData, "")
 			// 	So(err, ShouldNotBeNil)
 			// 	httpErr, ok := err.(*myErr.HTTPError)
 			// 	So(ok, ShouldBeTrue)
@@ -238,7 +240,7 @@ func TestImport(t *testing.T) {
 			// 	}
 
 			// 	mockCategoryManager.EXPECT().CheckCategory(gomock.Any()).Return(false)
-			// 	err := toolbox.Import(context.TODO(), nil, interfaces.ImportTypeCreate, importData, "")
+			// 	err := toolbox.Import(publicCtx, nil, interfaces.ImportTypeCreate, importData, "")
 			// 	So(err, ShouldNotBeNil)
 			// 	httpErr, ok := err.(*myErr.HTTPError)
 			// 	So(ok, ShouldBeTrue)
@@ -256,7 +258,7 @@ func TestImport(t *testing.T) {
 			// 		},
 			// 	}
 			// 	mockCategoryManager.EXPECT().CheckCategory(gomock.Any()).Return(false)
-			// 	err := toolbox.Import(context.TODO(), nil, interfaces.ImportTypeCreate, importData, "")
+			// 	err := toolbox.Import(publicCtx, nil, interfaces.ImportTypeCreate, importData, "")
 			// 	So(err, ShouldNotBeNil)
 			// 	httpErr, ok := err.(*myErr.HTTPError)
 			// 	So(ok, ShouldBeTrue)
@@ -271,7 +273,7 @@ func TestImport(t *testing.T) {
 			// 	}
 			// 	mockCategoryManager.EXPECT().CheckCategory(gomock.Any()).Return(false)
 			// 	mockToolBoxDB.EXPECT().InsertToolBox(gomock.Any(), gomock.Any(), gomock.Any()).Return("", mocks.MockFuncErr("InsertToolBox"))
-			// 	err := toolbox.Import(context.TODO(), nil, interfaces.ImportTypeCreate, importData, "")
+			// 	err := toolbox.Import(publicCtx, nil, interfaces.ImportTypeCreate, importData, "")
 			// 	So(err, ShouldNotBeNil)
 			// 	httpErr, ok := err.(*myErr.HTTPError)
 			// 	So(ok, ShouldBeTrue)
@@ -287,7 +289,7 @@ func TestImport(t *testing.T) {
 			// 	mockCategoryManager.EXPECT().CheckCategory(gomock.Any()).Return(false)
 			// 	mockToolBoxDB.EXPECT().InsertToolBox(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil)
 			// 	mockMetadataDB.EXPECT().InsertAPIMetadatas(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, mocks.MockFuncErr("InsertAPIMetadatas"))
-			// 	err := toolbox.Import(context.TODO(), nil, interfaces.ImportTypeCreate, importData, "")
+			// 	err := toolbox.Import(publicCtx, nil, interfaces.ImportTypeCreate, importData, "")
 			// 	So(err, ShouldNotBeNil)
 			// 	httpErr, ok := err.(*myErr.HTTPError)
 			// 	So(ok, ShouldBeTrue)
@@ -304,7 +306,7 @@ func TestImport(t *testing.T) {
 			// 	mockToolBoxDB.EXPECT().InsertToolBox(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil)
 			// 	mockMetadataDB.EXPECT().InsertAPIMetadatas(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil)
 			// 	mockToolDB.EXPECT().InsertTools(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, mocks.MockFuncErr("InsertTools"))
-			// 	err := toolbox.Import(context.TODO(), nil, interfaces.ImportTypeCreate, importData, "")
+			// 	err := toolbox.Import(publicCtx, nil, interfaces.ImportTypeCreate, importData, "")
 			// 	So(err, ShouldNotBeNil)
 			// 	httpErr, ok := err.(*myErr.HTTPError)
 			// 	So(ok, ShouldBeTrue)
@@ -327,7 +329,7 @@ func TestImport(t *testing.T) {
 			// 	mockMetadataDB.EXPECT().InsertAPIMetadatas(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil)
 			// 	mockToolDB.EXPECT().InsertTools(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil)
 			// 	mockOperatorMgnt.EXPECT().Import(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mocks.MockFuncErr("Import"))
-			// 	err := toolbox.Import(context.TODO(), nil, interfaces.ImportTypeCreate, importData, "")
+			// 	err := toolbox.Import(publicCtx, nil, interfaces.ImportTypeCreate, importData, "")
 			// 	So(err, ShouldNotBeNil)
 			// })
 			// Convey("添加所有者权限失败", func() {
@@ -349,7 +351,7 @@ func TestImport(t *testing.T) {
 			// 	mockOperatorMgnt.EXPECT().Import(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			// 	mockAuthService.EXPECT().CreateOwnerPolicy(gomock.Any(), gomock.Any(), gomock.Any()).Return(mocks.MockFuncErr("CreateOwnerPolicy"))
 			// 	mockAuditLog.EXPECT().Logger(gomock.Any(), gomock.Any())
-			// 	err := toolbox.Import(context.TODO(), nil, interfaces.ImportTypeCreate, importData, "")
+			// 	err := toolbox.Import(publicCtx, nil, interfaces.ImportTypeCreate, importData, "")
 			// 	So(err, ShouldBeNil)
 			// 	time.Sleep(100 * time.Millisecond)
 			// })
@@ -366,7 +368,7 @@ func TestImport(t *testing.T) {
 			// 	mockToolDB.EXPECT().InsertTools(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil)
 			// 	mockAuthService.EXPECT().CreateOwnerPolicy(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			// 	mockAuditLog.EXPECT().Logger(gomock.Any(), gomock.Any())
-			// 	err := toolbox.Import(context.TODO(), nil, interfaces.ImportTypeCreate, importData, "")
+			// 	err := toolbox.Import(publicCtx, nil, interfaces.ImportTypeCreate, importData, "")
 			// 	So(err, ShouldBeNil)
 			// 	time.Sleep(100 * time.Millisecond)
 			// })
@@ -384,14 +386,14 @@ func TestImport(t *testing.T) {
 		// 	Convey("检查编辑权限失败", func() {
 		// 		mockToolBoxDB.EXPECT().SelectListByBoxIDs(gomock.Any(), gomock.Any()).Return(boxList, nil)
 		// 		mockAuthService.EXPECT().CheckModifyPermission(gomock.Any(), gomock.Any(), gomock.Any(), interfaces.AuthResourceTypeToolBox).Return(mocks.MockFuncErr("CheckModifyPermission"))
-		// 		err := toolbox.Import(context.TODO(), nil, interfaces.ImportTypeUpsert, importData, "")
+		// 		err := toolbox.Import(publicCtx, nil, interfaces.ImportTypeUpsert, importData, "")
 		// 		So(err, ShouldNotBeNil)
 		// 	})
 		// 	Convey("内置工具箱不允许编辑", func() {
 		// 		boxList[0].IsInternal = true
 		// 		mockToolBoxDB.EXPECT().SelectListByBoxIDs(gomock.Any(), gomock.Any()).Return(boxList, nil)
 		// 		mockAuthService.EXPECT().CheckModifyPermission(gomock.Any(), gomock.Any(), gomock.Any(), interfaces.AuthResourceTypeToolBox).Return(nil)
-		// 		err := toolbox.Import(context.TODO(), nil, interfaces.ImportTypeUpsert, importData, "")
+		// 		err := toolbox.Import(publicCtx, nil, interfaces.ImportTypeUpsert, importData, "")
 		// 		So(err, ShouldNotBeNil)
 		// 		httpErr, ok := err.(*myErr.HTTPError)
 		// 		So(ok, ShouldBeTrue)
@@ -401,7 +403,7 @@ func TestImport(t *testing.T) {
 		// 		importData.Toolbox.Configs[0].BoxName = "mock name err 不允许空格"
 		// 		mockToolBoxDB.EXPECT().SelectListByBoxIDs(gomock.Any(), gomock.Any()).Return(boxList, nil)
 		// 		mockAuthService.EXPECT().CheckModifyPermission(gomock.Any(), gomock.Any(), gomock.Any(), interfaces.AuthResourceTypeToolBox).Return(nil)
-		// 		err := toolbox.Import(context.TODO(), nil, interfaces.ImportTypeUpsert, importData, "")
+		// 		err := toolbox.Import(publicCtx, nil, interfaces.ImportTypeUpsert, importData, "")
 		// 		So(err, ShouldNotBeNil)
 		// 		httpErr, ok := err.(*myErr.HTTPError)
 		// 		So(ok, ShouldBeTrue)
@@ -413,7 +415,7 @@ func TestImport(t *testing.T) {
 		// 		mockAuthService.EXPECT().CheckModifyPermission(gomock.Any(), gomock.Any(), gomock.Any(), interfaces.AuthResourceTypeToolBox).Return(nil)
 		// 		mockCategoryManager.EXPECT().CheckCategory(gomock.Any()).Return(false)
 		// 		mockToolBoxDB.EXPECT().UpdateToolBox(gomock.Any(), gomock.Any(), gomock.Any()).Return(mocks.MockFuncErr("UpdateToolBox"))
-		// 		err := toolbox.Import(context.TODO(), nil, interfaces.ImportTypeUpsert, importData, "")
+		// 		err := toolbox.Import(publicCtx, nil, interfaces.ImportTypeUpsert, importData, "")
 		// 		So(err, ShouldNotBeNil)
 		// 		httpErr, ok := err.(*myErr.HTTPError)
 		// 		So(ok, ShouldBeTrue)
@@ -425,7 +427,7 @@ func TestImport(t *testing.T) {
 		// 		mockCategoryManager.EXPECT().CheckCategory(gomock.Any()).Return(false)
 		// 		mockToolBoxDB.EXPECT().UpdateToolBox(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		// 		mockToolDB.EXPECT().SelectToolByBoxID(gomock.Any(), gomock.Any()).Return(nil, mocks.MockFuncErr("SelectToolByBoxID"))
-		// 		err := toolbox.Import(context.TODO(), nil, interfaces.ImportTypeUpsert, importData, "")
+		// 		err := toolbox.Import(publicCtx, nil, interfaces.ImportTypeUpsert, importData, "")
 		// 		So(err, ShouldNotBeNil)
 		// 		httpErr, ok := err.(*myErr.HTTPError)
 		// 		So(ok, ShouldBeTrue)
@@ -438,7 +440,7 @@ func TestImport(t *testing.T) {
 		// 		mockToolBoxDB.EXPECT().UpdateToolBox(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		// 		mockToolDB.EXPECT().SelectToolByBoxID(gomock.Any(), gomock.Any()).Return(tools, nil)
 		// 		mockToolDB.EXPECT().DeleteBoxByIDAndTools(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mocks.MockFuncErr("DeleteBoxByIDAndTools"))
-		// 		err := toolbox.Import(context.TODO(), nil, interfaces.ImportTypeUpsert, importData, "")
+		// 		err := toolbox.Import(publicCtx, nil, interfaces.ImportTypeUpsert, importData, "")
 		// 		So(err, ShouldNotBeNil)
 		// 		httpErr, ok := err.(*myErr.HTTPError)
 		// 		So(ok, ShouldBeTrue)
@@ -452,7 +454,7 @@ func TestImport(t *testing.T) {
 		// 	mockToolDB.EXPECT().SelectToolByBoxID(gomock.Any(), gomock.Any()).Return(tools, nil)
 		// 	mockToolDB.EXPECT().DeleteBoxByIDAndTools(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		// 	mockMetadataDB.EXPECT().InsertAPIMetadatas(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, mocks.MockFuncErr("InsertAPIMetadatas"))
-		// 	err := toolbox.Import(context.TODO(), nil, interfaces.ImportTypeUpsert, importData, "")
+		// 	err := toolbox.Import(publicCtx, nil, interfaces.ImportTypeUpsert, importData, "")
 		// 	So(err, ShouldNotBeNil)
 		// 	httpErr, ok := err.(*myErr.HTTPError)
 		// 	So(ok, ShouldBeTrue)
@@ -493,6 +495,7 @@ func TestExport(t *testing.T) {
 		}
 		boxID := "box_id_1"
 		accessor := &interfaces.AuthAccessor{}
+		publicCtx := common.SetPublicAPIToCtx(context.TODO(), true)
 		ids := []string{boxID}
 		exportReq := &interfaces.ExportReq{
 			IDs: ids,
@@ -524,21 +527,21 @@ func TestExport(t *testing.T) {
 		Convey("导出预检查", func() {
 			Convey("获取accessor信息失败", func() {
 				mockAuthService.EXPECT().GetAccessor(gomock.Any(), gomock.Any()).Return(nil, mocks.MockFuncErr("GetAccessor"))
-				_, err := toolbox.Export(context.TODO(), exportReq)
+				_, err := toolbox.Export(publicCtx, exportReq)
 				So(err, ShouldNotBeNil)
 			})
 			Convey("检查权限失败", func() {
 				mockAuthService.EXPECT().GetAccessor(gomock.Any(), gomock.Any()).Return(accessor, nil)
 				mockAuthService.EXPECT().ResourceFilterIDs(gomock.Any(), gomock.Any(), gomock.Any(), interfaces.AuthResourceTypeToolBox,
 					interfaces.AuthOperationTypeView).Return(nil, mocks.MockFuncErr("ResourceFilterIDs"))
-				_, err := toolbox.Export(context.TODO(), exportReq)
+				_, err := toolbox.Export(publicCtx, exportReq)
 				So(err, ShouldNotBeNil)
 			})
 			Convey("没有查看权限", func() {
 				mockAuthService.EXPECT().GetAccessor(gomock.Any(), gomock.Any()).Return(accessor, nil)
 				mockAuthService.EXPECT().ResourceFilterIDs(gomock.Any(), gomock.Any(), gomock.Any(), interfaces.AuthResourceTypeToolBox,
 					interfaces.AuthOperationTypeView).Return([]string{}, nil)
-				_, err := toolbox.Export(context.TODO(), exportReq)
+				_, err := toolbox.Export(publicCtx, exportReq)
 				So(err, ShouldNotBeNil)
 				httpErr, ok := err.(*myErr.HTTPError)
 				So(ok, ShouldBeTrue)
@@ -549,7 +552,7 @@ func TestExport(t *testing.T) {
 				mockAuthService.EXPECT().ResourceFilterIDs(gomock.Any(), gomock.Any(), gomock.Any(), interfaces.AuthResourceTypeToolBox,
 					interfaces.AuthOperationTypeView).Return(ids, nil)
 				mockToolBoxDB.EXPECT().SelectListByBoxIDs(gomock.Any(), gomock.Any()).Return(nil, mocks.MockFuncErr("SelectListByBoxIDs"))
-				_, err := toolbox.Export(context.TODO(), exportReq)
+				_, err := toolbox.Export(publicCtx, exportReq)
 				So(err, ShouldNotBeNil)
 				httpErr, ok := err.(*myErr.HTTPError)
 				So(ok, ShouldBeTrue)
@@ -560,7 +563,7 @@ func TestExport(t *testing.T) {
 				mockAuthService.EXPECT().ResourceFilterIDs(gomock.Any(), gomock.Any(), gomock.Any(), interfaces.AuthResourceTypeToolBox,
 					interfaces.AuthOperationTypeView).Return(ids, nil)
 				mockToolBoxDB.EXPECT().SelectListByBoxIDs(gomock.Any(), gomock.Any()).Return([]*model.ToolboxDB{}, nil)
-				_, err := toolbox.Export(context.TODO(), exportReq)
+				_, err := toolbox.Export(publicCtx, exportReq)
 				So(err, ShouldNotBeNil)
 				httpErr, ok := err.(*myErr.HTTPError)
 				So(ok, ShouldBeTrue)
@@ -574,7 +577,7 @@ func TestExport(t *testing.T) {
 			Convey("内置工具箱不允许导出", func() {
 				toolBoxDB.IsInternal = true
 				mockToolBoxDB.EXPECT().SelectListByBoxIDs(gomock.Any(), gomock.Any()).Return([]*model.ToolboxDB{toolBoxDB}, nil)
-				_, err := toolbox.Export(context.TODO(), exportReq)
+				_, err := toolbox.Export(publicCtx, exportReq)
 				So(err, ShouldNotBeNil)
 				httpErr, ok := err.(*myErr.HTTPError)
 				So(ok, ShouldBeTrue)
@@ -584,7 +587,7 @@ func TestExport(t *testing.T) {
 				mockToolBoxDB.EXPECT().SelectListByBoxIDs(gomock.Any(), gomock.Any()).Return([]*model.ToolboxDB{toolBoxDB}, nil)
 				mockCategoryManager.EXPECT().GetCategoryName(gomock.Any(), gomock.Any()).Return("")
 				mockToolDB.EXPECT().SelectToolBoxByIDs(gomock.Any(), gomock.Any()).Return(nil, mocks.MockFuncErr("SelectToolBoxByIDs"))
-				_, err := toolbox.Export(context.TODO(), exportReq)
+				_, err := toolbox.Export(publicCtx, exportReq)
 				So(err, ShouldNotBeNil)
 				httpErr, ok := err.(*myErr.HTTPError)
 				So(ok, ShouldBeTrue)
@@ -595,7 +598,7 @@ func TestExport(t *testing.T) {
 				mockToolBoxDB.EXPECT().SelectListByBoxIDs(gomock.Any(), gomock.Any()).Return([]*model.ToolboxDB{toolBoxDB}, nil)
 				mockCategoryManager.EXPECT().GetCategoryName(gomock.Any(), gomock.Any()).Return("")
 				mockToolDB.EXPECT().SelectToolBoxByIDs(gomock.Any(), gomock.Any()).Return(tools, nil)
-				_, err := toolbox.Export(context.TODO(), exportReq)
+				_, err := toolbox.Export(publicCtx, exportReq)
 				So(err, ShouldNotBeNil)
 				httpErr, ok := err.(*myErr.HTTPError)
 				So(ok, ShouldBeTrue)
@@ -606,7 +609,7 @@ func TestExport(t *testing.T) {
 			// 	mockCategoryManager.EXPECT().GetCategoryName(gomock.Any(), gomock.Any()).Return("")
 			// 	mockToolDB.EXPECT().SelectToolBoxByIDs(gomock.Any(), gomock.Any()).Return(tools, nil)
 			// 	mockMetadataDB.EXPECT().SelectListByVersion(gomock.Any(), gomock.Any()).Return(nil, mocks.MockFuncErr("SelectListByVersion"))
-			// 	_, err := toolbox.Export(context.TODO(), exportReq)
+			// 	_, err := toolbox.Export(publicCtx, exportReq)
 			// 	So(err, ShouldNotBeNil)
 			// 	httpErr, ok := err.(*myErr.HTTPError)
 			// 	So(ok, ShouldBeTrue)
@@ -618,7 +621,7 @@ func TestExport(t *testing.T) {
 			// 	mockCategoryManager.EXPECT().GetCategoryName(gomock.Any(), gomock.Any()).Return("")
 			// 	mockToolDB.EXPECT().SelectToolBoxByIDs(gomock.Any(), gomock.Any()).Return(tools, nil)
 			// 	mockMetadataDB.EXPECT().SelectListByVersion(gomock.Any(), gomock.Any()).Return([]*model.APIMetadataDB{metadataDB}, nil)
-			// 	_, err := toolbox.Export(context.TODO(), exportReq)
+			// 	_, err := toolbox.Export(publicCtx, exportReq)
 			// 	So(err, ShouldNotBeNil)
 			// 	httpErr, ok := err.(*myErr.HTTPError)
 			// 	So(ok, ShouldBeTrue)
@@ -629,7 +632,7 @@ func TestExport(t *testing.T) {
 			// 	mockCategoryManager.EXPECT().GetCategoryName(gomock.Any(), gomock.Any()).Return("")
 			// 	mockToolDB.EXPECT().SelectToolBoxByIDs(gomock.Any(), gomock.Any()).Return([]*model.ToolDB{tools[0]}, nil)
 			// 	mockMetadataDB.EXPECT().SelectListByVersion(gomock.Any(), gomock.Any()).Return([]*model.APIMetadataDB{metadataDB}, nil)
-			// 	_, err := toolbox.Export(context.TODO(), exportReq)
+			// 	_, err := toolbox.Export(publicCtx, exportReq)
 			// 	So(err, ShouldBeNil)
 			// })
 		})
@@ -642,7 +645,7 @@ func TestExport(t *testing.T) {
 		// 	mockToolDB.EXPECT().SelectToolBoxByIDs(gomock.Any(), gomock.Any()).Return(tools, nil)
 		// 	mockMetadataDB.EXPECT().SelectListByVersion(gomock.Any(), gomock.Any()).Return([]*model.APIMetadataDB{metadataDB}, nil)
 		// 	mockOperatorMgnt.EXPECT().Export(gomock.Any(), gomock.Any()).Return(nil, mocks.MockFuncErr("OperatorMgntExport"))
-		// 	_, err := toolbox.Export(context.TODO(), exportReq)
+		// 	_, err := toolbox.Export(publicCtx, exportReq)
 		// 	So(err, ShouldNotBeNil)
 		// })
 		// Convey("导出成功", func() {
@@ -654,7 +657,7 @@ func TestExport(t *testing.T) {
 		// 	mockToolDB.EXPECT().SelectToolBoxByIDs(gomock.Any(), gomock.Any()).Return(tools, nil)
 		// 	mockMetadataDB.EXPECT().SelectListByVersion(gomock.Any(), gomock.Any()).Return([]*model.APIMetadataDB{metadataDB}, nil)
 		// 	mockOperatorMgnt.EXPECT().Export(gomock.Any(), gomock.Any()).Return(&interfaces.ComponentImpexConfigModel{}, nil)
-		// 	data, err := toolbox.Export(context.TODO(), exportReq)
+		// 	data, err := toolbox.Export(publicCtx, exportReq)
 		// 	So(err, ShouldBeNil)
 		// 	So(data, ShouldNotBeNil)
 		// 	So(data.Toolbox, ShouldNotBeNil)


### PR DESCRIPTION
## 修复内容

1. importPreCheck 权限校验修复（toolbox 和 operator）：当请求来自内部 API 时跳过 IsInternal 检查
2. 导入创建/更新路径保留 IsInternal 标志
3. UpdateToolBox SQL 补充 f_is_internal 字段（根因）

## 涉及修改文件
- adp/execution-factory/operator-integration/server/logics/toolbox/impex.go
- adp/execution-factory/operator-integration/server/logics/operator/impex.go
- adp/execution-factory/operator-integration/server/dbaccess/toolbox.go