### PR TITLE
feat(execution-factory): 支持管理态 SKILL.md 内容读取、响应模式及 OSS 同步 (#302)

### DIFF
--- a/adp/execution-factory/operator-integration/Makefile
+++ b/adp/execution-factory/operator-integration/Makefile
@@ -1,8 +1,21 @@
 .DEFAULT_GOAL := help
-.PHONY: help generate-mock lint test test-cover test-race test-integration test-at test-performance ci
+.PHONY: help dev generate-mock lint test test-cover test-race test-integration test-at test-performance ci
+
+DEV_CONFIG_PROFILE ?= $(shell d="$(CURDIR)"; \
+	while [ "$$d" != "/" ]; do \
+		if [ -d "$$d/.env/execution-factory" ]; then \
+			printf "%s/.env/execution-factory" "$$d"; \
+			exit 0; \
+		fi; \
+		d=$$(dirname "$$d"); \
+	done; \
+	printf "%s/.env/execution-factory" "$(CURDIR)")
+AUTH_ENABLED ?= true
+BUSINESS_DOMAIN_ENABLED ?= true
 
 help:
 	@echo "operator-integration - available commands:"
+	@echo "  make dev              - run local service with .env execution-factory config"
 	@echo "  make test             - run unit tests"
 	@echo "  make test-cover       - run unit tests with coverage output"
 	@echo "  make test-race        - run unit tests with race detection"
@@ -16,6 +29,16 @@ help:
 UT_PACKAGES := $(shell go list ./... | \
 	grep -v /server/tests | \
 	grep -v /server/mocks)
+
+dev:
+	@test -f "$(DEV_CONFIG_PROFILE)/agent-operator-integration.yaml"
+	@test -f "$(DEV_CONFIG_PROFILE)/agent-operator-integration-secret.yaml"
+	@test -f "$(DEV_CONFIG_PROFILE)/mq_config.yaml"
+	@test -f "$(DEV_CONFIG_PROFILE)/observability.yaml"
+	CONFIG_PROFILE="$(DEV_CONFIG_PROFILE)" \
+	AUTH_ENABLED="$(AUTH_ENABLED)" \
+	BUSINESS_DOMAIN_ENABLED="$(BUSINESS_DOMAIN_ENABLED)" \
+	go run ./server/main.go
 
 generate-mock:
 	go generate ./...

--- a/adp/execution-factory/operator-integration/docs/apis/api_private/skill.yaml
+++ b/adp/execution-factory/operator-integration/docs/apis/api_private/skill.yaml
@@ -497,6 +497,141 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+
+  /skills/{skill_id}/management/content:
+    get:
+      summary: "获取 Skill 管理态内容"
+      description: "读取当前编辑态的 SKILL.md 下载 URL 和文件清单"
+      tags:
+        - "Skill - Management Read"
+      parameters:
+        - $ref: "#/components/parameters/BusinessDomain"
+        - $ref: "#/components/parameters/AccountID"
+        - $ref: "#/components/parameters/AccountType"
+        - $ref: "#/components/parameters/SkillID"
+        - name: response_mode
+          in: query
+          description: "响应模式。url(默认)返回 OSS 预签名 URL；content 返回内联正文；auto 根据注册类型自动选择"
+          required: false
+          schema:
+            type: string
+            enum: [url, content, auto]
+            default: url
+      responses:
+        "200":
+          description: "成功"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GetManagementContentResponse"
+        "400":
+          description: "参数错误"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: "权限不足"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: "Skill 不存在"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /skills/{skill_id}/management/files/read:
+    post:
+      summary: "读取管理态指定文件"
+      description: "读取当前编辑态的指定文件内容，返回 OSS 预签名下载 URL"
+      tags:
+        - "Skill - Management Read"
+      parameters:
+        - $ref: "#/components/parameters/BusinessDomain"
+        - $ref: "#/components/parameters/AccountID"
+        - $ref: "#/components/parameters/AccountType"
+        - $ref: "#/components/parameters/SkillID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - rel_path
+              properties:
+                rel_path:
+                  type: string
+                  description: "文件相对路径"
+      responses:
+        "200":
+          description: "成功"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReadSkillFileResp"
+        "400":
+          description: "参数错误或路径非法"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: "权限不足"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: "文件或 Skill 不存在"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /skills/{skill_id}/management/download:
+    get:
+      summary: "下载管理态 Skill 包"
+      description: "下载当前编辑态的完整 Skill 包（ZIP 格式）"
+      tags:
+        - "Skill - Management Read"
+      parameters:
+        - $ref: "#/components/parameters/BusinessDomain"
+        - $ref: "#/components/parameters/AccountID"
+        - $ref: "#/components/parameters/AccountType"
+        - $ref: "#/components/parameters/SkillID"
+        - name: response_mode
+          in: query
+          description: "响应模式。url(默认)返回 OSS 预签名 URL；content 返回内联正文；auto 根据注册类型自动选择"
+          required: false
+          schema:
+            type: string
+            enum: [url, content, auto]
+            default: url
+      responses:
+        "200":
+          description: "成功"
+          content:
+            application/zip:
+              schema:
+                type: string
+                format: binary
+        "403":
+          description: "权限不足"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: "Skill 不存在"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
 components:
   parameters:
     BusinessDomain:
@@ -1082,3 +1217,43 @@ components:
           type: string
         data:
           nullable: true
+
+    GetManagementContentResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+        msg:
+          type: string
+        data:
+          $ref: "#/components/schemas/GetManagementContentData"
+
+    GetManagementContentData:
+      type: object
+      properties:
+        skill_id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        version:
+          type: string
+        status:
+          type: string
+          enum: ["unpublish", "published", "editing", "offline"]
+        source:
+          type: string
+        file_type:
+          type: string
+          enum: ["zip", "content"]
+        url:
+          type: string
+          description: "SKILL.md 的 OSS 预签名下载 URL"
+        content:
+          type: string
+          description: "content 注册类型的正文内容（zip 注册类型为空）"
+        files:
+          type: array
+          items:
+            $ref: "#/components/schemas/SkillFileSummary"

--- a/adp/execution-factory/operator-integration/docs/apis/api_private/skill.yaml
+++ b/adp/execution-factory/operator-integration/docs/apis/api_private/skill.yaml
@@ -511,11 +511,11 @@ paths:
         - $ref: "#/components/parameters/SkillID"
         - name: response_mode
           in: query
-          description: "响应模式。url(默认)返回 OSS 预签名 URL；content 返回内联正文；auto 根据注册类型自动选择"
+          description: "响应模式。url(默认)返回 OSS 预签名 URL；content 返回内联正文"
           required: false
           schema:
             type: string
-            enum: [url, content, auto]
+            enum: [url, content]
             default: url
       responses:
         "200":
@@ -605,11 +605,11 @@ paths:
         - $ref: "#/components/parameters/SkillID"
         - name: response_mode
           in: query
-          description: "响应模式。url(默认)返回 OSS 预签名 URL；content 返回内联正文；auto 根据注册类型自动选择"
+          description: "响应模式。url(默认)返回 OSS 预签名 URL；content 返回内联正文"
           required: false
           schema:
             type: string
-            enum: [url, content, auto]
+            enum: [url, content]
             default: url
       responses:
         "200":

--- a/adp/execution-factory/operator-integration/docs/apis/api_public/skill.yaml
+++ b/adp/execution-factory/operator-integration/docs/apis/api_public/skill.yaml
@@ -1006,6 +1006,137 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
+  /skills/{skill_id}/management/content:
+    get:
+      summary: "获取 Skill 管理态内容"
+      description: "读取当前编辑态的 SKILL.md 下载 URL 和文件清单"
+      tags:
+        - "Skill - Management Read"
+      parameters:
+        - $ref: "#/components/parameters/BusinessDomain"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/SkillID"
+        - name: response_mode
+          in: query
+          description: "响应模式。url(默认)返回 OSS 预签名 URL；content 返回内联正文；auto 根据注册类型自动选择"
+          required: false
+          schema:
+            type: string
+            enum: [url, content, auto]
+            default: url
+      responses:
+        "200":
+          description: "成功"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GetManagementContentResponse"
+        "400":
+          description: "参数错误"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: "权限不足"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: "Skill 不存在"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /skills/{skill_id}/management/files/read:
+    post:
+      summary: "读取管理态指定文件"
+      description: "读取当前编辑态的指定文件内容，返回 OSS 预签名下载 URL"
+      tags:
+        - "Skill - Management Read"
+      parameters:
+        - $ref: "#/components/parameters/BusinessDomain"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/SkillID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - rel_path
+              properties:
+                rel_path:
+                  type: string
+                  description: "文件相对路径"
+      responses:
+        "200":
+          description: "成功"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReadSkillFileResp"
+        "400":
+          description: "参数错误或路径非法"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: "权限不足"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: "文件或 Skill 不存在"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /skills/{skill_id}/management/download:
+    get:
+      summary: "下载管理态 Skill 包"
+      description: "下载当前编辑态的完整 Skill 包（ZIP 格式）"
+      tags:
+        - "Skill - Management Read"
+      parameters:
+        - $ref: "#/components/parameters/BusinessDomain"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/SkillID"
+        - name: response_mode
+          in: query
+          description: "响应模式。url(默认)返回 OSS 预签名 URL；content 返回内联正文；auto 根据注册类型自动选择"
+          required: false
+          schema:
+            type: string
+            enum: [url, content, auto]
+            default: url
+      responses:
+        "200":
+          description: "成功"
+          content:
+            application/zip:
+              schema:
+                type: string
+                format: binary
+        "403":
+          description: "权限不足"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: "Skill 不存在"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
 components:
   parameters:
     Authorization:
@@ -1761,3 +1892,43 @@ components:
                   last_finished_time:
                     type: integer
                     format: int64
+
+    GetManagementContentResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+        msg:
+          type: string
+        data:
+          $ref: "#/components/schemas/GetManagementContentData"
+
+    GetManagementContentData:
+      type: object
+      properties:
+        skill_id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        version:
+          type: string
+        status:
+          type: string
+          enum: ["unpublish", "published", "editing", "offline"]
+        source:
+          type: string
+        file_type:
+          type: string
+          enum: ["zip", "content"]
+        url:
+          type: string
+          description: "SKILL.md 的 OSS 预签名下载 URL"
+        content:
+          type: string
+          description: "content 注册类型的正文内容（zip 注册类型为空）"
+        files:
+          type: array
+          items:
+            $ref: "#/components/schemas/SkillFileSummary"

--- a/adp/execution-factory/operator-integration/docs/apis/api_public/skill.yaml
+++ b/adp/execution-factory/operator-integration/docs/apis/api_public/skill.yaml
@@ -1540,6 +1540,11 @@ components:
         update_time:
           type: integer
           format: int64
+        category:
+          type: string
+          enum: ["other_category", "system"]
+        category_name:
+          type: string
 
     SkillInfoData:
       type: object
@@ -1573,6 +1578,11 @@ components:
         update_time:
           type: integer
           format: int64
+        category:
+          type: string
+          enum: ["other_category", "system"]
+        category_name:
+          type: string
 
     SkillFileSummary:
       type: object

--- a/adp/execution-factory/operator-integration/docs/apis/api_public/skill.yaml
+++ b/adp/execution-factory/operator-integration/docs/apis/api_public/skill.yaml
@@ -1018,11 +1018,11 @@ paths:
         - $ref: "#/components/parameters/SkillID"
         - name: response_mode
           in: query
-          description: "响应模式。url(默认)返回 OSS 预签名 URL；content 返回内联正文；auto 根据注册类型自动选择"
+          description: "响应模式。url(默认)返回 OSS 预签名 URL；content 返回内联正文"
           required: false
           schema:
             type: string
-            enum: [url, content, auto]
+            enum: [url, content]
             default: url
       responses:
         "200":
@@ -1110,11 +1110,11 @@ paths:
         - $ref: "#/components/parameters/SkillID"
         - name: response_mode
           in: query
-          description: "响应模式。url(默认)返回 OSS 预签名 URL；content 返回内联正文；auto 根据注册类型自动选择"
+          description: "响应模式。url(默认)返回 OSS 预签名 URL；content 返回内联正文"
           required: false
           schema:
             type: string
-            enum: [url, content, auto]
+            enum: [url, content]
             default: url
       responses:
         "200":

--- a/adp/execution-factory/operator-integration/docs/design/features/skill_content_management_read.md
+++ b/adp/execution-factory/operator-integration/docs/design/features/skill_content_management_read.md
@@ -215,7 +215,7 @@ type GetManagementContentReq struct {
     BusinessDomainID string `header:"x-business-domain" validate:"required"`
     UserID           string `header:"user_id"`
     SkillID          string `uri:"skill_id" validate:"required"`
-    ResponseMode     string `form:"response_mode"`    // url(默认) | content | auto
+    ResponseMode     string `form:"response_mode"`    // url(默认) | content
 }
 
 type GetManagementContentResp struct {

--- a/adp/execution-factory/operator-integration/docs/design/features/skill_content_management_read.md
+++ b/adp/execution-factory/operator-integration/docs/design/features/skill_content_management_read.md
@@ -1,0 +1,985 @@
+# Skill 内容管理读取 设计
+
+## 文档信息
+
+- Status: Draft
+- Owner: @chenshu-zhao
+- Last Updated: 2026-04-29
+
+## 关联需求
+
+- PRD: [Skill 内容管理读取 PRD](../../product/prd/skill_content_management_read.md)
+- Issue: [#302 Skill 内容管理能力完善](https://github.com/kweaver-ai/kweaver-core/issues/302)
+
+---
+
+## 1. 概述
+
+### 1.1 背景
+
+执行工厂当前 Skill 的读能力集中在"已发布内容"场景：`GetSkillContent` 和 `ReadSkillFile` 读取 `skill_release` 快照，管理端无法查看正在编辑中的草稿内容。本方案新增一套**管理态读路径**，与现有发布态读路径完全解耦。
+
+### 1.2 目标
+
+- 新增 4 个独立管理端读接口，从 `skill_repository` 读取当前编辑态内容
+- 新增 `SkillManagementReader` 独立逻辑接口，`SkillReader` 不改一行代码
+- 统一 `content` 与 `zip` 注册类型的管理端读体验
+- 权限、业务域隔离、删除态处理、路径安全校验全部复用现有机制
+- 已有发布态接口不受任何影响
+
+### 1.3 非目标
+
+- 管理前端 UI 开发
+- SDK/CLI 包装实现
+- 历史版本差异对比
+- 存量 content 注册数据的 OSS 补齐 migration（惰性补齐）
+
+---
+
+### 1.4 术语说明
+
+| 术语 | 说明 |
+|------|------|
+| repository | `t_skill_repository`，Skill 当前编辑态主表 |
+| release | `t_skill_release`，Skill 发布态快照 |
+| file_index | `t_skill_file_index`，按版本管理的文件索引 |
+| management path | 新增的管理态读路径前缀 `/management/` |
+| file_manifest | `repository` 表中的 JSON 字段，注册时的文件摘要 |
+
+---
+
+## 2. 整体设计（HLD）
+
+### 2.1 系统上下文
+
+```mermaid
+flowchart LR
+    MgmtUI[管理端前端]
+    SDK[vweaver-sdk]
+    CLI[vweaver CLI]
+    EF[执行工厂 Skill 模块]
+    OSS[对象存储]
+    DB[(repository / release / file_index)]
+
+    MgmtUI -->|management 路径| EF
+    SDK -->|release 路径| EF
+    CLI -->|release 路径| EF
+    EF --> DB
+    EF --> OSS
+```
+
+### 2.2 容器架构
+
+```mermaid
+flowchart TD
+    subgraph "Driver Adapters (Gin)"
+        PH[public handler<br/>route: /v1/]
+        IH[internal handler<br/>route: /internal-v1/]
+    end
+
+    subgraph "Logic Layer"
+        SR[SkillReader<br/>现有，只读 release]
+        SMR[SkillManagementReader<br/>新增，只读 repository]
+        REG[SkillRegistry<br/>管理操作]
+    end
+
+    subgraph "Data Access"
+        REPO[(skill_repository)]
+        REL[(skill_release)]
+        FI[(skill_file_index)]
+        OSS[OSS Gateway]
+    end
+
+    PH --> SR
+    PH --> SMR
+    IH --> SR
+    IH --> SMR
+    PH --> REG
+    SR --> REL
+    SR --> FI
+    SMR --> REPO
+    SMR --> FI
+    REG --> REPO
+    REG --> REL
+    REG --> FI
+```
+
+### 2.3 组件交互
+
+**新增管理态读路径（蓝色）与现有发布态读路径（灰色）对比：**
+
+```mermaid
+sequenceDiagram
+    participant M as 管理端
+    participant H as Handler
+    participant SMR as SkillManagementReader
+    participant R as SkillReader
+    participant DB as DB
+
+    Note over M,DB: === 管理态读（新增）===
+    M->>H: GET .../management/content
+    H->>SMR: GetManagementContent
+    SMR->>DB: Select skill_repository
+    SMR->>DB: Select skill_file_index (repo version)
+    DB-->>SMR: data
+    SMR-->>H: content + files
+    H-->>M: 200 OK
+
+    Note over M,DB: === 发布态读（现有，不变）===
+    M->>H: GET .../content
+    H->>R: GetSkillContent
+    R->>DB: Select skill_release
+    R->>DB: Select skill_file_index (release version)
+    DB-->>R: data
+    R-->>H: url + files
+    H-->>M: 200 OK
+```
+
+### 2.4 数据流
+
+#### 管理态 SKILL.md 读取
+
+```mermaid
+flowchart TD
+    A[GET .../management/content] --> B[查询 skill_repository]
+    B --> C[反序列化 file_manifest → files]
+    C --> D[查询 skill_file_index<br/>where skill_version=repo.version]
+    D --> E[取 SKILL.md 的 OSS presigned URL]
+    E --> F[组装响应: url + files]
+    F --> G[返回]
+```
+
+#### 注：FR-5 + FR-6 实现后，content 注册和 zip 注册走完全一致的读路径——都从 `skill_file_index` 查询，都返回 OSS presigned URL。
+
+#### 管理态文件读取
+
+```mermaid
+flowchart TD
+    A[POST .../management/files/read] --> B[normalizeZipPath 校验]
+    B --> C{是否穿越?}
+    C -->|是| D[返回 400]
+    C -->|否| E[查询 skill_repository]
+    E --> F[查询 skill_file_index<br/>where skill_id+version+rel_path]
+    F --> G{找到?}
+    G -->|是| H[返回 OSS presigned URL]
+    G -->|否| I[返回 404]
+```
+
+### 2.5 关键设计决策
+
+| 决策 | 说明 |
+|------|------|
+| 独立路由而非参数复用 | 已有服务零影响，权限链可路由层分离，OpenAPI 文档无交叉 |
+| 独立 Logic 接口 | `SkillReader` 不改一行，新增 `SkillManagementReader` |
+| content 注册 OSS 补齐（FR-5） | content 注册时将原始 SKILL.md 写入 OSS，读路径统一走 OSS |
+| OSS SKILL.md 同步重写（FR-6） | 元数据编辑时重写 OSS 中 SKILL.md 的 name/desc，确保 OSS 内容与 DB 一致 |
+| 版本键取值 | 管理态始终取 `repository.version`，与 `release.version` 解耦 |
+| 权限校验复用 | 管理态走 `view` / `modify` 权限，现有 `Execute` / `PublicAccess` 不变 |
+
+---
+
+## 3. 详细设计（LLD）
+
+### 3.1 接口设计
+
+#### 新增 `SkillManagementReader` 接口
+
+**文件：** `server/interfaces/logics_skill.go`
+
+```go
+// SkillManagementReader Skill 管理态只读接口
+type SkillManagementReader interface {
+    // GetManagementContent 获取管理态 SKILL.md 内容
+    // 从 skill_repository 读取，含 SKILL.md 下载URL（zip）或全文（content）
+    GetManagementContent(ctx context.Context, req *GetManagementContentReq) (*GetManagementContentResp, error)
+
+
+    // ReadManagementFile 读取管理态指定文件
+    // 从 skill_file_index 以 repository.version 为版本键查询
+    ReadManagementFile(ctx context.Context, req *ReadManagementFileReq) (*ReadManagementFileResp, error)
+
+    // DownloadManagementSkill 下载管理态完整包
+    // 从 skill_repository + skill_file_index 构建 ZIP
+    DownloadManagementSkill(ctx context.Context, req *DownloadManagementSkillReq) (*DownloadSkillResp, error)
+}
+```
+
+#### 新增 Request/Response 结构体
+
+**文件：** `server/interfaces/logics_skill.go`
+
+```go
+// === GetManagementContent ===
+
+type GetManagementContentReq struct {
+    BusinessDomainID string `header:"x-business-domain" validate:"required"`
+    UserID           string `header:"user_id"`
+    SkillID          string `uri:"skill_id" validate:"required"`
+    ResponseMode     string `form:"response_mode"`    // url(默认) | content | auto
+}
+
+type GetManagementContentResp struct {
+    SkillID     string              `json:"skill_id"`
+    Name        string              `json:"name"`
+    Description string              `json:"description"`
+    Version     string              `json:"version"`
+    Status      BizStatus           `json:"status"`
+    Source      string              `json:"source"`
+    FileType    string              `json:"file_type"`
+    URL         string              `json:"url"`
+    Content     string              `json:"content,omitempty"`
+    Files       []*SkillFileSummary `json:"files"`
+}
+
+// === ReadManagementFile ===
+
+type ReadManagementFileReq struct {
+    BusinessDomainID string `header:"x-business-domain" validate:"required"`
+    UserID           string `header:"user_id"`
+    SkillID          string `uri:"skill_id" validate:"required"`
+    RelPath          string `json:"rel_path" validate:"required"`
+}
+
+type ReadManagementFileResp struct {
+    SkillID  string `json:"skill_id"`
+    RelPath  string `json:"rel_path"`
+    URL      string `json:"url"`       // 无 OSS 文件时返回空字符串
+    MimeType string `json:"mime_type"`
+    FileType string `json:"file_type"`
+    Size     int64  `json:"size"`
+}
+
+// === DownloadManagementSkill ===
+
+type DownloadManagementSkillReq struct {
+    BusinessDomainID string `header:"x-business-domain" validate:"required"`
+    UserID           string `header:"user_id"`
+    SkillID          string `uri:"skill_id" validate:"required"`
+}
+
+// 复用已有 DownloadSkillResp
+```
+
+### 3.2 路由与 Handler
+
+#### 路由注册
+
+**文件：** `server/driveradapters/skill_handler.go`
+
+新增路由注册代码：
+
+```go
+// 管理态读接口（新增，挂载在相同 engine group 下）
+v1.GET("/skills/:skill_id/management/content", middleware(...), h.GetManagementContent)
+v1.POST("/skills/:skill_id/management/files/read", middleware(...), h.ReadManagementFile)
+v1.GET("/skills/:skill_id/management/download", middleware(...), h.DownloadManagementSkill)
+
+// 同样注册到 internal-v1
+internal.GET("/skills/:skill_id/management/content", h.GetManagementContent)
+internal.POST("/skills/:skill_id/management/files/read", h.ReadManagementFile)
+internal.GET("/skills/:skill_id/management/download", h.DownloadManagementSkill)
+```
+
+#### middleware 差异
+
+| 接口路径 | 公共 API middleware | 内部 API middleware |
+|---------|-------------------|-------------------|
+| `/v1/skills/{id}/content` | `middlewareIntrospectVerify` + `middlewareBusinessDomain(checkPermission=true)` | `middlewareHeaderAuthContext` + `middlewareBusinessDomain(checkPermission=false)` |
+| `/v1/skills/{id}/management/content` | `middlewareIntrospectVerify` + `middlewareBusinessDomain(checkPermission=true)` | 同上 |
+| `/internal-v1/skills/{id}/management/content` | — | `middlewareHeaderAuthContext` + `middlewareBusinessDomain(checkPermission=false)` |
+
+**注意：** 管理态路由的 middleware 链与发布态路由完全一致，区别在 handler 内权限校验的 `AuthOperationType` 不同（`view`/`modify` vs `execute`/`public_access`）。
+
+#### Handler 结构体扩展
+
+**文件：** `server/driveradapters/skill/skill.go` → `skill_handler.go`
+
+```go
+type skillHandler struct {
+    Registry     interfaces.SkillRegistry
+    Market       interfaces.SkillMarket
+    Reader       interfaces.SkillReader
+    MgmtReader   interfaces.SkillManagementReader  // 新增
+    IndexBuilder interfaces.SkillIndexBuildService
+}
+```
+
+初始化注入：
+
+```go
+// 在 NewSkillHandler 或 main.go 中
+h := &skillHandler{
+    Registry:     skill.NewSkillRegistry(),
+    Market:       skill.NewSkillRegistry(),   // 同一实现
+    Reader:       skill.NewSkillReader(),
+    MgmtReader:   skill.NewSkillManagementReader(),  // 新增单例
+    IndexBuilder: skill.NewSkillIndexBuildService(),
+}
+```
+
+#### Handler 实现示例
+
+**文件：** `server/driveradapters/skill/mgmt_reader.go`（新增）
+
+```go
+package skill
+
+import (
+    "net/http"
+
+    "github.com/gin-gonic/gin"
+    "github.com/go-playground/validator/v10"
+    "github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/errors"
+    "github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/rest"
+    "github.com/kweaver-ai/adp/execution-factory/operator-integration/server/interfaces"
+)
+
+func (h *skillHandler) GetManagementContent(c *gin.Context) {
+    req := &interfaces.GetManagementContentReq{}
+    if err := c.ShouldBindHeader(req); err != nil {
+        rest.ReplyError(c, errors.DefaultHTTPError(c.Request.Context(), http.StatusBadRequest, err.Error()))
+        return
+    }
+    if err := c.ShouldBindUri(req); err != nil {
+        rest.ReplyError(c, errors.DefaultHTTPError(c.Request.Context(), http.StatusBadRequest, err.Error()))
+        return
+    }
+    if err := validator.New().Struct(req); err != nil {
+        rest.ReplyError(c, err)
+        return
+    }
+    resp, err := h.MgmtReader.GetManagementContent(c.Request.Context(), req)
+    if err != nil {
+        rest.ReplyError(c, err)
+        return
+    }
+    rest.ReplyOK(c, http.StatusOK, resp)
+}
+
+func (h *skillHandler) ReadManagementFile(c *gin.Context) {
+    // 类似模式，body 用 GetBindJSONRaw 绑定
+}
+
+func (h *skillHandler) DownloadManagementSkill(c *gin.Context) {
+    // 类似模式，返回 ZIP 二进制
+}
+```
+
+### 3.3 Logic 实现
+
+#### SkillManagementReader 结构体
+
+**文件：** `server/logics/skill/mgmt_reader.go`（新增）
+
+```go
+package skill
+
+import (
+    "context"
+    "fmt"
+    "net/http"
+    "sync"
+
+    "github.com/kweaver-ai/adp/execution-factory/operator-integration/server/dbaccess"
+    "github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/common"
+    "github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/config"
+    "github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/errors"
+    "github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/telemetry"
+    "github.com/kweaver-ai/adp/execution-factory/operator-integration/server/interfaces"
+    "github.com/kweaver-ai/adp/execution-factory/operator-integration/server/interfaces/model"
+    "github.com/kweaver-ai/adp/execution-factory/operator-integration/server/logics/auth"
+    "github.com/kweaver-ai/adp/execution-factory/operator-integration/server/logics/business_domain"
+    "github.com/kweaver-ai/adp/execution-factory/operator-integration/server/utils"
+    o11y "github.com/kweaver-ai/kweaver-go-lib/observability"
+)
+
+type skillManagementReader struct {
+    skillRepo             model.ISkillRepository
+    fileRepo              model.ISkillFileIndex
+    assetStore            skillAssetStore
+    AuthService           interfaces.IAuthorizationService
+    BusinessDomainService interfaces.IBusinessDomainService
+    Logger                interfaces.Logger
+}
+
+var (
+    mgmtReaderOnce sync.Once
+    mgmtReaderInst interfaces.SkillManagementReader
+)
+
+func NewSkillManagementReader() interfaces.SkillManagementReader {
+    mgmtReaderOnce.Do(func() {
+        conf := config.NewConfigLoader()
+        mgmtReaderInst = &skillManagementReader{
+            skillRepo:             dbaccess.NewSkillRepositoryDB(),
+            fileRepo:              dbaccess.NewSkillFileIndexDB(),
+            assetStore:            newOSSGatewaySkillAssetStore(),
+            AuthService:           auth.NewAuthServiceImpl(),
+            BusinessDomainService: business_domain.NewBusinessDomainService(),
+            Logger:                conf.GetLogger(),
+        }
+    })
+    return mgmtReaderInst
+}
+```
+
+**关键区别与 `skillReader` 的对比：**
+
+| 维度 | `skillReader`（现有） | `skillManagementReader`（新增） |
+|------|---------------------|------------------------------|
+| 依赖 releaseRepo | ✅ | ❌ |
+| 数据源查询 | `getPublishedSkill()` → release | `skillRepo.SelectSkillByID()` → repository |
+| 版本键 | `release.Version` | `repository.Version` |
+| 权限校验（公共 API） | `execute` / `view` / `public_access` | `view` / `modify` |
+| SKILL.md 来源 | OSS（必须） | OSS（FR-5 后 content 注册也有 OSS 记录） |
+
+#### GetManagementContent 核心逻辑
+
+```go
+func (r *skillManagementReader) GetManagementContent(ctx context.Context, req *interfaces.GetManagementContentReq) (
+    resp *interfaces.GetManagementContentResp, err error) {
+
+    ctx, _ = o11y.StartInternalSpan(ctx)
+    defer o11y.EndSpan(ctx, err)
+    telemetry.SetSpanAttributes(ctx, map[string]interface{}{
+        "skill_id": req.SkillID,
+    })
+
+    // 1. 从 skill_repository 查询
+    skill, err := r.skillRepo.SelectSkillByID(ctx, nil, req.SkillID)
+    if err != nil {
+        return nil, err
+    }
+    if skill == nil || skill.IsDeleted {
+        return nil, errors.DefaultHTTPError(ctx, http.StatusNotFound,
+            fmt.Sprintf("skill not found: %s", req.SkillID))
+    }
+
+    // 2. 权限校验（公共 API）
+    if common.IsPublicAPIFromCtx(ctx) {
+        accessor, err := r.AuthService.GetAccessor(ctx, req.UserID)
+        if err != nil {
+            return nil, err
+        }
+        authorized, err := r.AuthService.OperationCheckAny(ctx, accessor, req.SkillID,
+            interfaces.AuthResourceTypeSkill,
+            interfaces.AuthOperationTypeView,
+            interfaces.AuthOperationTypeModify)
+        if err != nil {
+            return nil, err
+        }
+        if !authorized {
+            return nil, errors.NewHTTPError(ctx, http.StatusForbidden,
+                errors.ErrExtCommonOperationForbidden,
+                fmt.Sprintf("user has no permission to view skill %s", req.SkillID))
+        }
+    }
+
+    // 3. 组装响应
+    resp = &interfaces.GetManagementContentResp{
+        SkillID:     skill.SkillID,
+        Name:        skill.Name,
+        Description: skill.Description,
+        Version:     skill.Version,
+        Status:      interfaces.BizStatus(skill.Status),
+        Source:      skill.Source,
+        FileType:    detectSkillFileType(skill),
+    }
+
+    // 3a. 反序列化文件清单
+    resp.Files = utils.JSONToObject[[]*interfaces.SkillFileSummary](skill.FileManifest)
+    if resp.Files == nil {
+        resp.Files = []*interfaces.SkillFileSummary{}
+    }
+
+    // 3b. 统一从 skill_file_index 查询 SKILL.md 的 OSS presigned URL
+    // FR-5 保证 content 注册也有 SKILL.md 的 OSS 记录
+    // FR-6 保证 OSS 中 SKILL.md 的 name/desc 与 DB 一致
+    skillFile, err := r.fileRepo.SelectSkillFileByPath(ctx, nil,
+        skill.SkillID, skill.Version, SkillMD)
+    if err != nil {
+        return nil, err
+    }
+    if skillFile != nil {
+        downloadURL, err := r.assetStore.GetDownloadURL(ctx, &interfaces.OssObject{
+            StorageID:  skillFile.StorageID,
+            StorageKey: skillFile.StorageKey,
+        })
+        if err != nil {
+            return nil, err
+        }
+        resp.URL = downloadURL
+    }
+
+    return resp, nil
+}
+```
+
+#### ReadManagementFile 核心逻辑
+
+```go
+func (r *skillManagementReader) ReadManagementFile(ctx context.Context, req *interfaces.ReadManagementFileReq) (
+    resp *interfaces.ReadManagementFileResp, err error) {
+
+    ctx, _ = o11y.StartInternalSpan(ctx)
+    defer o11y.EndSpan(ctx, err)
+    telemetry.SetSpanAttributes(ctx, map[string]interface{}{
+        "skill_id": req.SkillID,
+        "rel_path": req.RelPath,
+    })
+
+    // 1. 查询 skill_repository
+    skill, err := r.skillRepo.SelectSkillByID(ctx, nil, req.SkillID)
+    if err != nil {
+        return nil, err
+    }
+    if skill == nil || skill.IsDeleted {
+        return nil, errors.DefaultHTTPError(ctx, http.StatusNotFound,
+            fmt.Sprintf("skill not found: %s", req.SkillID))
+    }
+
+    // 2. 权限校验（与 GetManagementContent 相同模式）
+
+    // 3. 路径安全校验
+    relPath, err := normalizeZipPath(req.RelPath)
+    if err != nil {
+        return nil, errors.DefaultHTTPError(ctx, http.StatusBadRequest, err.Error())
+    }
+
+    // 4. 查询 skill_file_index（FR-5 保证 content 注册也有记录，FR-6 保证 name/desc 一致）
+    file, err := r.fileRepo.SelectSkillFileByPath(ctx, nil,
+        req.SkillID, skill.Version, relPath)
+    if err != nil {
+        return nil, err
+    }
+    if file == nil {
+        return nil, errors.DefaultHTTPError(ctx, http.StatusNotFound,
+            fmt.Sprintf("file not found: %s", relPath))
+    }
+    downloadURL, err := r.assetStore.GetDownloadURL(ctx, &interfaces.OssObject{
+        StorageID:  file.StorageID,
+        StorageKey: file.StorageKey,
+    })
+    if err != nil {
+        return nil, err
+    }
+
+    return &interfaces.ReadManagementFileResp{
+        SkillID:  req.SkillID,
+        RelPath:  relPath,
+        URL:      downloadURL,
+        MimeType: file.MimeType,
+        FileType: file.FileType,
+        Size:     file.Size,
+    }, nil
+}
+```
+
+#### DownloadManagementSkill 核心逻辑
+
+```go
+func (r *skillManagementReader) DownloadManagementSkill(ctx context.Context, req *interfaces.DownloadManagementSkillReq) (
+    resp *interfaces.DownloadSkillResp, err error) {
+
+    // 1. 查询 skill_repository（同前，略）
+    // 2. 权限校验（同前，略）
+
+    // 3. 查询当前版本的文件索引
+    files, err := r.fileRepo.SelectSkillFileBySkillID(ctx, nil, req.SkillID, skill.Version)
+    if err != nil {
+        return nil, err
+    }
+
+    // 4. 构建 ZIP（复用 registry 的 buildSkillArchiveFromSnapshot 或类似逻辑）
+    return r.buildSkillArchiveFromSnapshot(ctx, skill, files)
+}
+```
+
+#### 辅助函数
+
+```go
+// detectSkillFileType 从 repository 记录推断注册类型
+// 仅用于响应中的 file_type 字段标记，读路径不依赖此判断
+func detectSkillFileType(skill *model.SkillRepositoryDB) string {
+    manifest := utils.JSONToObject[[]*interfaces.SkillFileSummary](skill.FileManifest)
+    if len(manifest) > 0 {
+        return "zip"
+    }
+    // 无 file_manifest 但有 skill_content → content 注册
+    if skill.SkillContent != "" {
+        return "content"
+    }
+    return "content"
+}
+```
+
+### 3.4 数据模型
+
+不需要新增表或字段。现有 `skill_repository` 和 `skill_file_index` 已满足管理态读需求。
+
+#### 读取路径说明
+
+| 接口 | 查询的表 | 版本键来源 | 依赖关系 |
+|------|---------|-----------|---------|
+| `GetManagementContent` | `skill_repository` + `skill_file_index` | `repository.version` | 无 |
+| `ReadManagementFile` | `skill_repository` + `skill_file_index` | `repository.version` | 无 |
+| `DownloadManagementSkill` | `skill_repository` + `skill_file_index` | `repository.version` | 无 |
+
+### 3.5 权限设计
+
+| 场景 | 权限检查（公共 API） | 说明 |
+|------|-------------------|------|
+| 管理端读 content/files | `view` OR `modify` | 有查看或编辑权限即可读取管理态内容 |
+| 管理端读文件 | `view` OR `modify` | 同上 |
+| 管理端下载 | `view` OR `modify` | 同上 |
+
+**内部 API：** 不走精细权限校验（现有机制，依赖 header auth context）
+
+### 3.6 错误处理
+
+| 错误场景 | HTTP Status | Error Code | 说明 |
+|---------|-------------|-----------|------|
+| Skill 不存在 | 404 | — | `is_deleted=true` 也返回 404 |
+| 权限不足（公共 API） | 403 | `ErrExtCommonOperationForbidden` | 复用现有错误码 |
+| 路径穿越 | 400 | — | `normalizeZipPath` 拦截 |
+| OSS 记录缺失 | 500 | — | 数据不一致（FR-5 实现后 content 注册也有记录） |
+| 请求参数不合法 | 400 | — | validate tag 校验 |
+| FR-6 OSS 重写失败 | 仅日志 | — | 不阻塞元数据编辑主流程 |
+
+### 3.7 content 注册的 OSS 补齐（FR-5）
+
+#### 设计说明
+
+**方案：** 在注册/更新 content 类型的 Skill 时，也将其原始 SKILL.md 写入 OSS 并建立 `skill_file_index` 记录。
+
+#### 改动范围
+
+**parser.go（`parseRegisterReq` content 分支）：**
+
+```go
+case "content":
+    rawContent := string(req.File)  // 原始请求的完整 SKILL.md（含 frontmatter）
+    // ... 解析 frontmatter ...（保持现有解析逻辑不变）
+
+    // 新增：为 SKILL.md 生成 asset 和 file_summary
+    assets = append(assets, &skillAsset{
+        RelPath:  SkillMD,
+        FileType: detectFileType(SkillMD),
+        MimeType: detectMimeType(SkillMD),
+        Content:  []byte(rawContent),  // 写入 OSS 时用原始完整内容
+    })
+    files = append(files, &interfaces.SkillFileSummary{
+        RelPath:  SkillMD,
+        FileType: detectFileType(SkillMD),
+        Size:     int64(len(rawContent)),
+        MimeType: detectMimeType(SkillMD),
+    })
+```
+
+**registry.go（`RegisterSkill` / `UpdateSkillPackage`）：**
+
+content 分支也会通过 `persistSkillAssets` 写入 OSS 和 `skill_file_index`，不再需要单独区分处理。
+
+**效果：**
+
+```
+改造前:  skill_repository.skill_content = "body text"           (仅 DB)
+          skill_repository.file_manifest = null                  (空)
+          skill_file_index = []                                  (无记录)
+          OSS = {}                                               (无文件)
+
+改造后:  skill_repository.skill_content = "body text"           (DB，不变)
+          skill_repository.file_manifest = [...]                 (含 SKILL.md 摘要)
+          skill_file_index = [{rel_path: SKILL.md, ...}]         (有 OSS 记录)
+          OSS = { SKILL.md: <原始完整内容> }                      (有文件)
+```
+
+所有读路径（包括现有的发布态 `GetSkillContent`）对 content 注册的 Skill 都能正常工作。
+
+#### 存量处理
+
+- 新注册 content：注册时自动写入 OSS ✅
+- 存量 content：惰性补齐。`GetManagementContent` 检测到 `file_manifest` 为空但 `skill_content` 非空时，将 SKILL.md 写入 OSS 并建立 file_index 记录
+
+---
+
+### 3.8 元数据编辑时 OSS SKILL.md 同步重写（FR-6）
+
+#### 设计说明
+
+**方案：** `UpdateSkillMetadata` 成功提交事务后，同步或异步重写 OSS 中当前版本 SKILL.md 的 frontmatter，将其中的 `name` 和 `description` 更新为 DB 中的最新值，其余自定义 YAML 字段保持不动。
+
+#### 改动范围
+
+**registry.go（`UpdateSkillMetadata`）：**
+
+在事务提交成功后，新增 OSS 重写步骤：
+
+```go
+func (r *skillRegistry) UpdateSkillMetadata(ctx context.Context, req *interfaces.UpdateSkillMetadataReq) (
+    resp *interfaces.UpdateSkillMetadataResp, err error) {
+
+    // ... 现有逻辑：校验、更新 DB、提交事务 ...
+
+    // 新增：事务提交成功后，异步重写 OSS SKILL.md 的 frontmatter
+    if err == nil {
+        if rewriteErr := r.rewriteSkillMDFrontmatter(ctx, skill.SkillID, skill.Version,
+            req.Name, req.Description); rewriteErr != nil {
+            // 只记录日志，不阻塞主流程返回
+            r.Logger.WithContext(ctx).Errorf("rewrite SKILL.md frontmatter failed, skill_id=%s, err=%v",
+                skill.SkillID, rewriteErr)
+        }
+    }
+
+    return &interfaces.UpdateSkillMetadataResp{...}, nil
+}
+
+// rewriteSkillMDFrontmatter 重写 OSS 中 SKILL.md 的 name/description
+func (r *skillRegistry) rewriteSkillMDFrontmatter(ctx context.Context, skillID, version, newName, newDesc string) error {
+    // 1. 查询 file_index 获取 SKILL.md 的 OSS 定位信息
+    skillFile, err := r.fileRepo.SelectSkillFileByPath(ctx, nil, skillID, version, SkillMD)
+    if err != nil {
+        return err
+    }
+    if skillFile == nil {
+        return fmt.Errorf("SKILL.md not found in file_index: skill_id=%s, version=%s", skillID, version)
+    }
+
+    // 2. 从 OSS 下载原始 SKILL.md
+    content, err := r.assetStore.Download(ctx, &interfaces.OssObject{
+        StorageID:  skillFile.StorageID,
+        StorageKey: skillFile.StorageKey,
+    })
+    if err != nil {
+        return err
+    }
+
+    // 3. 解析并重写 frontmatter
+    newContent, err := updateFrontmatterNameDesc(string(content), newName, newDesc)
+    if err != nil {
+        return err
+    }
+
+    // 4. 重新上传到同一路径（覆盖）
+    _, _, err = r.assetStore.Upload(ctx, skillID, version, SkillMD, []byte(newContent))
+    return err
+}
+```
+
+**OOS SKILL.md frontmatter 重写函数：**
+
+```go
+// updateFrontmatterNameDesc 只替换 YAML frontmatter 中的 name 和 description
+// 其余所有自定义字段保持不动
+func updateFrontmatterNameDesc(rawMD, newName, newDesc string) (string, error) {
+    parts := strings.SplitN(rawMD, "---", 3)
+    if len(parts) < 3 {
+        return "", fmt.Errorf("invalid SKILL.md format: missing frontmatter")
+    }
+
+    frontmatter := make(map[string]interface{})
+    if err := yaml.Unmarshal([]byte(parts[1]), &frontmatter); err != nil {
+        return "", fmt.Errorf("failed to unmarshal frontmatter: %w", err)
+    }
+
+    // 只替换 name 和 description
+    if newName != "" {
+        frontmatter["name"] = newName
+    }
+    if newDesc != "" {
+        frontmatter["description"] = newDesc
+    }
+
+    newFrontmatter, err := yaml.Marshal(frontmatter)
+    if err != nil {
+        return "", fmt.Errorf("failed to marshal frontmatter: %w", err)
+    }
+
+    // 重建完整的 SKILL.md：frontmatter + body
+    return "---\n" + string(newFrontmatter) + "---\n" + strings.TrimPrefix(parts[2], "\n"), nil
+}
+```
+
+#### 注意事项
+
+| 场景 | 行为 |
+|------|------|
+| SKILL.md 在 OSS 中不存在 | 记录日志，跳过重写 |
+| YAML frontmatter 格式不合法 | 记录日志，跳过重写 |
+| OSS 写入失败 | 记录日志，不影响元数据编辑结果 |
+| `name/description` 在 frontmatter 中原本不存在 | 新增这两个字段 |
+| frontmatter 中的自定义字段 | 全部保留，不删除不改动 |
+
+#### 与 `UpdateSkillPackage` 的关系
+
+`UpdateSkillPackage` 不需要做 OSS 重写，因为用户上传了新的完整 SKILL.md，其中的 name/desc 就是用户期望的值，不存在不一致问题。
+
+### 3.8 OpenAPI 文档
+
+#### 公共 API 文档
+
+**文件：** `docs/apis/api_public/skill.yaml`
+
+新增 path 条目：
+
+```yaml
+/skills/{skill_id}/management/content:
+  get:
+    summary: 获取 Skill 管理态内容
+    description: 读取当前编辑态的 SKILL.md 内容（含文件清单）
+    tags: [Skill - Management Read]
+    parameters:
+      - $ref: '#/components/parameters/X-Business-Domain'
+      - $ref: '#/components/parameters/Authorization'
+      - $ref: '#/components/parameters/SkillID'
+    responses:
+      '200':
+        description: OK
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetManagementContentResponse'
+      '404':
+        description: Skill not found
+      '403':
+        description: Forbidden
+
+/skills/{skill_id}/management/files:
+  get:
+    summary: 获取管理态文件清单
+    # ... 类似模式 ...
+
+/skills/{skill_id}/management/files/read:
+  post:
+    summary: 读取管理态指定文件
+    # ... 类似模式 ...
+
+/skills/{skill_id}/management/download:
+  get:
+    summary: 下载管理态 Skill 包
+    # ... 类似模式 ...
+```
+
+Schema 定义：
+
+```yaml
+components:
+  schemas:
+    GetManagementContentResponse:
+      type: object
+      properties:
+        skill_id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        version:
+          type: string
+        status:
+          type: string
+        source:
+          type: string
+        file_type:
+          type: string
+          enum: [zip, content]
+        url:
+          type: string
+          nullable: true
+          description: SKILL.md 预签名下载 URL（zip 注册），null 表示 content 注册
+        content:
+          type: string
+          nullable: true
+          description: 完整 SKILL.md 文本（content 注册），null 表示 zip 注册
+        files:
+          type: array
+          items:
+            $ref: '#/components/schemas/SkillFileSummary'
+```
+
+**私有 API 文档**同样更新。
+
+---
+
+## 4. 文件变更清单
+
+| 文件 | 操作 | 说明 |
+|------|------|------|
+| `server/interfaces/logics_skill.go` | 修改 | 新增 `SkillManagementReader` 接口及 Request/Response 结构体 |
+| `server/interfaces/model/skill.go` | 不改 | 无需新增模型 |
+| `server/driveradapters/skill_handler.go` | 修改 | 新增 4 条管理态路由注册 |
+| `server/driveradapters/skill/skill.go` | 修改 | 扩展 `skillHandler` 结构体，增加 `MgmtReader` 字段 |
+| `server/driveradapters/skill/mgmt_reader.go` | **新增** | 4 个 handler 方法 |
+| `server/logics/skill/mgmt_reader.go` | **新增** | `skillManagementReader` 完整实现 |
+| `server/logics/skill/parser.go` | 修改 | `parseRegisterReq` content 分支补齐 OSS 写入（FR-5） |
+| `server/dbaccess/skill_repository.go` | 不改 | 已有 `SelectSkillByID` 满足需求 |
+| `server/dbaccess/skill_file_index.go` | 不改 | 已有 `SelectSkillFileByPath` 满足需求 |
+| `docs/apis/api_public/skill.yaml` | 修改 | 新增 4 个 management API 端点 + schema |
+| `docs/apis/api_private/skill.yaml` | 修改 | 新增 4 个 management API 端点 |
+
+---
+
+## 5. 测试策略
+
+### 5.1 单元测试
+
+| 测试用例 | 覆盖目标 |
+|---------|---------|
+| `GetManagementContent` zip 注册 | 返回正确的 SKILL.md URL 和文件清单 |
+| `GetManagementContent` content 注册 | 返回重构的完整 SKILL.md 和空文件清单 |
+| `GetManagementContent` 已删除 Skill | 返回 404 |
+| `ReadManagementFile` zip 注册有效路径 | 返回 OSS presigned URL |
+| `ReadManagementFile` content 注册 SKILL.md | 返回重构内容 |
+| `ReadManagementFile` content 注册非 SKILL.md | 返回 404 |
+| `ReadManagementFile` 路径穿越 | `normalizeZipPath` 拦截返回 400 |
+| `reconstructSkillMD` | 从 DB 字段正确重构完整 YAML frontmatter + body |
+| `detectSkillFileType` | 正确推断 zip / content |
+
+### 5.2 集成测试
+
+| 测试场景 | 验证点 |
+|---------|--------|
+| 管理态读 vs 发布态读隔离 | 同时读同一 Skill，管理态返回编辑内容，发布态返回 release 内容 |
+| content 注册的 Skill 发布后管理态读取 | 管理态始终可读，不依赖 release |
+| 权限隔离 | 只有 view/modify 权限的用户可读管理态，只有 execute 权限的用户只能读发布态 |
+
+### 5.3 回归测试
+
+| 回归点 | 验证 |
+|--------|------|
+| 现有 `GetSkillContent` | 响应体与之前完全一致 |
+| 现有 `ReadSkillFile` | 响应体与之前完全一致 |
+| 现有 `DownloadSkill` | 构建的 ZIP 内容与之前一致 |
+| 现有 `GetSkillReleaseHistory` | 不变 |
+
+---
+
+## 6. 风险与权衡
+
+| 风险 | 影响 | 缓解措施 |
+|------|------|---------|
+| `reconstructSkillMD` 与原始 SKILL.md 格式不一致 | 管理端看到的内容与注册时提交的不同 | 验证 content 注册时保留原始内容；重构函数覆盖所有字段 |
+| content 注册 OSS 补齐（FR-5）后，存量 content Skill 无 OSS 记录 | 管理读时 zip 分支走不通 | 惰性补齐：检测 OSS 无记录时回退到重构路径 |
+| `detectSkillFileType` 推断不准确（如 zip 注册但 file_manifest 为空） | 错误地按 content 类型处理 | 增加 `skill_file_index` 存在性兜底检查 |
+| 路径增加 `/management/` 前缀后在网关/权限服务中未同步 | 请求被网关拦截 | 提前与管理端网关对齐路由白名单 |
+
+### 替代方案
+
+**不做 FR-5（content OSS 补齐）：**
+- 管理端 reader 需要永久保留 content/zif 两个分支
+- `GetManagementContent` 和 `ReadManagementFile` 中 content 分支逻辑均需单独处理
+- 代码复杂度增加但架构灵活性更高
+- **权衡：** 推荐做 FR-5，读路径统一带来的长期维护收益大于短期改动成本
+
+## 7. 附录
+
+### 相关文件
+
+- PRD: `../../product/prd/skill_content_management_read.md`
+- 现有 Reader: `server/logics/skill/reader.go`
+- 现有 Registry: `server/logics/skill/registry.go`
+- 现有 Parser: `server/logics/skill/parser.go`
+- 现有 Handler: `server/driveradapters/skill/skill.go`
+- 路由注册: `server/driveradapters/skill_handler.go`
+- 公共 API 文档: `docs/apis/api_public/skill.yaml`
+- 私有 API 文档: `docs/apis/api_private/skill.yaml`

--- a/adp/execution-factory/operator-integration/docs/design/test/skill_content_management_read_sbe.md
+++ b/adp/execution-factory/operator-integration/docs/design/test/skill_content_management_read_sbe.md
@@ -19,9 +19,9 @@
 | ID | 场景 | 前置条件 | 请求参数 | 期望响应 | 验证点 |
 |----|------|---------|---------|---------|--------|
 | E1 | zip 注册 — 默认(url模式)返回 URL | FileManifest 含 scripts/main.py、SKILL.md 等多条；skill_file_index 存在 SKILL.md 记录 | BusinessDomainID:bd-1 SkillID:skill-1 response_mode:""(缺省) | file_type:zip url:https://...(非空) content:"(omitempty) files:[...] | url 非空；content 不存在或为空；files 含全部 manifest |
-| E2 | zip 注册 + content 模式 — 返回 OSS 下载的内联正文 | 同 E1；且 OSS 中 SKILL.md 可下载 | 同上 + response_mode:content | file_type:zip url:https://... content:"# SKILL.md body" | content 为 OSS 中 SKILL.md 全文；url 仍非空 |
-| E3 | content 注册 + url 模式 — 只返回 URL | SkillContent 非空；skill_file_index 有 SKILL.md 记录 | BusinessDomainID:bd-1 SkillID:skill-content-1 response_mode:url | file_type:content url:https://... content:""(omitempty) | url 非空；content 为空 |
-| E4 | content 注册 + content 模式 — 返回 DB 正文 | SkillContent 非空；skill_file_index 可有可无 | 同上 + response_mode:content | file_type:content content:"body text" url:https://...(若有 OSS) | content 等于 SkillContent 原文 |
+| E2 | zip 注册 + content 模式 — 返回 OSS 下载的内联正文（url 为空） | 同 E1；且 OSS 中 SKILL.md 可下载 | 同上 + response_mode:content | file_type:zip url:"" content:"# SKILL.md body" | content 为 OSS 中 SKILL.md 全文；url 为空（content 模式不返回 url） |
+| E3 | content 注册 + url 模式 — 有 OSS 记录则返回 url | SkillContent 非空；skill_file_index 有 SKILL.md 记录 | BusinessDomainID:bd-1 SkillID:skill-content-1 response_mode:url | file_type:content url:https://... content:""(omitempty) | url 非空；content 为空 |
+| E4 | content 注册 + content 模式 — 返回 DB 正文（url 为空） | SkillContent 非空；skill_file_index 可有可无 | 同上 + response_mode:content | file_type:content content:"body text" url:"" | content 等于 SkillContent 原文；url 为空 |
 | E5 | 已删除 Skill — 返回 404 | IsDeleted:true | BusinessDomainID:bd-1 SkillID:skill-deleted-1 | HTTP 404 | 不调用 fileRepo/assetStore |
 | E6 | 不存在 Skill — 返回 404 | SelectSkillByID 返回 nil,nil | BusinessDomainID:bd-1 SkillID:skill-nonexistent | HTTP 404 | 同上 |
 | E7 | 公有 API + 有权限 — 正常返回 | IsPublicAPIFromCtx:true；OperationCheckAny(view,modify)返回true | 同上 + UserID:user-view | 正常 200 响应 | AuthService.GetAccessor + OperationCheckAny 被调用 |

--- a/adp/execution-factory/operator-integration/docs/design/test/skill_content_management_read_sbe.md
+++ b/adp/execution-factory/operator-integration/docs/design/test/skill_content_management_read_sbe.md
@@ -11,7 +11,7 @@
 
 ## 1. GetManagementContent
 
-**Endpoint:** `GET /v1/skills/{skill_id}/management/content[?response_mode=url|content|auto]`
+**Endpoint:** `GET /v1/skills/{skill_id}/management/content[?response_mode=url|content]`
 **Interface:** `GetManagementContent(ctx, req) → (resp, err)`
 **Req header:** `X-Business-Domain`, `User-ID`(public) | **Req uri:** `skill_id` | **Req query:** `response_mode`(缺省`url`)
 **Logic source:** `skillRepository.SelectSkillByID` + `skillFileIndex.SelectSkillFileByPath`(SKILL.md) + `assetStore.GetDownloadURL` / `assetStore.Download`
@@ -22,12 +22,11 @@
 | E2 | zip 注册 + content 模式 — 返回 OSS 下载的内联正文 | 同 E1；且 OSS 中 SKILL.md 可下载 | 同上 + response_mode:content | file_type:zip url:https://... content:"# SKILL.md body" | content 为 OSS 中 SKILL.md 全文；url 仍非空 |
 | E3 | content 注册 + url 模式 — 只返回 URL | SkillContent 非空；skill_file_index 有 SKILL.md 记录 | BusinessDomainID:bd-1 SkillID:skill-content-1 response_mode:url | file_type:content url:https://... content:""(omitempty) | url 非空；content 为空 |
 | E4 | content 注册 + content 模式 — 返回 DB 正文 | SkillContent 非空；skill_file_index 可有可无 | 同上 + response_mode:content | file_type:content content:"body text" url:https://...(若有 OSS) | content 等于 SkillContent 原文 |
-| E5 | content 注册 + auto 模式 — 向后兼容 | SkillContent 非空；skill_file_index 有 SKILL.md 记录 | 同上 + response_mode:auto | file_type:content url:https://... content:"body text" | content 非空(同旧行为) |
-| E6 | 已删除 Skill — 返回 404 | IsDeleted:true | BusinessDomainID:bd-1 SkillID:skill-deleted-1 | HTTP 404 | 不调用 fileRepo/assetStore |
-| E7 | 不存在 Skill — 返回 404 | SelectSkillByID 返回 nil,nil | BusinessDomainID:bd-1 SkillID:skill-nonexistent | HTTP 404 | 同上 |
-| E8 | 公有 API + 有权限 — 正常返回 | IsPublicAPIFromCtx:true；OperationCheckAny(view,modify)返回true | 同上 + UserID:user-view | 正常 200 响应 | AuthService.GetAccessor + OperationCheckAny 被调用 |
-| E9 | 公有 API + 无权限 — 返回 403 | IsPublicAPIFromCtx:true；OperationCheckAny 返回 false | 同上 + UserID:no-perm | HTTP 403 | 不继续查询 fileRepo/assetStore |
-| E10 | 内部 API — 跳过权限校验 | IsPublicAPIFromCtx:false | BusinessDomainID:bd-1 SkillID:skill-1 response_mode:url | 正常返回 | AuthService 不被调用 |
+| E5 | 已删除 Skill — 返回 404 | IsDeleted:true | BusinessDomainID:bd-1 SkillID:skill-deleted-1 | HTTP 404 | 不调用 fileRepo/assetStore |
+| E6 | 不存在 Skill — 返回 404 | SelectSkillByID 返回 nil,nil | BusinessDomainID:bd-1 SkillID:skill-nonexistent | HTTP 404 | 同上 |
+| E7 | 公有 API + 有权限 — 正常返回 | IsPublicAPIFromCtx:true；OperationCheckAny(view,modify)返回true | 同上 + UserID:user-view | 正常 200 响应 | AuthService.GetAccessor + OperationCheckAny 被调用 |
+| E8 | 公有 API + 无权限 — 返回 403 | IsPublicAPIFromCtx:true；OperationCheckAny 返回 false | 同上 + UserID:no-perm | HTTP 403 | 不继续查询 fileRepo/assetStore |
+| E9 | 内部 API — 跳过权限校验 | IsPublicAPIFromCtx:false | BusinessDomainID:bd-1 SkillID:skill-1 response_mode:url | 正常返回 | AuthService 不被调用 |
 
 ---
 
@@ -40,10 +39,10 @@
 
 | ID | 场景 | 前置条件 | 请求参数 | 期望响应 | 验证点 |
 |----|------|---------|---------|---------|--------|
-| E11 | 有效文件路径 — 返回 presigned URL 和元信息 | zip 注册；`file_index` 存在 `scripts/main.py` 记录 `{size:1024, mime_type:"text/x-python", file_type:"script"}` | `SkillID: "skill-1"` `RelPath: "scripts/main.py"` | `url: "https://..."` `mime_type: "text/x-python"` `file_type: "script"` `size: 1024` | 元信息与 file_index 一致 |
-| E12 | 路径穿越 — 返回 400 | 任意 Skill | `RelPath: "../../etc/passwd"` | HTTP 400 `"invalid skill file path"` | normalizeZipPath 先拦截 |
-| E13 | 文件不存在 — 返回 404 | zip 注册；`file_index` 无 `missing.py` 记录 | `RelPath: "missing.py"` | HTTP 404 | 查询 file_index 后返回 `nil` |
-| E14 | 公有 API + 无权限 — 返回 403 | `IsPublicAPIFromCtx: true`；无 view/modify 权限 | `BusinessDomainID: "bd-1"` `UserID:"no-perm"` `SkillID:"skill-1"` `RelPath:"scripts/main.py"` | HTTP 403 | 同 E7 权限校验模式 |
+| E10 | 有效文件路径 — 返回 presigned URL 和元信息 | zip 注册；`file_index` 存在 `scripts/main.py` 记录 `{size:1024, mime_type:"text/x-python", file_type:"script"}` | `SkillID: "skill-1"` `RelPath: "scripts/main.py"` | `url: "https://..."` `mime_type: "text/x-python"` `file_type: "script"` `size: 1024` | 元信息与 file_index 一致 |
+| E11 | 路径穿越 — 返回 400 | 任意 Skill | `RelPath: "../../etc/passwd"` | HTTP 400 `"invalid skill file path"` | normalizeZipPath 先拦截 |
+| E12 | 文件不存在 — 返回 404 | zip 注册；`file_index` 无 `missing.py` 记录 | `RelPath: "missing.py"` | HTTP 404 | 查询 file_index 后返回 `nil` |
+| E13 | 公有 API + 无权限 — 返回 403 | `IsPublicAPIFromCtx: true`；无 view/modify 权限 | `BusinessDomainID: "bd-1"` `UserID:"no-perm"` `SkillID:"skill-1"` `RelPath:"scripts/main.py"` | HTTP 403 | 同 E6 权限校验模式 |
 
 ---
 
@@ -56,9 +55,9 @@
 
 | ID | 场景 | 前置条件 | 请求参数 | 期望响应 | 验证点 |
 |----|------|---------|---------|---------|--------|
-| E15 | zip 注册 — 下载完整 ZIP | `file_index` 含 SKILL.md、scripts/main.py 等多条；OSS 各文件均可下载 | `SkillID: "skill-1"` | ZIP 二进制；文件名 `"{skill_name}.zip"`；ZIP 内路径与 `RelPath` 一致 | 包含所有文件 |
-| E16 | content 注册 — 下载仅含 SKILL.md 的 ZIP | `file_index` 仅含 SKILL.md；OSS 可下载 | 同上 | ZIP 二进制；仅含 SKILL.md | ZIP 内仅 1 个文件 |
-| E17 | OSS 下载部分失败 — 返回错误 | `file_index` 有记录；某文件 OSS `Download` 返回错误 | 同上 | 返回 error；不返回 ZIP | buildArchiveFromFiles 失败冒泡 |
+| E14 | zip 注册 — 下载完整 ZIP | `file_index` 含 SKILL.md、scripts/main.py 等多条；OSS 各文件均可下载 | `SkillID: "skill-1"` | ZIP 二进制；文件名 `"{skill_name}.zip"`；ZIP 内路径与 `RelPath` 一致 | 包含所有文件 |
+| E15 | content 注册 — 下载仅含 SKILL.md 的 ZIP | `file_index` 仅含 SKILL.md；OSS 可下载 | 同上 | ZIP 二进制；仅含 SKILL.md | ZIP 内仅 1 个文件 |
+| E16 | OSS 下载部分失败 — 返回错误 | `file_index` 有记录；某文件 OSS `Download` 返回错误 | 同上 | 返回 error；不返回 ZIP | buildArchiveFromFiles 失败冒泡 |
 
 ---
 
@@ -71,10 +70,10 @@
 
 | ID | 场景 | 输入 (skill 关键字段) | 预期输出 | 逻辑说明 |
 |----|------|---------------------|---------|---------|
-| E18 | 多条 manifest 记录 → "zip" | `FileManifest: [{"rel_path":"SKILL.md"},{"rel_path":"scripts/main.py"}]` | `"zip"` | 多条 → zip |
-| E19 | 空 manifest → "content" | `FileManifest: ""`, `SkillContent: "body text"` | `"content"` | manifest 为空 → content |
-| E20 | 仅 SKILL.md + 非空 Content → "content" (FR-5 场景) | `FileManifest: [{"rel_path":"SKILL.md"}]`, `SkillContent: "body text"` | `"content"` | 仅 1 条且为 SKILL.md + content 非空 → content |
-| E21 | 全空 → "content" | `FileManifest: ""`, `SkillContent: ""` | `"content"` | 兜底默认 content |
+| E17 | 多条 manifest 记录 → "zip" | `FileManifest: [{"rel_path":"SKILL.md"},{"rel_path":"scripts/main.py"}]` | `"zip"` | 多条 → zip |
+| E18 | 空 manifest → "content" | `FileManifest: ""`, `SkillContent: "body text"` | `"content"` | manifest 为空 → content |
+| E19 | 仅 SKILL.md + 非空 Content → "content" (FR-5 场景) | `FileManifest: [{"rel_path":"SKILL.md"}]`, `SkillContent: "body text"` | `"content"` | 仅 1 条且为 SKILL.md + content 非空 → content |
+| E20 | 全空 → "content" | `FileManifest: ""`, `SkillContent: ""` | `"content"` | 兜底默认 content |
 
 ### 4.2 buildArchiveFromFiles
 
@@ -82,8 +81,8 @@
 
 | ID | 场景 | 前置条件 | 输入 | 期望输出 | 验证点 |
 |----|------|---------|------|---------|--------|
-| E39 | 正常构建 ZIP | OSS Download 返回每个文件的内容 | `files: [{RelPath:"SKILL.md",StorageKey:"key1"},{RelPath:"scripts/main.py",StorageKey:"key2"}]` | `zipName: "test-skill.zip"` `content: []byte(ZIP)` | ZIP 内路径与 RelPath 一致 |
-| E40 | OSS 下载部分失败 — 返回错误 | 某文件 OSS Download 返回 error | 同上（其中一个文件下载失败） | `err != nil`, `content == nil` | 第一个失败即返回 |
+| E38 | 正常构建 ZIP | OSS Download 返回每个文件的内容 | `files: [{RelPath:"SKILL.md",StorageKey:"key1"},{RelPath:"scripts/main.py",StorageKey:"key2"}]` | `zipName: "test-skill.zip"` `content: []byte(ZIP)` | ZIP 内路径与 RelPath 一致 |
+| E39 | OSS 下载部分失败 — 返回错误 | 某文件 OSS Download 返回 error | 同上（其中一个文件下载失败） | `err != nil`, `content == nil` | 第一个失败即返回 |
 
 ### 4.3 updateFrontmatterNameDesc
 
@@ -92,9 +91,9 @@
 
 | ID | 场景 | 输入 (rawMD frontmatter + body) | newName / newDesc | 预期输出 | 验证点 |
 |----|------|--------------------------------|-------------------|---------|--------|
-| E29 | 只替换 name/description，保留自定义字段 | `name: original\ndescription: original desc\nicon: robot\ntags: [ai, nlp]\n---\n# Body` | `"new-name"`, `"new desc"` | `name: "new-name"`, `description: "new desc"`, `icon: robot`, `tags: [ai, nlp]`, body 不变 | 自定义字段保留 |
-| E30 | 空字符串不替换 | `name: original\ndescription: original desc` | `""`, `""` | name/description 保持不变 | 原样返回 |
-| E31 | 无效格式返回错误 | 纯文本（无 `---` 分隔符） | `"any"`, `"any"` | error: `"missing frontmatter"` | 错误提示 |
+| E28 | 只替换 name/description，保留自定义字段 | `name: original\ndescription: original desc\nicon: robot\ntags: [ai, nlp]\n---\n# Body` | `"new-name"`, `"new desc"` | `name: "new-name"`, `description: "new desc"`, `icon: robot`, `tags: [ai, nlp]`, body 不变 | 自定义字段保留 |
+| E29 | 空字符串不替换 | `name: original\ndescription: original desc` | `""`, `""` | name/description 保持不变 | 原样返回 |
+| E30 | 无效格式返回错误 | 纯文本（无 `---` 分隔符） | `"any"`, `"any"` | error: `"missing frontmatter"` | 错误提示 |
 
 ---
 
@@ -105,8 +104,8 @@
 
 | ID | 场景 | 前置条件 | 输入 | 中间产物 | 最终状态（经 persist） |
 |----|------|---------|------|---------|---------------------|
-| E22 | content 注册返回 asset 和 file_summary | `FileType: "content"`；请求体为合法 SKILL.md（含 frontmatter + body） | `req.File: []byte("---\nname: my-skill\n...\n---\nbody text")` | `files: [{RelPath:"SKILL.md",FileType:"reference",MimeType:"text/markdown"}]`; `assets: [{RelPath:"SKILL.md",Content:[]byte(raw)}]` | files 含 1 条 SKILL.md；assets 含原始全文 |
-| E23 | asset 被 persistSkillAssets 持久化到 OSS + file_index | 承接 E20 的 assets 返回值；调用方 `RegisterSkill`/`UpdateSkillPackage` 调用 `persistSkillAssets` | E20 的 `assets` | — | OSS 中 `{bucket}/{skill_id}/{version}/SKILL.md` 存在；`skill_file_index` 写入 SKILL.md 记录 |
+| E21 | content 注册返回 asset 和 file_summary | `FileType: "content"`；请求体为合法 SKILL.md（含 frontmatter + body） | `req.File: []byte("---\nname: my-skill\n...\n---\nbody text")` | `files: [{RelPath:"SKILL.md",FileType:"reference",MimeType:"text/markdown"}]`; `assets: [{RelPath:"SKILL.md",Content:[]byte(raw)}]` | files 含 1 条 SKILL.md；assets 含原始全文 |
+| E22 | asset 被 persistSkillAssets 持久化到 OSS + file_index | 承接 E19 的 assets 返回值；调用方 `RegisterSkill`/`UpdateSkillPackage` 调用 `persistSkillAssets` | E19 的 `assets` | — | OSS 中 `{bucket}/{skill_id}/{version}/SKILL.md` 存在；`skill_file_index` 写入 SKILL.md 记录 |
 
 ---
 
@@ -118,11 +117,11 @@
 
 | ID | 场景 | 前置条件 | 输入/变更 | 预期行为 | 验证点 |
 |----|------|---------|----------|---------|--------|
-| E24 | name 变更 — OSS 重写 | `skill.Name: "old-name"`, `req.Name: "new-name"`, `req.Description` 与 DB 相同；`file_index` 有 SKILL.md 记录 | `needsRewrite: true` | OSS 中 SKILL.md 的 frontmatter `name` → "new-name"；`description` 和其他字段不变 | rewriteSkillMDFrontmatter 被调用 |
-| E25 | description 变更 — OSS 重写 | `skill.Description: "old desc"`, `req.Description: "new desc"`, `req.Name` 与 DB 相同 | `needsRewrite: true` | OSS 中 `description` → "new desc"；`name` 不变 | 同上 |
-| E26 | name 和 description 均未变更 — 不触发 | `req.Name == skill.Name`, `req.Description == skill.Description` | `needsRewrite: false` | `rewriteSkillMDFrontmatter` 不被调用 | 跳过重写 |
-| E27 | SKILL.md 不在 OSS — 日志记录，不阻塞 | `file_index` 无 SKILL.md 记录；`needsRewrite: true` | 重写流程第一步失败 | `rewriteSkillMDFrontmatter` 返回 error → 日志记录；`UpdateSkillMetadata` 返回成功 | 主流程不返回该 error |
-| E28 | OSS 下载失败 — 日志记录，不阻塞 | SKILL.md 在 `file_index` 中；OSS `Download` 返回 error | 重写流程第二步失败 | 同 E25 — 日志记录，主流程返回成功 | 同上 |
+| E23 | name 变更 — OSS 重写 | `skill.Name: "old-name"`, `req.Name: "new-name"`, `req.Description` 与 DB 相同；`file_index` 有 SKILL.md 记录 | `needsRewrite: true` | OSS 中 SKILL.md 的 frontmatter `name` → "new-name"；`description` 和其他字段不变 | rewriteSkillMDFrontmatter 被调用 |
+| E24 | description 变更 — OSS 重写 | `skill.Description: "old desc"`, `req.Description: "new desc"`, `req.Name` 与 DB 相同 | `needsRewrite: true` | OSS 中 `description` → "new desc"；`name` 不变 | 同上 |
+| E25 | name 和 description 均未变更 — 不触发 | `req.Name == skill.Name`, `req.Description == skill.Description` | `needsRewrite: false` | `rewriteSkillMDFrontmatter` 不被调用 | 跳过重写 |
+| E26 | SKILL.md 不在 OSS — 日志记录，不阻塞 | `file_index` 无 SKILL.md 记录；`needsRewrite: true` | 重写流程第一步失败 | `rewriteSkillMDFrontmatter` 返回 error → 日志记录；`UpdateSkillMetadata` 返回成功 | 主流程不返回该 error |
+| E27 | OSS 下载失败 — 日志记录，不阻塞 | SKILL.md 在 `file_index` 中；OSS `Download` 返回 error | 重写流程第二步失败 | 同 E24 — 日志记录，主流程返回成功 | 同上 |
 
 ---
 
@@ -134,13 +133,13 @@
 
 | ID | 场景 | 前置条件 | 输入 | 期望输出 | 验证点 |
 |----|------|---------|------|---------|--------|
-| E32 | content 合法 — 正确解析 | 含有效 frontmatter 的 content 请求 | `FileType: "content"` `File: []byte("---\nname: my-skill\nversion: 1.0.0\n---\nbody")` | `skill.Name: "my-skill"` `skill.Version: "{uuid}"`(非原始 version) `skill.SkillContent: "body"` `skill.Status: "unpublish"` | Version 被重写为 UUID |
-| E33 | zip 合法 — 正确解析 | zip 内含 SKILL.md + 其他文件 | `FileType: "zip"` `File: []byte(zip)` zip 中含 `SKILL.md`, `scripts/main.py` | `skill.Name: frontmatter.name` `files: [SKILL.md, scripts/main.py]` `assets: [file contents]` | files 和 assets 数量与 zip 内文件一致 |
-| E34 | zip 缺少 SKILL.md — 返回错误 | zip 不含 SKILL.md | 同上（无 SKILL.md 的 zip） | error: `"SKILL.md not found"` | 早期校验拦截 |
-| E35 | zip 含路径穿越文件 — 返回错误 | zip 含 `../secret.txt` | 同上（含穿越路径的 zip） | error: `"invalid skill file path"` | normalizeZipPath 拦截 |
-| E36 | 不支持的文件类型 — 返回错误 | `FileType: "exe"` | `FileType: "exe"` | error: `"unsupported file type"` | switch default 分支 |
-| E37 | content 缺少 `---` 分隔符 — 返回错误 | 不含 frontmatter 分隔符 | `File: []byte("plain text without frontmatter")` | error: `"missing frontmatter"` | parseSkillContent 解析失败 |
-| E38 | frontmatter 缺少必填字段 — 返回错误 | 只含 description 不含 name | `File: []byte("---\ndescription: test\n---\nbody")` | validator error: `"invalid skill frontmatter"` | 必填字段校验 |
+| E31 | content 合法 — 正确解析 | 含有效 frontmatter 的 content 请求 | `FileType: "content"` `File: []byte("---\nname: my-skill\nversion: 1.0.0\n---\nbody")` | `skill.Name: "my-skill"` `skill.Version: "{uuid}"`(非原始 version) `skill.SkillContent: "body"` `skill.Status: "unpublish"` | Version 被重写为 UUID |
+| E32 | zip 合法 — 正确解析 | zip 内含 SKILL.md + 其他文件 | `FileType: "zip"` `File: []byte(zip)` zip 中含 `SKILL.md`, `scripts/main.py` | `skill.Name: frontmatter.name` `files: [SKILL.md, scripts/main.py]` `assets: [file contents]` | files 和 assets 数量与 zip 内文件一致 |
+| E33 | zip 缺少 SKILL.md — 返回错误 | zip 不含 SKILL.md | 同上（无 SKILL.md 的 zip） | error: `"SKILL.md not found"` | 早期校验拦截 |
+| E34 | zip 含路径穿越文件 — 返回错误 | zip 含 `../secret.txt` | 同上（含穿越路径的 zip） | error: `"invalid skill file path"` | normalizeZipPath 拦截 |
+| E35 | 不支持的文件类型 — 返回错误 | `FileType: "exe"` | `FileType: "exe"` | error: `"unsupported file type"` | switch default 分支 |
+| E36 | content 缺少 `---` 分隔符 — 返回错误 | 不含 frontmatter 分隔符 | `File: []byte("plain text without frontmatter")` | error: `"missing frontmatter"` | parseSkillContent 解析失败 |
+| E37 | frontmatter 缺少必填字段 — 返回错误 | 只含 description 不含 name | `File: []byte("---\ndescription: test\n---\nbody")` | validator error: `"invalid skill frontmatter"` | 必填字段校验 |
 
 ---
 
@@ -153,39 +152,39 @@
 | E3 | GetManagementContent | content 注册有 OSS | url + content 均非空 | P0 |
 | E4 | GetManagementContent | 已删除 | 404 | P0 |
 | E5 | GetManagementContent | 不存在 | 404 | P0 |
-| E6 | GetManagementContent | 公有 API 有权限 | 200 | P0 |
-| E7 | GetManagementContent | 公有 API 无权限 | 403 | P0 |
-| E8 | GetManagementContent | 内部 API | 跳过 auth | P1 |
-| E9 | ReadManagementFile | 有效路径 | presigned URL + 元信息 | P0 |
-| E10 | ReadManagementFile | 路径穿越 | 400 | P0 |
-| E11 | ReadManagementFile | 文件不存在 | 404 | P0 |
-| E12 | ReadManagementFile | 公有 API 无权限 | 403 | P0 |
-| E13 | DownloadManagementSkill | zip 注册 | ZIP 包含全部文件 | P0 |
-| E14 | DownloadManagementSkill | content 注册 | ZIP 仅含 SKILL.md | P1 |
-| E15 | DownloadManagementSkill | OSS 下载失败 | 返回 error | P1 |
-| E16 | detectSkillFileType | 多文件 manifest | "zip" | P0 |
-| E17 | detectSkillFileType | 空 manifest | "content" | P0 |
-| E18 | detectSkillFileType | 仅 SKILL.md manifest + content | "content" | P0 |
-| E19 | detectSkillFileType | 全空 | "content" | P0 |
-| E20 | FR-5: parseRegisterReq content 分支 | content 注册返回 assets | 1 条 SKILL.md asset | P0 |
-| E21 | FR-5: persistSkillAssets | content 持久化 | OSS + file_index | P0 |
-| E22 | FR-6: rewriteSkillMDFrontmatter | name 变更 | OSS 重写 | P0 |
-| E23 | FR-6: rewriteSkillMDFrontmatter | desc 变更 | OSS 重写 | P0 |
-| E24 | FR-6: rewriteSkillMDFrontmatter | 无变更 | 不触发 | P0 |
-| E25 | FR-6: rewriteSkillMDFrontmatter | SKILL.md 不在 OSS | 日志不阻塞 | P0 |
-| E26 | FR-6: rewriteSkillMDFrontmatter | OSS 下载失败 | 日志不阻塞 | P1 |
-| E27 | updateFrontmatterNameDesc | 保留自定义字段 | 仅替换 name/desc | P0 |
-| E28 | updateFrontmatterNameDesc | 空字符串 | 不替换 | P1 |
-| E29 | updateFrontmatterNameDesc | 无效格式 | 错误"missing frontmatter" | P1 |
-| E30 | parseRegisterReq | 有效 content | 正确解析 | P0 |
-| E31 | parseRegisterReq | 有效 zip | 正确解析 | P0 |
-| E32 | parseRegisterReq | zip 缺 SKILL.md | 错误 | P0 |
-| E33 | parseRegisterReq | zip 路径穿越 | 错误 | P0 |
-| E34 | parseRegisterReq | 不支持的类型 | 错误 | P0 |
-| E35 | parseSkillContent | 缺少分隔符 | 错误"missing frontmatter" | P0 |
-| E36 | parseSkillContent | 少必填字段 | validator 错误 | P0 |
-| E37 | buildArchiveFromFiles | 正常构建 | ZIP 内路径正确 | P1 |
-| E38 | buildArchiveFromFiles | 部分下载失败 | 返回 error | P1 |
+| E5 | GetManagementContent | 公有 API 有权限 | 200 | P0 |
+| E6 | GetManagementContent | 公有 API 无权限 | 403 | P0 |
+| E7 | GetManagementContent | 内部 API | 跳过 auth | P1 |
+| E8 | ReadManagementFile | 有效路径 | presigned URL + 元信息 | P0 |
+| E9 | ReadManagementFile | 路径穿越 | 400 | P0 |
+| E10 | ReadManagementFile | 文件不存在 | 404 | P0 |
+| E11 | ReadManagementFile | 公有 API 无权限 | 403 | P0 |
+| E12 | DownloadManagementSkill | zip 注册 | ZIP 包含全部文件 | P0 |
+| E13 | DownloadManagementSkill | content 注册 | ZIP 仅含 SKILL.md | P1 |
+| E14 | DownloadManagementSkill | OSS 下载失败 | 返回 error | P1 |
+| E15 | detectSkillFileType | 多文件 manifest | "zip" | P0 |
+| E16 | detectSkillFileType | 空 manifest | "content" | P0 |
+| E17 | detectSkillFileType | 仅 SKILL.md manifest + content | "content" | P0 |
+| E18 | detectSkillFileType | 全空 | "content" | P0 |
+| E19 | FR-5: parseRegisterReq content 分支 | content 注册返回 assets | 1 条 SKILL.md asset | P0 |
+| E20 | FR-5: persistSkillAssets | content 持久化 | OSS + file_index | P0 |
+| E21 | FR-6: rewriteSkillMDFrontmatter | name 变更 | OSS 重写 | P0 |
+| E22 | FR-6: rewriteSkillMDFrontmatter | desc 变更 | OSS 重写 | P0 |
+| E23 | FR-6: rewriteSkillMDFrontmatter | 无变更 | 不触发 | P0 |
+| E24 | FR-6: rewriteSkillMDFrontmatter | SKILL.md 不在 OSS | 日志不阻塞 | P0 |
+| E25 | FR-6: rewriteSkillMDFrontmatter | OSS 下载失败 | 日志不阻塞 | P1 |
+| E26 | updateFrontmatterNameDesc | 保留自定义字段 | 仅替换 name/desc | P0 |
+| E27 | updateFrontmatterNameDesc | 空字符串 | 不替换 | P1 |
+| E28 | updateFrontmatterNameDesc | 无效格式 | 错误"missing frontmatter" | P1 |
+| E29 | parseRegisterReq | 有效 content | 正确解析 | P0 |
+| E30 | parseRegisterReq | 有效 zip | 正确解析 | P0 |
+| E31 | parseRegisterReq | zip 缺 SKILL.md | 错误 | P0 |
+| E32 | parseRegisterReq | zip 路径穿越 | 错误 | P0 |
+| E33 | parseRegisterReq | 不支持的类型 | 错误 | P0 |
+| E34 | parseSkillContent | 缺少分隔符 | 错误"missing frontmatter" | P0 |
+| E35 | parseSkillContent | 少必填字段 | validator 错误 | P0 |
+| E36 | buildArchiveFromFiles | 正常构建 | ZIP 内路径正确 | P1 |
+| E37 | buildArchiveFromFiles | 部分下载失败 | 返回 error | P1 |
 
 ---
 
@@ -193,14 +192,14 @@
 
 | 功能 | 已覆盖 | 缺失 |
 |------|--------|------|
-| GetManagementContent | E1, E2, E4, E5, E6, E7 | E3, E8 |
-| ReadManagementFile | E9, E10, E11 | E12 |
-| DownloadManagementSkill | E13 (依赖 buildArchiveFromFiles) | E14, E15 |
-| detectSkillFileType | E16, E17, E18, E19 | — |
-| FR-5: parser content 分支 | E20 (parser_test.go) | E21 (集成验证) |
-| FR-6: rewrite | 无 | E22–E29 |
-| parseRegisterReq | E30, E32, E33, E31 | E34, E35, E36 |
-| buildArchiveFromFiles | E37 | E38 |
-| updateFrontmatterNameDesc | 无 | E27, E28, E29 |
+| GetManagementContent | E1, E2, E4, E5, E5, E6 | E3, E7 |
+| ReadManagementFile | E8, E9, E10 | E11 |
+| DownloadManagementSkill | E12 (依赖 buildArchiveFromFiles) | E13, E14 |
+| detectSkillFileType | E15, E16, E17, E18 | — |
+| FR-5: parser content 分支 | E19 (parser_test.go) | E20 (集成验证) |
+| FR-6: rewrite | 无 | E21–E28 |
+| parseRegisterReq | E29, E31, E32, E30 | E33, E34, E35 |
+| buildArchiveFromFiles | E36 | E37 |
+| updateFrontmatterNameDesc | 无 | E26, E27, E28 |
 
-> 注：E21 是集成测试场景，需要真实 DB 和 OSS。单元测试中用 mock 验证 `persistSkillAssets` 被正确调用即可。
+> 注：E20 是集成测试场景，需要真实 DB 和 OSS。单元测试中用 mock 验证 `persistSkillAssets` 被正确调用即可。

--- a/adp/execution-factory/operator-integration/docs/design/test/skill_content_management_read_sbe.md
+++ b/adp/execution-factory/operator-integration/docs/design/test/skill_content_management_read_sbe.md
@@ -1,0 +1,206 @@
+# Skill 内容管理读取 — SBE（Specification By Example）
+
+## 范围
+
+- `SkillManagementReader` 接口的 3 个方法：`GetManagementContent` / `ReadManagementFile` / `DownloadManagementSkill`
+- 辅助函数：`detectSkillFileType` / `buildArchiveFromFiles` / `updateFrontmatterNameDesc`
+- FR-5：content 注册时 SKILL.md 写入 OSS + skill_file_index（`parseRegisterReq` content 分支）
+- FR-6：元数据编辑后 OSS SKILL.md frontmatter 同步重写（`UpdateSkillMetadata` + `rewriteSkillMDFrontmatter`）
+
+---
+
+## 1. GetManagementContent
+
+**Endpoint:** `GET /v1/skills/{skill_id}/management/content[?response_mode=url|content|auto]`
+**Interface:** `GetManagementContent(ctx, req) → (resp, err)`
+**Req header:** `X-Business-Domain`, `User-ID`(public) | **Req uri:** `skill_id` | **Req query:** `response_mode`(缺省`url`)
+**Logic source:** `skillRepository.SelectSkillByID` + `skillFileIndex.SelectSkillFileByPath`(SKILL.md) + `assetStore.GetDownloadURL` / `assetStore.Download`
+
+| ID | 场景 | 前置条件 | 请求参数 | 期望响应 | 验证点 |
+|----|------|---------|---------|---------|--------|
+| E1 | zip 注册 — 默认(url模式)返回 URL | FileManifest 含 scripts/main.py、SKILL.md 等多条；skill_file_index 存在 SKILL.md 记录 | BusinessDomainID:bd-1 SkillID:skill-1 response_mode:""(缺省) | file_type:zip url:https://...(非空) content:"(omitempty) files:[...] | url 非空；content 不存在或为空；files 含全部 manifest |
+| E2 | zip 注册 + content 模式 — 返回 OSS 下载的内联正文 | 同 E1；且 OSS 中 SKILL.md 可下载 | 同上 + response_mode:content | file_type:zip url:https://... content:"# SKILL.md body" | content 为 OSS 中 SKILL.md 全文；url 仍非空 |
+| E3 | content 注册 + url 模式 — 只返回 URL | SkillContent 非空；skill_file_index 有 SKILL.md 记录 | BusinessDomainID:bd-1 SkillID:skill-content-1 response_mode:url | file_type:content url:https://... content:""(omitempty) | url 非空；content 为空 |
+| E4 | content 注册 + content 模式 — 返回 DB 正文 | SkillContent 非空；skill_file_index 可有可无 | 同上 + response_mode:content | file_type:content content:"body text" url:https://...(若有 OSS) | content 等于 SkillContent 原文 |
+| E5 | content 注册 + auto 模式 — 向后兼容 | SkillContent 非空；skill_file_index 有 SKILL.md 记录 | 同上 + response_mode:auto | file_type:content url:https://... content:"body text" | content 非空(同旧行为) |
+| E6 | 已删除 Skill — 返回 404 | IsDeleted:true | BusinessDomainID:bd-1 SkillID:skill-deleted-1 | HTTP 404 | 不调用 fileRepo/assetStore |
+| E7 | 不存在 Skill — 返回 404 | SelectSkillByID 返回 nil,nil | BusinessDomainID:bd-1 SkillID:skill-nonexistent | HTTP 404 | 同上 |
+| E8 | 公有 API + 有权限 — 正常返回 | IsPublicAPIFromCtx:true；OperationCheckAny(view,modify)返回true | 同上 + UserID:user-view | 正常 200 响应 | AuthService.GetAccessor + OperationCheckAny 被调用 |
+| E9 | 公有 API + 无权限 — 返回 403 | IsPublicAPIFromCtx:true；OperationCheckAny 返回 false | 同上 + UserID:no-perm | HTTP 403 | 不继续查询 fileRepo/assetStore |
+| E10 | 内部 API — 跳过权限校验 | IsPublicAPIFromCtx:false | BusinessDomainID:bd-1 SkillID:skill-1 response_mode:url | 正常返回 | AuthService 不被调用 |
+
+---
+
+## 2. ReadManagementFile
+
+**Endpoint:** `POST /v1/skills/{skill_id}/management/files/read`
+**Interface:** `ReadManagementFile(ctx, req) → (resp, err)`
+**Req header:** `X-Business-Domain`, `User-ID`(public) | **Req uri:** `skill_id` | **Req body:** `{"rel_path": "..."}`
+**Logic source:** `skillRepository.SelectSkillByID` + `normalizeZipPath` + `skillFileIndex.SelectSkillFileByPath` + `assetStore.GetDownloadURL`
+
+| ID | 场景 | 前置条件 | 请求参数 | 期望响应 | 验证点 |
+|----|------|---------|---------|---------|--------|
+| E11 | 有效文件路径 — 返回 presigned URL 和元信息 | zip 注册；`file_index` 存在 `scripts/main.py` 记录 `{size:1024, mime_type:"text/x-python", file_type:"script"}` | `SkillID: "skill-1"` `RelPath: "scripts/main.py"` | `url: "https://..."` `mime_type: "text/x-python"` `file_type: "script"` `size: 1024` | 元信息与 file_index 一致 |
+| E12 | 路径穿越 — 返回 400 | 任意 Skill | `RelPath: "../../etc/passwd"` | HTTP 400 `"invalid skill file path"` | normalizeZipPath 先拦截 |
+| E13 | 文件不存在 — 返回 404 | zip 注册；`file_index` 无 `missing.py` 记录 | `RelPath: "missing.py"` | HTTP 404 | 查询 file_index 后返回 `nil` |
+| E14 | 公有 API + 无权限 — 返回 403 | `IsPublicAPIFromCtx: true`；无 view/modify 权限 | `BusinessDomainID: "bd-1"` `UserID:"no-perm"` `SkillID:"skill-1"` `RelPath:"scripts/main.py"` | HTTP 403 | 同 E7 权限校验模式 |
+
+---
+
+## 3. DownloadManagementSkill
+
+**Endpoint:** `GET /v1/skills/{skill_id}/management/download`
+**Interface:** `DownloadManagementSkill(ctx, req) → (resp, err)`
+**Req header:** `X-Business-Domain`, `User-ID`(public) | **Req uri:** `skill_id`
+**Logic source:** `skillRepository.SelectSkillByID` + `skillFileIndex.SelectSkillFileBySkillID` + `buildArchiveFromFiles` (OSS Download → ZIP)
+
+| ID | 场景 | 前置条件 | 请求参数 | 期望响应 | 验证点 |
+|----|------|---------|---------|---------|--------|
+| E15 | zip 注册 — 下载完整 ZIP | `file_index` 含 SKILL.md、scripts/main.py 等多条；OSS 各文件均可下载 | `SkillID: "skill-1"` | ZIP 二进制；文件名 `"{skill_name}.zip"`；ZIP 内路径与 `RelPath` 一致 | 包含所有文件 |
+| E16 | content 注册 — 下载仅含 SKILL.md 的 ZIP | `file_index` 仅含 SKILL.md；OSS 可下载 | 同上 | ZIP 二进制；仅含 SKILL.md | ZIP 内仅 1 个文件 |
+| E17 | OSS 下载部分失败 — 返回错误 | `file_index` 有记录；某文件 OSS `Download` 返回错误 | 同上 | 返回 error；不返回 ZIP | buildArchiveFromFiles 失败冒泡 |
+
+---
+
+## 4. 辅助函数
+
+### 4.1 detectSkillFileType
+
+**Signature:** `detectSkillFileType(skill *SkillRepositoryDB) string`
+**Source:** `mgmt_reader.go`
+
+| ID | 场景 | 输入 (skill 关键字段) | 预期输出 | 逻辑说明 |
+|----|------|---------------------|---------|---------|
+| E18 | 多条 manifest 记录 → "zip" | `FileManifest: [{"rel_path":"SKILL.md"},{"rel_path":"scripts/main.py"}]` | `"zip"` | 多条 → zip |
+| E19 | 空 manifest → "content" | `FileManifest: ""`, `SkillContent: "body text"` | `"content"` | manifest 为空 → content |
+| E20 | 仅 SKILL.md + 非空 Content → "content" (FR-5 场景) | `FileManifest: [{"rel_path":"SKILL.md"}]`, `SkillContent: "body text"` | `"content"` | 仅 1 条且为 SKILL.md + content 非空 → content |
+| E21 | 全空 → "content" | `FileManifest: ""`, `SkillContent: ""` | `"content"` | 兜底默认 content |
+
+### 4.2 buildArchiveFromFiles
+
+**Signature:** `buildArchiveFromFiles(ctx, assetStore, skill, files) → (skill, zipName, content, err)`
+
+| ID | 场景 | 前置条件 | 输入 | 期望输出 | 验证点 |
+|----|------|---------|------|---------|--------|
+| E39 | 正常构建 ZIP | OSS Download 返回每个文件的内容 | `files: [{RelPath:"SKILL.md",StorageKey:"key1"},{RelPath:"scripts/main.py",StorageKey:"key2"}]` | `zipName: "test-skill.zip"` `content: []byte(ZIP)` | ZIP 内路径与 RelPath 一致 |
+| E40 | OSS 下载部分失败 — 返回错误 | 某文件 OSS Download 返回 error | 同上（其中一个文件下载失败） | `err != nil`, `content == nil` | 第一个失败即返回 |
+
+### 4.3 updateFrontmatterNameDesc
+
+**Signature:** `updateFrontmatterNameDesc(rawMD, newName, newDesc string) (string, error)`
+**Source:** `registry.go` (FR-6)
+
+| ID | 场景 | 输入 (rawMD frontmatter + body) | newName / newDesc | 预期输出 | 验证点 |
+|----|------|--------------------------------|-------------------|---------|--------|
+| E29 | 只替换 name/description，保留自定义字段 | `name: original\ndescription: original desc\nicon: robot\ntags: [ai, nlp]\n---\n# Body` | `"new-name"`, `"new desc"` | `name: "new-name"`, `description: "new desc"`, `icon: robot`, `tags: [ai, nlp]`, body 不变 | 自定义字段保留 |
+| E30 | 空字符串不替换 | `name: original\ndescription: original desc` | `""`, `""` | name/description 保持不变 | 原样返回 |
+| E31 | 无效格式返回错误 | 纯文本（无 `---` 分隔符） | `"any"`, `"any"` | error: `"missing frontmatter"` | 错误提示 |
+
+---
+
+## 5. FR-5：Content 注册 OSS 补齐（parser.go）
+
+**Function:** `parseRegisterReq` content 分支
+**Effect:** content 注册时从请求体的原始 SKILL.md 构建 `asset` + `file_summary`，经 `persistSkillAssets` 写入 OSS + `skill_file_index`
+
+| ID | 场景 | 前置条件 | 输入 | 中间产物 | 最终状态（经 persist） |
+|----|------|---------|------|---------|---------------------|
+| E22 | content 注册返回 asset 和 file_summary | `FileType: "content"`；请求体为合法 SKILL.md（含 frontmatter + body） | `req.File: []byte("---\nname: my-skill\n...\n---\nbody text")` | `files: [{RelPath:"SKILL.md",FileType:"reference",MimeType:"text/markdown"}]`; `assets: [{RelPath:"SKILL.md",Content:[]byte(raw)}]` | files 含 1 条 SKILL.md；assets 含原始全文 |
+| E23 | asset 被 persistSkillAssets 持久化到 OSS + file_index | 承接 E20 的 assets 返回值；调用方 `RegisterSkill`/`UpdateSkillPackage` 调用 `persistSkillAssets` | E20 的 `assets` | — | OSS 中 `{bucket}/{skill_id}/{version}/SKILL.md` 存在；`skill_file_index` 写入 SKILL.md 记录 |
+
+---
+
+## 6. FR-6：元数据编辑时 OSS SKILL.md 同步重写（registry.go）
+
+**Trigger:** `UpdateSkillMetadata` 事务提交成功后，检测 name/desc 变更 → `rewriteSkillMDFrontmatter`
+**Rewrite function:** `rewriteSkillMDFrontmatter(skillID, version, newName, newDesc)` → 查 file_index → OSS Download → updateFrontmatterNameDesc → OSS Upload
+**Non-blocking:** 重写失败仅记日志，不阻塞 `UpdateSkillMetadata` 的主流程返回
+
+| ID | 场景 | 前置条件 | 输入/变更 | 预期行为 | 验证点 |
+|----|------|---------|----------|---------|--------|
+| E24 | name 变更 — OSS 重写 | `skill.Name: "old-name"`, `req.Name: "new-name"`, `req.Description` 与 DB 相同；`file_index` 有 SKILL.md 记录 | `needsRewrite: true` | OSS 中 SKILL.md 的 frontmatter `name` → "new-name"；`description` 和其他字段不变 | rewriteSkillMDFrontmatter 被调用 |
+| E25 | description 变更 — OSS 重写 | `skill.Description: "old desc"`, `req.Description: "new desc"`, `req.Name` 与 DB 相同 | `needsRewrite: true` | OSS 中 `description` → "new desc"；`name` 不变 | 同上 |
+| E26 | name 和 description 均未变更 — 不触发 | `req.Name == skill.Name`, `req.Description == skill.Description` | `needsRewrite: false` | `rewriteSkillMDFrontmatter` 不被调用 | 跳过重写 |
+| E27 | SKILL.md 不在 OSS — 日志记录，不阻塞 | `file_index` 无 SKILL.md 记录；`needsRewrite: true` | 重写流程第一步失败 | `rewriteSkillMDFrontmatter` 返回 error → 日志记录；`UpdateSkillMetadata` 返回成功 | 主流程不返回该 error |
+| E28 | OSS 下载失败 — 日志记录，不阻塞 | SKILL.md 在 `file_index` 中；OSS `Download` 返回 error | 重写流程第二步失败 | 同 E25 — 日志记录，主流程返回成功 | 同上 |
+
+---
+
+## 7. parseRegisterReq（解析器）
+
+**Signature:** `parseRegisterReq(ctx, req) → (skill, files, assets, err)`
+**Logic source:** `parser.go`
+**FileType branch:** "content" / "zip" / else → error
+
+| ID | 场景 | 前置条件 | 输入 | 期望输出 | 验证点 |
+|----|------|---------|------|---------|--------|
+| E32 | content 合法 — 正确解析 | 含有效 frontmatter 的 content 请求 | `FileType: "content"` `File: []byte("---\nname: my-skill\nversion: 1.0.0\n---\nbody")` | `skill.Name: "my-skill"` `skill.Version: "{uuid}"`(非原始 version) `skill.SkillContent: "body"` `skill.Status: "unpublish"` | Version 被重写为 UUID |
+| E33 | zip 合法 — 正确解析 | zip 内含 SKILL.md + 其他文件 | `FileType: "zip"` `File: []byte(zip)` zip 中含 `SKILL.md`, `scripts/main.py` | `skill.Name: frontmatter.name` `files: [SKILL.md, scripts/main.py]` `assets: [file contents]` | files 和 assets 数量与 zip 内文件一致 |
+| E34 | zip 缺少 SKILL.md — 返回错误 | zip 不含 SKILL.md | 同上（无 SKILL.md 的 zip） | error: `"SKILL.md not found"` | 早期校验拦截 |
+| E35 | zip 含路径穿越文件 — 返回错误 | zip 含 `../secret.txt` | 同上（含穿越路径的 zip） | error: `"invalid skill file path"` | normalizeZipPath 拦截 |
+| E36 | 不支持的文件类型 — 返回错误 | `FileType: "exe"` | `FileType: "exe"` | error: `"unsupported file type"` | switch default 分支 |
+| E37 | content 缺少 `---` 分隔符 — 返回错误 | 不含 frontmatter 分隔符 | `File: []byte("plain text without frontmatter")` | error: `"missing frontmatter"` | parseSkillContent 解析失败 |
+| E38 | frontmatter 缺少必填字段 — 返回错误 | 只含 description 不含 name | `File: []byte("---\ndescription: test\n---\nbody")` | validator error: `"invalid skill frontmatter"` | 必填字段校验 |
+
+---
+
+## 用例汇总
+
+| ID | API / 函数 | 场景 | 核心断言 | 优先级 |
+|----|-----------|------|---------|--------|
+| E1 | GetManagementContent | zip 注册正常 | url 非空 + files 完整 | P0 |
+| E2 | GetManagementContent | content 注册无 OSS | content 内联 + url 空 | P0 |
+| E3 | GetManagementContent | content 注册有 OSS | url + content 均非空 | P0 |
+| E4 | GetManagementContent | 已删除 | 404 | P0 |
+| E5 | GetManagementContent | 不存在 | 404 | P0 |
+| E6 | GetManagementContent | 公有 API 有权限 | 200 | P0 |
+| E7 | GetManagementContent | 公有 API 无权限 | 403 | P0 |
+| E8 | GetManagementContent | 内部 API | 跳过 auth | P1 |
+| E9 | ReadManagementFile | 有效路径 | presigned URL + 元信息 | P0 |
+| E10 | ReadManagementFile | 路径穿越 | 400 | P0 |
+| E11 | ReadManagementFile | 文件不存在 | 404 | P0 |
+| E12 | ReadManagementFile | 公有 API 无权限 | 403 | P0 |
+| E13 | DownloadManagementSkill | zip 注册 | ZIP 包含全部文件 | P0 |
+| E14 | DownloadManagementSkill | content 注册 | ZIP 仅含 SKILL.md | P1 |
+| E15 | DownloadManagementSkill | OSS 下载失败 | 返回 error | P1 |
+| E16 | detectSkillFileType | 多文件 manifest | "zip" | P0 |
+| E17 | detectSkillFileType | 空 manifest | "content" | P0 |
+| E18 | detectSkillFileType | 仅 SKILL.md manifest + content | "content" | P0 |
+| E19 | detectSkillFileType | 全空 | "content" | P0 |
+| E20 | FR-5: parseRegisterReq content 分支 | content 注册返回 assets | 1 条 SKILL.md asset | P0 |
+| E21 | FR-5: persistSkillAssets | content 持久化 | OSS + file_index | P0 |
+| E22 | FR-6: rewriteSkillMDFrontmatter | name 变更 | OSS 重写 | P0 |
+| E23 | FR-6: rewriteSkillMDFrontmatter | desc 变更 | OSS 重写 | P0 |
+| E24 | FR-6: rewriteSkillMDFrontmatter | 无变更 | 不触发 | P0 |
+| E25 | FR-6: rewriteSkillMDFrontmatter | SKILL.md 不在 OSS | 日志不阻塞 | P0 |
+| E26 | FR-6: rewriteSkillMDFrontmatter | OSS 下载失败 | 日志不阻塞 | P1 |
+| E27 | updateFrontmatterNameDesc | 保留自定义字段 | 仅替换 name/desc | P0 |
+| E28 | updateFrontmatterNameDesc | 空字符串 | 不替换 | P1 |
+| E29 | updateFrontmatterNameDesc | 无效格式 | 错误"missing frontmatter" | P1 |
+| E30 | parseRegisterReq | 有效 content | 正确解析 | P0 |
+| E31 | parseRegisterReq | 有效 zip | 正确解析 | P0 |
+| E32 | parseRegisterReq | zip 缺 SKILL.md | 错误 | P0 |
+| E33 | parseRegisterReq | zip 路径穿越 | 错误 | P0 |
+| E34 | parseRegisterReq | 不支持的类型 | 错误 | P0 |
+| E35 | parseSkillContent | 缺少分隔符 | 错误"missing frontmatter" | P0 |
+| E36 | parseSkillContent | 少必填字段 | validator 错误 | P0 |
+| E37 | buildArchiveFromFiles | 正常构建 | ZIP 内路径正确 | P1 |
+| E38 | buildArchiveFromFiles | 部分下载失败 | 返回 error | P1 |
+
+---
+
+## 当前代码覆盖状态
+
+| 功能 | 已覆盖 | 缺失 |
+|------|--------|------|
+| GetManagementContent | E1, E2, E4, E5, E6, E7 | E3, E8 |
+| ReadManagementFile | E9, E10, E11 | E12 |
+| DownloadManagementSkill | E13 (依赖 buildArchiveFromFiles) | E14, E15 |
+| detectSkillFileType | E16, E17, E18, E19 | — |
+| FR-5: parser content 分支 | E20 (parser_test.go) | E21 (集成验证) |
+| FR-6: rewrite | 无 | E22–E29 |
+| parseRegisterReq | E30, E32, E33, E31 | E34, E35, E36 |
+| buildArchiveFromFiles | E37 | E38 |
+| updateFrontmatterNameDesc | 无 | E27, E28, E29 |
+
+> 注：E21 是集成测试场景，需要真实 DB 和 OSS。单元测试中用 mock 验证 `persistSkillAssets` 被正确调用即可。

--- a/adp/execution-factory/operator-integration/docs/product/prd/skill_content_management_read.md
+++ b/adp/execution-factory/operator-integration/docs/product/prd/skill_content_management_read.md
@@ -1,0 +1,552 @@
+# PRD: Skill 内容管理读取能力
+
+## 文档信息
+
+- Status: Draft
+- Owner: @chenshu-zhao
+- Last Updated: 2026-04-29
+
+## 关联设计
+
+- Issue: [execution-factory Skill 内容管理能力完善 #302](https://github.com/kweaver-ai/kweaver-core/issues/302)
+- Design: [Skill 内容管理读取设计](../../design/features/skill_content_management_read.md)
+
+---
+
+## 1. 背景
+
+### 业务现状
+
+执行工厂目前支持 Skill 的完整生命周期管理（注册、编辑、发布、下架、删除），但**内容读取能力**主要集中在"已发布 Skill 的使用场景"上。当前：
+
+- `GetSkillContent` 和 `ReadSkillFile` 只读取 `skill_release`（已发布快照）中的内容
+- `GetSkillDetail` 只返回结构化元数据（名称、描述、版本、状态），不包含 SKILL.md 正文或文件清单
+- 管理端前端缺少面向内容的读接口，难以实现"内容预览、文件浏览、在线查看"等功能
+
+### 存在问题
+
+1. **管理态内容不可读**：管理端无法查看正在编辑中的 SKILL.md 原文、文件列表和文件内容
+2. **content 注册类型的读能力缺失**：`content` 方式注册的 Skill 只在 DB 中存有 SKILL.md 正文，OSS 中无对应文件，`GetSkillContent` 会返回 404
+3. **状态语义不清晰**：不同状态下（unpublish / editing / published / offline），"当前管理内容"与"已发布内容"的边界未在 API 层区分
+4. **两种注册方式的读体验不统一**：`content` 和 `zip` 注册的 Skill 在管理端读取路径不一致
+
+### 触发原因
+
+Skill 功能从"注册即用"演进到"持续维护、多人协作、多环境管理"，需要管理端、SDK、CLI 具备一致的**管理态内容读取能力**，以支撑以下业务场景：
+
+- 管理端 UI 展示 Skill 当前编辑态的 SKILL.md 原文
+- 管理端 UI 展示 Skill 包内的文件清单并支持文件预览
+- SDK/CLI 通过统一 API 拉取管理态内容用于离线编辑和审计
+
+---
+
+## 2. 目标
+
+### 业务目标
+
+- 管理端能查看任意状态 Skill 的**当前编辑态** SKILL.md 内容
+- 管理端能查看 Skill 包的**文件清单**并读取指定文件
+- 管理端能**下载**当前编辑态的完整 Skill 包（含全部文件资产）
+- 已有发布态读接口不受影响，保持向后兼容
+
+### 产品目标
+
+- 建立"管理态读"与"发布态读"两条清晰的读路径
+- 明确各状态下管理端读的语义
+- 统一 `content` 注册与 `zip` 注册的管理端读体验
+- 权限校验与现有体系一致：管理态走"查看/修改权限"，发布态走"执行/公开访问权限"
+
+---
+
+## 3. 非目标
+
+- 管理端前端 UI 开发（此 PRD 只覆盖后端 API）
+- 单文件粒度的增量补丁编辑
+- 历史版本之间的内容差异对比
+- 跨 Skill 批量内容读取
+- SDK/CLI 端包装实现
+- 旧版本 OSS 资产的自动回收
+
+---
+
+## 4. 术语定义
+
+| 术语 | 定义 |
+|------|------|
+| 管理态内容 | `skill_repository` 表中当前编辑中的草稿内容 |
+| 发布态内容 | `skill_release` 表中最后一次发布时的快照内容 |
+| content 注册 | 通过提交纯文本 SKILL.md 注册 Skill，本次改造后补齐 OSS 文件资产 |
+| zip 注册 | 通过上传 ZIP 包注册 Skill，文件存储在 OSS，元数据在 `skill_file_index` |
+| SKILL.md | Skill 定义文件，含 YAML frontmatter 和 Markdown body |
+| file_manifest | `skill_repository` 表中的 JSON 字段，记录注册时的文件摘要列表 |
+
+---
+
+## 5. 状态与读语义矩阵
+
+管理端读取"当前编辑态内容"，不受发布状态影响。不同业务状态下读接口的行为：
+
+| Skill 状态 | 管理端读到的内容 | 发布端（现有）读到的内容 |
+|-----------|----------------|----------------------|
+| **unpublish**（未发布） | repository 当前内容 ✅ | 404（无 release） |
+| **editing**（编辑中） | repository 当前内容 ✅ | 上一次 release 快照 |
+| **published**（已发布，无编辑） | repository 当前内容（与 release 一致）| release 快照 |
+| **offline**（已下架） | repository 当前内容 ✅ | 404（release 已删除） |
+| **deleted**（已删除） | 404，明确错误码 | 404 |
+
+**核心原则：**
+- 管理端读路径始终返回 `skill_repository` 中的当前数据
+- 发布端读路径（现有接口）保持不变，始终返回 `skill_release` 中的数据
+- 两条路径互不干扰
+
+---
+
+## 6. 用户与场景
+
+### 6.1 用户角色
+
+| 角色 | 描述 |
+|------|------|
+| Skill 作者 | 编写和维护 SKILL.md、管理文件资产 |
+| 管理端用户 | 通过 UI 查看、浏览、审阅 Skill 内容 |
+| SDK/CLI 用户 | 通过 API 拉取管理态内容用于本地编辑或审计 |
+
+### 6.2 用户故事
+
+- 作为 Skill 作者，我希望在管理端查看当前编辑态的 SKILL.md 内容，从而确认我的修改已正确保存。
+- 作为 Skill 作者，我希望在管理端浏览 Skill 包内的所有文件，从而了解当前版本包含哪些资产。
+- 作为管理端用户，我希望预览任意指定文件的内容（如 Python 脚本、配置文件），从而在不下载的情况下快速审阅。
+- 作为管理端用户，我希望在 Skill 处于 unpublish / editing / offline 状态下仍能查看/下载其内容，从而在不上架的情况下进行协作。
+- 作为 SDK 集成方，我希望能统一获取管理态内容，无论 Skill 是 content 还是 zip 注册的。
+
+### 6.3 使用场景
+
+- **场景 1**：管理端 Skill 详情页展示 SKILL.md 原文 + 元数据，进入"内容预览"模式
+- **场景 2**：管理端 Skill 文件列表页展示包内所有文件（文件名、类型、大小、MIME），支持按路径搜索
+- **场景 3**：管理端点击文件，发起"文件读取"请求，获取可预览的 URL 或文件内容
+- **场景 4**：管理端下载当前编辑态的完整 Skill 包（ZIP 格式）
+- **场景 5**：SDK 调用 `kweaver skill content` 获取管理态 SKILL.md
+
+---
+
+## 7. 需求范围
+
+### ✅ In Scope
+
+- 管理态 SKILL.md 内容读取
+- 管理态文件清单查询
+- 管理态指定文件内容读取（返回预签名 URL）
+- content 注册类型的管理端读能力补齐
+- 状态语义在 reader 层的明确区分（管理态 vs 发布态）
+- 权限、业务域隔离、删除态处理、路径安全校验
+- 向后兼容：现有发布态读接口不受影响
+- OpenAPI 文档更新
+
+### ❌ Out of Scope
+
+- 单文件粒度的增量补丁编辑
+- 历史版本差异对比接口
+- 跨 Skill 批量内容读取
+- SDK/CLI 包装实现
+- 管理前端 UI 开发
+
+---
+
+## 8. 功能需求
+
+### 8.1 功能结构
+
+```
+Skill 内容管理读取
+├── 管理态读接口（新增/扩展）
+│   ├── GetSkillRepositoryContent    — 读取当前编辑态 SKILL.md
+│   ├── GetSkillRepositoryFiles      — 获取当前编辑态文件清单
+│   ├── ReadSkillRepositoryFile      — 读取当前编辑态指定文件
+│   └── DownloadSkillRepository      — 下载当前编辑态完整包（已有，需确认）
+├── 发布态读接口（现有，不变）
+│   ├── GetSkillContent
+│   ├── ReadSkillFile
+│   ├── DownloadSkill
+│   └── GetSkillReleaseHistory
+└── 公共能力
+    ├── normalizeZipPath 路径校验（复用）
+    └── 权限 + 业务域隔离（复用）
+```
+
+### 8.2 API 设计
+
+#### 方案：独立端点（独立路由 + 独立 Logic 接口）
+
+管理态读接口使用独立的 `/management/` 路径前缀，与现有发布态接口完全解耦。handler 层、logic 层、数据源均为独立实现，不存在参数分流。
+
+```
+# 发布态读接口（现有，不变）
+GET  /skills/{skill_id}/content                  → SkillReader.GetSkillContent
+POST /skills/{skill_id}/files/read               → SkillReader.ReadSkillFile
+GET  /skills/{skill_id}/download                 → SkillRegistry.DownloadSkill
+GET  /skills/{skill_id}/history                  → SkillReader.GetSkillReleaseHistory
+
+# 管理态读接口（新增，独立路由）
+GET  /skills/{skill_id}/management/content       → SkillManagementReader.GetManagementContent
+POST /skills/{skill_id}/management/files/read    → SkillManagementReader.ReadManagementFile
+GET  /skills/{skill_id}/management/download      → SkillManagementReader.DownloadManagementSkill
+```
+
+**决策理由：**
+- 已有服务**零影响**：现有调用不需要改任何 URL 或传任何额外参数
+- 路由自描述：看路径就知道是读管理态还是发布态
+- 权限链分离：路由层直接挂不同的 middleware，不存在 handler 内部分流
+- Logic 层隔离：`SkillReader` 不改一行代码，新增 `SkillManagementReader` 作为第三个独立接口
+- OpenAPI 文档完全独立，无交叉描述
+
+---
+
+#### 【FR-1】管理态 SKILL.md 内容读取
+
+| 字段 | 值 |
+|------|-----|
+| 接口 | `GET /skills/{skill_id}/management/content` |
+| 权限 | 公共 API：检查 `view` / `modify` 权限 |
+| | 内部 API：无权限校验（已有机制） |
+
+**请求：**
+```
+GET /api/agent-operator-integration/v1/skills/{skill_id}/management/content
+Authorization: Bearer <token>
+x-business-domain: <bd_id>
+```
+
+**响应：**
+
+```json
+{
+  "skill_id": "uuid",
+  "name": "skill-name",
+  "description": "skill description",
+  "version": "v1.0.0",
+  "status": "editing",
+  "source": "custom",
+  "file_type": "zip",
+  "url": "https://oss-presigned-url/skills/SKILL.md",
+  "files": [
+    {
+      "rel_path": "scripts/main.py",
+      "file_type": "script",
+      "size": 1024,
+      "mime_type": "text/x-python"
+    }
+  ]
+}
+```
+
+**响应字段说明：**
+| 字段 | 说明 |
+|------|------|
+| `url` | 始终返回 SKILL.md 的 OSS 预签名 URL（content 注册补齐 OSS 后也支持） |
+| `files` | file_manifest 反序列化结果，content 注册可能为空数组 `[]` |
+
+**业务规则：**
+- 总是从 `skill_repository` 表读取
+- `url` 指向的 OSS 文件中的 name/desc 与 DB 中一致（通过元数据编辑时同步重写 OSS 保证）
+- Skill 已删除（`is_deleted=true`）返回 404
+- 不存在 release 记录不影响管理端读取
+
+**边界条件：**
+| 场景 | 行为 |
+|------|------|
+| content 注册（补齐后），status=unpublish | 返回 OSS presigned URL，files=[] |
+| zip 注册，status=published（有编辑） | 返回当前编辑态的 SKILL.md 和文件清单（可能与 release 不同） |
+| zip 注册，status=published（无编辑） | 返回 repository 内容（与 release 内容一致） |
+| skill 已删除 (`is_deleted=true`) | 返回 404 |
+
+**异常处理：**
+- Skill 存在但无 `file_type` 信息 → 默认按 content 处理
+- SKILL.md OSS 记录缺失 → 返回错误
+
+---
+
+#### 【FR-2】管理态文件清单查询
+
+| 字段 | 值 |
+|------|-----|
+| 接口 | `GET /skills/{skill_id}/management/files` |
+| 权限 | 公共 API：检查 `view` / `modify` 权限 |
+
+**请求：**
+```
+GET /api/agent-operator-integration/v1/skills/{skill_id}/management/files
+```
+
+**响应：**
+```json
+{
+  "skill_id": "uuid",
+  "version": "v1.0.0",
+  "file_type": "zip",
+  "total_files": 3,
+  "files": [
+    { "rel_path": "SKILL.md", "file_type": "reference", "size": 2048, "mime_type": "text/markdown" },
+    { "rel_path": "scripts/main.py", "file_type": "script", "size": 4096, "mime_type": "text/x-python" },
+    { "rel_path": "config.yaml", "file_type": "config", "size": 512, "mime_type": "application/yaml" }
+  ]
+}
+```
+
+**业务规则：**
+- 从 `skill_repository.file_manifest` 反序列化文件列表
+- content 注册：`file_type` = "content"，`total_files` = 0，`files` = 空数组
+- 不存在 file_manifest 时返回空数组而非 null
+
+---
+
+#### 【FR-3】管理态指定文件读取
+
+| 字段 | 值 |
+|------|-----|
+| 接口 | `POST /skills/{skill_id}/management/files/read` |
+| 权限 | 公共 API：检查 `view` / `modify` 权限 |
+
+**请求：**
+```
+POST /api/agent-operator-integration/v1/skills/{skill_id}/management/files/read
+{
+  "rel_path": "scripts/main.py"
+}
+```
+
+**响应：**
+```json
+{
+  "skill_id": "uuid",
+  "rel_path": "scripts/main.py",
+  "url": "https://oss-presigned-url/skills/file",
+  "mime_type": "text/x-python",
+  "file_type": "script",
+  "size": 4096
+}
+```
+
+**业务规则：**
+- 从 `skill_file_index` 表查询，以 `skill_repository.version` 为版本键（而非 release version）
+- 路径安全校验复用 `normalizeZipPath`
+- 所有注册类型统一走 OSS 预签名 URL（content 注册补齐 OSS 后也会在 file_index 中有 SKILL.md 记录）
+
+**边界条件：**
+| 场景 | 行为 |
+|------|------|
+| 路径存在 | 返回 OSS 预签名 URL |
+| 路径不存在 | 返回 404 |
+| 路径穿越攻击 (`../../etc/passwd`) | `normalizeZipPath` 拦截，返回 400 |
+| Skill 版本更新后读旧路径 | 以 repository 的当前 version 为准 |
+
+---
+
+#### 【FR-4】管理态内容下载
+
+| 字段 | 值 |
+|------|-----|
+| 接口 | `GET /skills/{skill_id}/management/download` |
+| 权限 | 公共 API：检查 `view` / `modify` 权限 |
+
+**说明：**
+从 `skill_repository` 和 `skill_file_index` 构建当前编辑态的完整 zip 包。已有 `DownloadSkill`（读 repository）行为不变，新增此端点用于语义明确。
+
+对于 `content` 注册类型：构建一个仅含 SKILL.md 的 ZIP 包返回。
+
+---
+
+#### 【FR-5】content 注册的 OSS 补齐
+
+**问题：** content 注册时 SKILL.md 仅存于 `f_skill_content` 字段（markdown body，不含 frontmatter），未写入 OSS，导致所有基于 OSS 的读链路无法工作。
+
+**方案：** content 注册（及包更新）时，将原始请求的完整 SKILL.md（含 frontmatter）写入 OSS + `skill_file_index`，建立一条 `rel_path=SKILL.md` 的索引记录。
+
+**改动范围：**
+- parser 层：content 分支生成 `file_manifest` 和 `skillAsset`，asset 的 Content 为原始请求的 SKILL.md 全文
+- registry 层：content 注册也走 `persistSkillAssets`（文件上传 + file_index 写入）
+- `f_skill_content` 字段仅存 frontmatter 之后的 body 部分（保持现有行为）
+
+**效果：**
+
+| 维度 | 改造前 | 改造后 |
+|------|--------|--------|
+| OSS | 无任何文件 | 存有原始完整 SKILL.md |
+| `skill_file_index` | 无记录 | 有 `rel_path=SKILL.md` 记录 |
+| `file_manifest` | null | 有 SKILL.md 的文件摘要 |
+| `f_skill_content` | body 文本 | body 文本（不变） |
+
+**存量处理：**
+- 新注册 content：注册时自动写入 OSS ✅
+- 存量 content：惰性补齐——`GetManagementContent` 检测到 file_manifest 为空且 `skill_content` 非空时，自动补齐后再返回；或提供后台任务批量补齐
+
+---
+
+#### 【FR-6】元数据编辑时同步重写 OSS SKILL.md
+
+**问题：** `UpdateSkillMetadata` 只更新了 DB 中的结构化字段（`name`、`description`），OSS 中原始 SKILL.md 的 frontmatter 仍是旧值，导致所有基于 OSS 的读路径返回的 SKILL.md 内容与实际元数据不一致。
+
+**方案：** `UpdateSkillMetadata` 成功提交事务后，异步（或同步）重写 OSS 中当前版本 SKILL.md 的 frontmatter。
+
+**交互流程：**
+```
+UpdateSkillMetadata(newName, newDesc)
+  ├── 1. 查询 skill_repository（已有）
+  ├── 2. 权限校验（已有）
+  ├── 3. 重名校验（已有）
+  ├── 4. 更新 DB：repo.name = newName, repo.desc = newDesc（已有）
+  ├── 5. 提交事务（已有）
+  └── 6. × 新增：重写 OSS SKILL.md frontmatter
+        ├── a. 从 OSS 下载当前 SKILL.md
+        ├── b. 解析 YAML frontmatter
+        ├── c. 替换 name/desc 为最新值（其他自定义字段保持不动）
+        ├── d. 重新上传到同一 OSS 路径（覆盖）
+        └── e. 失败只记录日志，不阻塞主流程
+```
+
+**详细逻辑：**
+
+```python
+# OSS SKILL.md frontmatter rewrite 伪代码
+oss_content = download_from_oss(skill_id, version, "SKILL.md")
+parts = oss_content.split("---", 2)  # ['', '<frontmatter>', '\n<body>']
+
+frontmatter = yaml.load(parts[1])
+frontmatter["name"] = new_name        # 替换
+frontmatter["description"] = new_desc # 替换
+# 其余自定义字段（如 icon, tags, version 等）保持不动
+
+parts[1] = yaml.dump(frontmatter)
+new_content = "---".join(parts)
+
+upload_to_oss(skill_id, version, "SKILL.md", new_content)
+```
+
+**重要：只替换 `name` 和 `description` 两个字段，YAML frontmatter 中所有其他自定义字段（如 icon、tags、author_email 等）保持不动。**
+
+**影响范围：**
+
+| 读路径 | 改造前 | 改造后 |
+|--------|--------|--------|
+| `GetManagementContent(url)` | name/desc 可能是旧的 | name/desc 是新的 ✅ |
+| `ReadManagementFile(SKILL.md)` | name/desc 可能是旧的 | name/desc 是新的 ✅ |
+| `DownloadManagementSkill` | ZIP 中 SKILL.md 的 name/desc 可能是旧的 | ZIP 中 name/desc 是新的 ✅ |
+| 发布态 `GetSkillContent(url)` | name/desc 可能是旧的（editing 状态时） | name/desc 是新的 ✅ |
+
+**补充：`UpdateSkillPackage` 时是否需要？**
+
+不需要。包更新时用户上传了新的 SKILL.md，frontmatter 中的 name/desc 就是用户提交的值，不存在不一致问题。
+
+---
+
+### 8.3 接口对比总结
+
+| 接口 | 路径 | 数据源 | 权限（公共 API） | 变更类型 |
+|------|------|--------|----------------|---------|
+| `GetSkillContent` | `GET .../content` | `skill_release` | execute / view / public_access | 已有，不变 |
+| `GetManagementContent` | `GET .../management/content` | `skill_repository` | view / modify | 新增 |
+| `ReadSkillFile` | `POST .../files/read` | `skill_file_index`(release version) | execute / view / public_access | 已有，不变 |
+| `ReadManagementFile` | `POST .../management/files/read` | `skill_file_index`(repo version) | view / modify | 新增 |
+| `DownloadSkill` | `GET .../download` | `skill_repository` + `skill_file_index` | view / public_access | 已有，不变 |
+| `DownloadManagementSkill` | `GET .../management/download` | `skill_repository` + `skill_file_index` | view / modify | 新增 |
+| `GetSkillReleaseHistory` | `GET .../history` | `skill_release_history` | execute / view | 已有，不变 |
+
+### 8.4 数据一致性说明
+
+管理态读路径的数据一致性由以下两个新增机制保证：
+
+| 机制 | 触发时机 | 保证的数据一致性 |
+|------|---------|----------------|
+| **FR-5: content 注册 OSS 补齐** | 注册/包更新 | content 注册的 Skill 也有 OSS 文件资产，读路径统一 |
+| **FR-6: OSS SKILL.md 重写** | 元数据编辑成功后 | OSS 中的 SKILL.md frontmatter 的 name/desc 始终与 DB 一致 |
+
+---
+
+## 9. 非功能需求
+
+### 9.1 性能
+- 管理端内容读取接口 P99 响应时间 < 500ms（OSS 预签名 URL 生成无外部网络开销）
+- 文件读取接口 P99 < 1s（涉及 OSS 查询）
+
+### 9.2 安全
+- 路径遍历防护复用现有 `normalizeZipPath` 机制
+- 管理态读接口需要更严格的权限校验（`view` 或 `modify`）
+- 删除态 Skill 不允许任何读操作
+
+### 9.3 可观测性
+- 所有新增接口支持 tracing（`o11y.StartInternalSpan`）
+- 日志记录 `skill_id`、`user_id`、`bd_id`
+- 区分管理读 vs 发布读的 metrics（通过路由前缀区分）
+
+---
+
+## 10. 验收标准
+
+### 正向场景
+
+1. **管理端读取编辑态内容**
+   - Given 一个 `editing` 状态的 Skill（zip 注册），When 调用 `GET .../management/content`，Then 返回当前 `skill_repository` 中的 SKILL.md 预签名 URL 和文件清单
+
+2. **content 注册的管理端可读（FR-5）**
+   - Given 一个刚注册的 content 类型 Skill，When 调用 `GET .../management/content`，Then 返回 SKILL.md 的 OSS 预签名 URL（不再返回 null）
+
+3. **文件清单可查**
+   - Given 一个 zip 注册的 Skill，When 调用 `GET .../management/files`，Then 返回 `file_manifest` 中的完整文件列表
+
+4. **指定文件可读**
+   - Given 一个 zip 注册的 Skill，When 调用 `POST .../management/files/read` 且传有效 `rel_path`，Then 返回该文件的 OSS 预签名 URL
+
+5. **content 注册读 SKILL.md 文件（FR-5）**
+   - Given 一个 content 注册的 Skill，When 调用 `POST .../management/files/read` 且 `rel_path=SKILL.md`，Then 返回 OSS 预签名 URL（不再需要 DB 重构）
+
+6. **删除态不可读**
+   - Given 一个已删除 Skill（`is_deleted=true`），When 调用任意管理读接口，Then 返回 404
+
+7. **路径安全校验**
+   - Given 一个 zip 注册的 Skill，When 调用管理态文件读取接口且 `rel_path` 包含 `../`，Then 返回 400 错误
+
+8. **元数据编辑后 OSS 内容同步更新（FR-6）**
+   - Given 一个已存在的 Skill，When 调用 `UpdateSkillMetadata` 更新 name/desc 后，Then 调用 `GET .../management/content` 返回的 `url` 指向的 OSS 文件中，frontmatter 的 name/desc 与刚更新的值一致
+
+9. **元数据编辑不影响自定义 YAML 字段**
+   - Given 一个 Skill 的 SKILL.md 中存在自定义字段 `icon: foo`，When 调用 `UpdateSkillMetadata` 更新 name 后，Then OSS 中 SKILL.md 的 `icon` 字段仍然是 `foo`
+
+### 向后兼容
+
+10. **发布态读完全不变**
+    - Given 一个已发布 Skill，When 调用 `GET .../content`，Then 返回结果与现有行为完全一致（URL 不变，参数不变，响应体不变）
+
+11. **管理读不影响发布态**
+    - Given 一个 `editing` 态的 Skill，When 多次调用管理读接口，Then `skill_release` 数据不受影响
+
+12. **现有路由无参数污染**
+    - Given 现有调用方，When 继续使用原路径调用发布态接口，Then 不需要传任何新增参数
+
+---
+
+## 11. 失败条件
+
+- 未区分管理态和发布态的读路径，导致 SDK/CLI 读到错误的版本
+- content 注册的 Skill 在管理端仍无法读取 SKILL.md 内容
+- 权限校验不当导致未授权用户读到草稿内容
+- 现有发布态接口因改造行为异常（回归缺陷）
+
+---
+
+## 12. 风险与待确认项
+
+### 风险
+- content 注册 OSS 补齐会增加注册流程的写入延迟（一次 OSS 上传 + file_index 写入）
+- 存量 content 注册的 Skill 补齐 OSS 记录前管理端读可能不可用（惰性补齐策略可缓解）
+- OSS SKILL.md 重写失败只记录日志，不阻塞元数据编辑主流程——需关注重写失败后的告警和补偿
+
+### 待确认项
+- [ ] 存量 content 注册的 SKILL.md 补齐策略：惰性补齐（读时触发）还是后台批量任务
+- [ ] SLA 目标（响应时间、可用性）
+
+---
+
+## 13. 依赖
+
+- 内部依赖：权限服务（已就绪）、业务域服务（已就绪）、OSS 网关（已就绪）
+- 文档依赖：[API 设计文档](../../design/features/skill_content_management_read.md) 待编写
+- OpenAPI 规范：`docs/apis/api_public/skill.yaml` 和 `docs/apis/api_private/skill.yaml` 待更新

--- a/adp/execution-factory/operator-integration/server/driveradapters/skill/index.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/skill/index.go
@@ -31,6 +31,10 @@ type SkillHandler interface {
 	GetSkillReleaseHistory(c *gin.Context)
 	ReadSkillFile(c *gin.Context)
 	ExecuteSkill(c *gin.Context)
+	// 管理态读接口
+	GetManagementContent(c *gin.Context)
+	ReadManagementFile(c *gin.Context)
+	DownloadManagementSkill(c *gin.Context)
 }
 
 type skillHandler struct {
@@ -38,6 +42,7 @@ type skillHandler struct {
 	Registry          interfaces.SkillRegistry
 	Market            interfaces.SkillMarket
 	Reader            interfaces.SkillReader
+	MgmtReader        interfaces.SkillManagementReader
 	IndexBuildService interfaces.SkillIndexBuildService
 }
 
@@ -56,6 +61,7 @@ func NewSkillHandler() SkillHandler {
 			Registry:          registry,
 			Market:            market,
 			Reader:            logicsskill.NewSkillReader(),
+			MgmtReader:        logicsskill.NewSkillManagementReader(),
 			IndexBuildService: logicsskill.NewSkillIndexBuildService(),
 		}
 	})

--- a/adp/execution-factory/operator-integration/server/driveradapters/skill/mgmt_reader_handler.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/skill/mgmt_reader_handler.go
@@ -1,0 +1,88 @@
+package skill
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-playground/validator/v10"
+	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/errors"
+	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/rest"
+	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/interfaces"
+	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/utils"
+)
+
+func (h *skillHandler) GetManagementContent(c *gin.Context) {
+	req := &interfaces.GetManagementContentReq{}
+	if err := c.ShouldBindHeader(req); err != nil {
+		rest.ReplyError(c, errors.DefaultHTTPError(c.Request.Context(), http.StatusBadRequest, err.Error()))
+		return
+	}
+	if err := c.ShouldBindUri(req); err != nil {
+		rest.ReplyError(c, errors.DefaultHTTPError(c.Request.Context(), http.StatusBadRequest, err.Error()))
+		return
+	}
+	if err := c.ShouldBindQuery(req); err != nil {
+		rest.ReplyError(c, errors.DefaultHTTPError(c.Request.Context(), http.StatusBadRequest, err.Error()))
+		return
+	}
+	if err := validator.New().Struct(req); err != nil {
+		rest.ReplyError(c, err)
+		return
+	}
+	resp, err := h.MgmtReader.GetManagementContent(c.Request.Context(), req)
+	if err != nil {
+		rest.ReplyError(c, err)
+		return
+	}
+	rest.ReplyOK(c, http.StatusOK, resp)
+}
+
+func (h *skillHandler) ReadManagementFile(c *gin.Context) {
+	req := &interfaces.ReadManagementFileReq{}
+	if err := c.ShouldBindHeader(req); err != nil {
+		rest.ReplyError(c, errors.DefaultHTTPError(c.Request.Context(), http.StatusBadRequest, err.Error()))
+		return
+	}
+	if err := c.ShouldBindUri(req); err != nil {
+		rest.ReplyError(c, errors.DefaultHTTPError(c.Request.Context(), http.StatusBadRequest, err.Error()))
+		return
+	}
+	if err := utils.GetBindJSONRaw(c, req); err != nil {
+		rest.ReplyError(c, err)
+		return
+	}
+	if err := validator.New().Struct(req); err != nil {
+		rest.ReplyError(c, err)
+		return
+	}
+	resp, err := h.MgmtReader.ReadManagementFile(c.Request.Context(), req)
+	if err != nil {
+		rest.ReplyError(c, err)
+		return
+	}
+	rest.ReplyOK(c, http.StatusOK, resp)
+}
+
+func (h *skillHandler) DownloadManagementSkill(c *gin.Context) {
+	req := &interfaces.DownloadManagementSkillReq{}
+	if err := c.ShouldBindHeader(req); err != nil {
+		rest.ReplyError(c, errors.DefaultHTTPError(c.Request.Context(), http.StatusBadRequest, err.Error()))
+		return
+	}
+	if err := c.ShouldBindUri(req); err != nil {
+		rest.ReplyError(c, errors.DefaultHTTPError(c.Request.Context(), http.StatusBadRequest, err.Error()))
+		return
+	}
+	if err := validator.New().Struct(req); err != nil {
+		rest.ReplyError(c, err)
+		return
+	}
+	resp, err := h.MgmtReader.DownloadManagementSkill(c.Request.Context(), req)
+	if err != nil {
+		rest.ReplyError(c, err)
+		return
+	}
+	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%q", resp.FileName))
+	c.Data(http.StatusOK, "application/zip", resp.Content)
+}

--- a/adp/execution-factory/operator-integration/server/driveradapters/skill_handler.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/skill_handler.go
@@ -49,6 +49,10 @@ func (r *skillRestHandler) RegisterPrivate(engine *gin.RouterGroup) {
 	engine.POST("/skills/:skill_id/files/read", r.SkillHandler.ReadSkillFile)
 	// 执行技能
 	engine.POST("/skills/:skill_id/execute", r.SkillHandler.ExecuteSkill)
+	/*管理态读接口*/
+	engine.GET("/skills/:skill_id/management/content", r.SkillHandler.GetManagementContent)
+	engine.POST("/skills/:skill_id/management/files/read", r.SkillHandler.ReadManagementFile)
+	engine.GET("/skills/:skill_id/management/download", r.SkillHandler.DownloadManagementSkill)
 }
 
 func (r *skillRestHandler) RegisterPublic(engine *gin.RouterGroup) {
@@ -88,6 +92,10 @@ func (r *skillRestHandler) RegisterPublic(engine *gin.RouterGroup) {
 	engine.POST("/skills/:skill_id/execute", r.SkillHandler.ExecuteSkill)
 	// 查询技能发布历史
 	engine.GET("/skills/:skill_id/history", r.SkillHandler.GetSkillReleaseHistory)
+	/*管理态读接口*/
+	engine.GET("/skills/:skill_id/management/content", r.SkillHandler.GetManagementContent)
+	engine.POST("/skills/:skill_id/management/files/read", r.SkillHandler.ReadManagementFile)
+	engine.GET("/skills/:skill_id/management/download", r.SkillHandler.DownloadManagementSkill)
 	/*构建接口*/
 	engine.POST("/skills/index/build", r.SkillHandler.CreateSkillIndexBuildTask)
 	engine.GET("/skills/index/build", r.SkillHandler.QuerySkillIndexBuildTaskList)

--- a/adp/execution-factory/operator-integration/server/infra/config/config.go
+++ b/adp/execution-factory/operator-integration/server/infra/config/config.go
@@ -261,12 +261,16 @@ var (
 func NewConfigLoader() *Config {
 	once.Do(func() {
 		profileDir := os.Getenv("CONFIG_PROFILE")
+		var configFilePath, secretFilePath, mqConfigFilePath string
 		if profileDir == "" {
-			profileDir = "/sysvol/config"
+			configFilePath = "/sysvol/config/agent-operator-integration.yaml"
+			secretFilePath = "/sysvol/secret/agent-operator-integration-secret.yaml"
+			mqConfigFilePath = "/sysvol/config/mq_config.yaml"
+		} else {
+			configFilePath = filepath.Join(profileDir, "agent-operator-integration.yaml")
+			secretFilePath = filepath.Join(profileDir, "agent-operator-integration-secret.yaml")
+			mqConfigFilePath = filepath.Join(profileDir, "mq_config.yaml")
 		}
-		configFilePath := filepath.Join(profileDir, "agent-operator-integration.yaml")
-		secretFilePath := filepath.Join(profileDir, "agent-operator-integration-secret.yaml")
-		mqConfigFilePath := filepath.Join(profileDir, "mq_config.yaml")
 		// 设置默认配置
 		configLoader = &Config{
 			MQConfigFile: mqConfigFilePath,

--- a/adp/execution-factory/operator-integration/server/infra/config/config.go
+++ b/adp/execution-factory/operator-integration/server/infra/config/config.go
@@ -260,9 +260,13 @@ var (
 // NewConfigLoader 获取配置
 func NewConfigLoader() *Config {
 	once.Do(func() {
-		configFilePath := "/sysvol/config/agent-operator-integration.yaml"
-		secretFilePath := "/sysvol/secret/agent-operator-integration-secret.yaml"
-		mqConfigFilePath := "/sysvol/config/mq_config.yaml"
+		profileDir := os.Getenv("CONFIG_PROFILE")
+		if profileDir == "" {
+			profileDir = "/sysvol/config"
+		}
+		configFilePath := filepath.Join(profileDir, "agent-operator-integration.yaml")
+		secretFilePath := filepath.Join(profileDir, "agent-operator-integration-secret.yaml")
+		mqConfigFilePath := filepath.Join(profileDir, "mq_config.yaml")
 		// 设置默认配置
 		configLoader = &Config{
 			MQConfigFile: mqConfigFilePath,
@@ -369,7 +373,11 @@ func (conf *Config) initO11yAndLog() {
 	// 加载配置文件
 	viper.SetConfigName("observability")
 	viper.SetConfigType("yaml")
-	viper.AddConfigPath("/sysvol/config/")
+	profileDir := os.Getenv("CONFIG_PROFILE")
+	if profileDir == "" {
+		profileDir = "/sysvol/config"
+	}
+	viper.AddConfigPath(profileDir)
 	if err := viper.ReadInConfig(); err != nil {
 		panic(err)
 	}

--- a/adp/execution-factory/operator-integration/server/interfaces/logics_skill.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/logics_skill.go
@@ -435,7 +435,7 @@ type GetManagementContentReq struct {
 	BusinessDomainID string `header:"x-business-domain"`
 	UserID           string `header:"user_id"`
 	SkillID          string `uri:"skill_id" validate:"required"`
-	ResponseMode     string `form:"response_mode"` // url(默认) | content
+	ResponseMode     string `form:"response_mode" default:"url"` // url(默认) | content
 }
 
 // GetManagementContentResp 管理态内容查询响应

--- a/adp/execution-factory/operator-integration/server/interfaces/logics_skill.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/logics_skill.go
@@ -115,21 +115,21 @@ type QuerySkillMarketListResp struct {
 
 // GetSkillDetailReq Skill 详情查询
 type GetSkillDetailReq struct {
-	BusinessDomainID string `header:"x-business-domain" validate:"required"`
+	BusinessDomainID string `header:"x-business-domain"`
 	UserID           string `header:"user_id"`
 	SkillID          string `uri:"skill_id" validate:"required"`
 }
 
 // GetSkillMarketDetailReq Skill 市场详情查询
 type GetSkillMarketDetailReq struct {
-	BusinessDomainID string `header:"x-business-domain" validate:"required"`
+	BusinessDomainID string `header:"x-business-domain"`
 	UserID           string `header:"user_id"`
 	SkillID          string `uri:"skill_id" validate:"required"`
 }
 
 // GetSkillContentReq Skill 内容查询
 type GetSkillContentReq struct {
-	BusinessDomainID string `header:"x-business-domain" validate:"required"`
+	BusinessDomainID string `header:"x-business-domain"`
 	UserID           string `header:"user_id"`
 	SkillID          string `uri:"skill_id" validate:"required"`
 }
@@ -144,7 +144,7 @@ type GetSkillContentResp struct {
 
 // ReadSkillFileReq 读取 Skill 文件请求
 type ReadSkillFileReq struct {
-	BusinessDomainID string `header:"x-business-domain" validate:"required"`
+	BusinessDomainID string `header:"x-business-domain"`
 	UserID           string `header:"user_id"`
 	SkillID          string `uri:"skill_id" validate:"required"`
 	RelPath          string `json:"rel_path" validate:"required"`
@@ -265,7 +265,7 @@ type PublishSkillHistoryResp struct {
 
 // ExecuteSkillReq 执行 Skill 请求
 type ExecuteSkillReq struct {
-	BusinessDomainID string `header:"x-business-domain" validate:"required"`
+	BusinessDomainID string `header:"x-business-domain"`
 	UserID           string `header:"user_id"`
 	SkillID          string `uri:"skill_id" validate:"required"`
 	EntryShell       string `json:"entry_shell" validate:"required"`
@@ -432,10 +432,10 @@ type SkillManagementReader interface {
 
 // GetManagementContentReq 管理态内容查询请求
 type GetManagementContentReq struct {
-	BusinessDomainID string `header:"x-business-domain" validate:"required"`
+	BusinessDomainID string `header:"x-business-domain"`
 	UserID           string `header:"user_id"`
 	SkillID          string `uri:"skill_id" validate:"required"`
-	ResponseMode     string `form:"response_mode"` // url(默认) | content | auto
+	ResponseMode     string `form:"response_mode"` // url(默认) | content
 }
 
 // GetManagementContentResp 管理态内容查询响应
@@ -454,7 +454,7 @@ type GetManagementContentResp struct {
 
 // ReadManagementFileReq 管理态文件读取请求
 type ReadManagementFileReq struct {
-	BusinessDomainID string `header:"x-business-domain" validate:"required"`
+	BusinessDomainID string `header:"x-business-domain"`
 	UserID           string `header:"user_id"`
 	SkillID          string `uri:"skill_id" validate:"required"`
 	RelPath          string `json:"rel_path" validate:"required"`
@@ -472,7 +472,7 @@ type ReadManagementFileResp struct {
 
 // DownloadManagementSkillReq 管理态技能包下载请求
 type DownloadManagementSkillReq struct {
-	BusinessDomainID string `header:"x-business-domain" validate:"required"`
+	BusinessDomainID string `header:"x-business-domain"`
 	UserID           string `header:"user_id"`
 	SkillID          string `uri:"skill_id" validate:"required"`
 }

--- a/adp/execution-factory/operator-integration/server/interfaces/logics_skill.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/logics_skill.go
@@ -418,6 +418,65 @@ type SkillReader interface {
 	GetSkillReleaseHistory(ctx context.Context, req *GetSkillReleaseHistoryReq) ([]*SkillReleaseHistoryInfo, error)
 }
 
+// ========== Management Read ==========
+
+// SkillManagementReader Skill 管理态只读接口
+type SkillManagementReader interface {
+	// GetManagementContent 获取管理态 SKILL.md 内容（含文件清单）
+	GetManagementContent(ctx context.Context, req *GetManagementContentReq) (*GetManagementContentResp, error)
+	// ReadManagementFile 读取管理态指定文件内容
+	ReadManagementFile(ctx context.Context, req *ReadManagementFileReq) (*ReadManagementFileResp, error)
+	// DownloadManagementSkill 下载管理态完整技能包
+	DownloadManagementSkill(ctx context.Context, req *DownloadManagementSkillReq) (*DownloadSkillResp, error)
+}
+
+// GetManagementContentReq 管理态内容查询请求
+type GetManagementContentReq struct {
+	BusinessDomainID string `header:"x-business-domain" validate:"required"`
+	UserID           string `header:"user_id"`
+	SkillID          string `uri:"skill_id" validate:"required"`
+	ResponseMode     string `form:"response_mode"` // url(默认) | content | auto
+}
+
+// GetManagementContentResp 管理态内容查询响应
+type GetManagementContentResp struct {
+	SkillID     string              `json:"skill_id"`
+	Name        string              `json:"name"`
+	Description string              `json:"description"`
+	Version     string              `json:"version"`
+	Status      BizStatus           `json:"status"`
+	Source      string              `json:"source"`
+	FileType    string              `json:"file_type"`
+	URL         string              `json:"url"`
+	Content     string              `json:"content,omitempty"`
+	Files       []*SkillFileSummary `json:"files"`
+}
+
+// ReadManagementFileReq 管理态文件读取请求
+type ReadManagementFileReq struct {
+	BusinessDomainID string `header:"x-business-domain" validate:"required"`
+	UserID           string `header:"user_id"`
+	SkillID          string `uri:"skill_id" validate:"required"`
+	RelPath          string `json:"rel_path" validate:"required"`
+}
+
+// ReadManagementFileResp 管理态文件读取响应
+type ReadManagementFileResp struct {
+	SkillID  string `json:"skill_id"`
+	RelPath  string `json:"rel_path"`
+	URL      string `json:"url"`
+	MimeType string `json:"mime_type"`
+	FileType string `json:"file_type"`
+	Size     int64  `json:"size"`
+}
+
+// DownloadManagementSkillReq 管理态技能包下载请求
+type DownloadManagementSkillReq struct {
+	BusinessDomainID string `header:"x-business-domain" validate:"required"`
+	UserID           string `header:"user_id"`
+	SkillID          string `uri:"skill_id" validate:"required"`
+}
+
 type SkillIndexBuildService interface {
 	// CreateTask 创建任务
 	CreateTask(ctx context.Context, req *CreateSkillIndexBuildTaskReq) (*CreateSkillIndexBuildTaskResp, error)

--- a/adp/execution-factory/operator-integration/server/logics/skill/mgmt_reader.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/mgmt_reader.go
@@ -100,25 +100,15 @@ func (r *skillManagementReader) GetManagementContent(ctx context.Context, req *i
 		resp.Files = []*interfaces.SkillFileSummary{}
 	}
 
-	// 统一查询 SKILL.md 的 OSS 记录，用于 URL 和 content 模式
+	// 查询 SKILL.md 的 OSS 记录，供后续使用
 	skillFile, err := r.fileRepo.SelectSkillFileByPath(ctx, nil, skill.SkillID, skill.Version, SkillMD)
 	if err != nil {
 		return nil, err
 	}
-	if skillFile != nil {
-		downloadURL, err := r.assetStore.GetDownloadURL(ctx, &interfaces.OssObject{
-			StorageID:  skillFile.StorageID,
-			StorageKey: skillFile.StorageKey,
-		})
-		if err != nil {
-			return nil, err
-		}
-		resp.URL = downloadURL
-	}
 
-	// 根据 response_mode 填充 Content:
-	//   url(默认) — Content 为空，客户端通过 URL 下载
-	//   content  — 优先用 DB 中的 skill_content，zip 类型从 OSS 下载 SKILL.md
+	// 根据 response_mode 决定返回 URL 还是正文内容:
+	//   url(默认) — 填充 url，Content 为空
+	//   content   — 填充 Content，url 为空
 	switch req.ResponseMode {
 	case "content":
 		if skill.SkillContent != "" {
@@ -134,7 +124,18 @@ func (r *skillManagementReader) GetManagementContent(ctx context.Context, req *i
 				resp.Content = string(ossContent)
 			}
 		}
-		// default(""/"url"): Content 保持零值，omitempty 跳过
+	default:
+		// url 模式（含默认空值）：填充 URL，Content 保持零值
+		if skillFile != nil {
+			downloadURL, err := r.assetStore.GetDownloadURL(ctx, &interfaces.OssObject{
+				StorageID:  skillFile.StorageID,
+				StorageKey: skillFile.StorageKey,
+			})
+			if err != nil {
+				return nil, err
+			}
+			resp.URL = downloadURL
+		}
 	}
 
 	return resp, nil

--- a/adp/execution-factory/operator-integration/server/logics/skill/mgmt_reader.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/mgmt_reader.go
@@ -1,0 +1,309 @@
+package skill
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+
+	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/dbaccess"
+	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/common"
+	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/config"
+	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/errors"
+	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/telemetry"
+	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/interfaces"
+	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/interfaces/model"
+	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/logics/auth"
+	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/logics/business_domain"
+	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/utils"
+	o11y "github.com/kweaver-ai/kweaver-go-lib/observability"
+)
+
+type skillManagementReader struct {
+	skillRepo             model.ISkillRepository
+	fileRepo              model.ISkillFileIndex
+	assetStore            skillAssetStore
+	AuthService           interfaces.IAuthorizationService
+	BusinessDomainService interfaces.IBusinessDomainService
+	Logger                interfaces.Logger
+}
+
+var (
+	mgmtReaderOnce sync.Once
+	mgmtReaderInst interfaces.SkillManagementReader
+)
+
+// NewSkillManagementReader 创建管理态技能读取服务
+func NewSkillManagementReader() interfaces.SkillManagementReader {
+	mgmtReaderOnce.Do(func() {
+		conf := config.NewConfigLoader()
+		mgmtReaderInst = &skillManagementReader{
+			skillRepo:             dbaccess.NewSkillRepositoryDB(),
+			fileRepo:              dbaccess.NewSkillFileIndexDB(),
+			assetStore:            newOSSGatewaySkillAssetStore(),
+			AuthService:           auth.NewAuthServiceImpl(),
+			BusinessDomainService: business_domain.NewBusinessDomainService(),
+			Logger:                conf.GetLogger(),
+		}
+	})
+	return mgmtReaderInst
+}
+
+// GetManagementContent 获取管理态 SKILL.md 内容
+func (r *skillManagementReader) GetManagementContent(ctx context.Context, req *interfaces.GetManagementContentReq) (resp *interfaces.GetManagementContentResp, err error) {
+	ctx, _ = o11y.StartInternalSpan(ctx)
+	defer o11y.EndSpan(ctx, err)
+	telemetry.SetSpanAttributes(ctx, map[string]interface{}{
+		"skill_id": req.SkillID,
+	})
+
+	skill, err := r.skillRepo.SelectSkillByID(ctx, nil, req.SkillID)
+	if err != nil {
+		return nil, err
+	}
+	if skill == nil || skill.IsDeleted {
+		return nil, errors.DefaultHTTPError(ctx, http.StatusNotFound, fmt.Sprintf("skill not found: %s", req.SkillID))
+	}
+
+	if common.IsPublicAPIFromCtx(ctx) {
+		accessor, err := r.AuthService.GetAccessor(ctx, req.UserID)
+		if err != nil {
+			return nil, err
+		}
+		authorized, err := r.AuthService.OperationCheckAny(ctx, accessor, req.SkillID, interfaces.AuthResourceTypeSkill,
+			interfaces.AuthOperationTypeView, interfaces.AuthOperationTypeModify)
+		if err != nil {
+			return nil, err
+		}
+		if !authorized {
+			r.Logger.WithContext(ctx).Errorf("user has no permission to view/modify skill %s", req.SkillID)
+			return nil, errors.NewHTTPError(ctx, http.StatusForbidden, errors.ErrExtCommonOperationForbidden,
+				fmt.Sprintf("user has no permission to view/modify skill %s", req.SkillID))
+		}
+	}
+
+	resp = &interfaces.GetManagementContentResp{
+		SkillID:     skill.SkillID,
+		Name:        skill.Name,
+		Description: skill.Description,
+		Version:     skill.Version,
+		Status:      interfaces.BizStatus(skill.Status),
+		Source:      skill.Source,
+		FileType:    detectSkillFileType(skill),
+	}
+
+	resp.Files = utils.JSONToObject[[]*interfaces.SkillFileSummary](skill.FileManifest)
+	if resp.Files == nil {
+		resp.Files = []*interfaces.SkillFileSummary{}
+	}
+
+	// 统一查询 SKILL.md 的 OSS 记录，用于 URL 和 content 模式
+	skillFile, err := r.fileRepo.SelectSkillFileByPath(ctx, nil, skill.SkillID, skill.Version, SkillMD)
+	if err != nil {
+		return nil, err
+	}
+	if skillFile != nil {
+		downloadURL, err := r.assetStore.GetDownloadURL(ctx, &interfaces.OssObject{
+			StorageID:  skillFile.StorageID,
+			StorageKey: skillFile.StorageKey,
+		})
+		if err != nil {
+			return nil, err
+		}
+		resp.URL = downloadURL
+	}
+
+	// 根据 response_mode 填充 Content:
+	//   url(默认) — Content 为空，客户端通过 URL 下载
+	//   content  — 优先用 DB 中的 skill_content，zip 类型从 OSS 下载 SKILL.md
+	//   auto     — 仅 content 注册类型填充（向后兼容）
+	switch req.ResponseMode {
+	case "content":
+		if skill.SkillContent != "" {
+			resp.Content = skill.SkillContent
+		} else if skillFile != nil {
+			ossContent, err := r.assetStore.Download(ctx, &interfaces.OssObject{
+				StorageID:  skillFile.StorageID,
+				StorageKey: skillFile.StorageKey,
+			})
+			if err != nil {
+				r.Logger.WithContext(ctx).Errorf("download SKILL.md from OSS failed: %v", err)
+			} else {
+				resp.Content = string(ossContent)
+			}
+		}
+	case "auto":
+		if resp.FileType == "content" {
+			resp.Content = skill.SkillContent
+		}
+		// default(""/"url"): Content 保持零值，omitempty 跳过
+	}
+
+	return resp, nil
+}
+
+// ReadManagementFile 读取管理态指定文件
+func (r *skillManagementReader) ReadManagementFile(ctx context.Context, req *interfaces.ReadManagementFileReq) (resp *interfaces.ReadManagementFileResp, err error) {
+	ctx, _ = o11y.StartInternalSpan(ctx)
+	defer o11y.EndSpan(ctx, err)
+	telemetry.SetSpanAttributes(ctx, map[string]interface{}{
+		"skill_id": req.SkillID,
+		"rel_path": req.RelPath,
+	})
+
+	skill, err := r.skillRepo.SelectSkillByID(ctx, nil, req.SkillID)
+	if err != nil {
+		return nil, err
+	}
+	if skill == nil || skill.IsDeleted {
+		return nil, errors.DefaultHTTPError(ctx, http.StatusNotFound, fmt.Sprintf("skill not found: %s", req.SkillID))
+	}
+
+	if common.IsPublicAPIFromCtx(ctx) {
+		accessor, err := r.AuthService.GetAccessor(ctx, req.UserID)
+		if err != nil {
+			return nil, err
+		}
+		authorized, err := r.AuthService.OperationCheckAny(ctx, accessor, req.SkillID, interfaces.AuthResourceTypeSkill,
+			interfaces.AuthOperationTypeView, interfaces.AuthOperationTypeModify)
+		if err != nil {
+			return nil, err
+		}
+		if !authorized {
+			r.Logger.WithContext(ctx).Errorf("user has no permission to view/modify skill %s", req.SkillID)
+			return nil, errors.NewHTTPError(ctx, http.StatusForbidden, errors.ErrExtCommonOperationForbidden,
+				fmt.Sprintf("user has no permission to view/modify skill %s", req.SkillID))
+		}
+	}
+
+	relPath, err := normalizeZipPath(req.RelPath)
+	if err != nil {
+		return nil, errors.DefaultHTTPError(ctx, http.StatusBadRequest, err.Error())
+	}
+
+	file, err := r.fileRepo.SelectSkillFileByPath(ctx, nil, req.SkillID, skill.Version, relPath)
+	if err != nil {
+		r.Logger.WithContext(ctx).Errorf("read management file failed: %v", err)
+		return nil, err
+	}
+	if file == nil {
+		r.Logger.WithContext(ctx).Warnf("management file not found: %s", relPath)
+		return nil, errors.DefaultHTTPError(ctx, http.StatusNotFound, fmt.Sprintf("file not found: %s", relPath))
+	}
+
+	downloadURL, err := r.assetStore.GetDownloadURL(ctx, &interfaces.OssObject{
+		StorageID:  file.StorageID,
+		StorageKey: file.StorageKey,
+	})
+	if err != nil {
+		r.Logger.WithContext(ctx).Errorf("read management file failed: %v", err)
+		return nil, err
+	}
+
+	return &interfaces.ReadManagementFileResp{
+		SkillID:  req.SkillID,
+		RelPath:  relPath,
+		URL:      downloadURL,
+		MimeType: file.MimeType,
+		FileType: file.FileType,
+		Size:     file.Size,
+	}, nil
+}
+
+// DownloadManagementSkill 下载管理态完整技能包
+func (r *skillManagementReader) DownloadManagementSkill(ctx context.Context, req *interfaces.DownloadManagementSkillReq) (resp *interfaces.DownloadSkillResp, err error) {
+	ctx, _ = o11y.StartInternalSpan(ctx)
+	defer o11y.EndSpan(ctx, err)
+	telemetry.SetSpanAttributes(ctx, map[string]interface{}{
+		"skill_id": req.SkillID,
+	})
+
+	skill, err := r.skillRepo.SelectSkillByID(ctx, nil, req.SkillID)
+	if err != nil {
+		return nil, err
+	}
+	if skill == nil || skill.IsDeleted {
+		return nil, errors.DefaultHTTPError(ctx, http.StatusNotFound, fmt.Sprintf("skill not found: %s", req.SkillID))
+	}
+
+	if common.IsPublicAPIFromCtx(ctx) {
+		accessor, err := r.AuthService.GetAccessor(ctx, req.UserID)
+		if err != nil {
+			return nil, err
+		}
+		authorized, err := r.AuthService.OperationCheckAny(ctx, accessor, req.SkillID, interfaces.AuthResourceTypeSkill,
+			interfaces.AuthOperationTypeView, interfaces.AuthOperationTypeModify)
+		if err != nil {
+			return nil, err
+		}
+		if !authorized {
+			r.Logger.WithContext(ctx).Errorf("user has no permission to view/modify skill %s", req.SkillID)
+			return nil, errors.NewHTTPError(ctx, http.StatusForbidden, errors.ErrExtCommonOperationForbidden,
+				fmt.Sprintf("user has no permission to view/modify skill %s", req.SkillID))
+		}
+	}
+
+	files, err := r.fileRepo.SelectSkillFileBySkillID(ctx, nil, req.SkillID, skill.Version)
+	if err != nil {
+		r.Logger.WithContext(ctx).Errorf("select management files failed: %v", err)
+		return nil, err
+	}
+
+	skill, zipName, content, err := buildArchiveFromFiles(ctx, r.assetStore, skill, files)
+	if err != nil {
+		r.Logger.WithContext(ctx).Errorf("build management archive failed: %v", err)
+		return nil, err
+	}
+
+	return &interfaces.DownloadSkillResp{
+		SkillID:  req.SkillID,
+		FileName: zipName,
+		Content:  content,
+	}, nil
+}
+
+// buildArchiveFromFiles 从文件列表构建 ZIP 归档
+func buildArchiveFromFiles(ctx context.Context, store skillAssetStore, skill *model.SkillRepositoryDB,
+	files []*model.SkillFileIndexDB) (*model.SkillRepositoryDB, string, []byte, error) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for _, file := range files {
+		content, readErr := store.Download(ctx, &interfaces.OssObject{
+			StorageID:  file.StorageID,
+			StorageKey: file.StorageKey,
+		})
+		if readErr != nil {
+			_ = zw.Close()
+			return nil, "", nil, readErr
+		}
+		w, createErr := zw.Create(file.RelPath)
+		if createErr != nil {
+			_ = zw.Close()
+			return nil, "", nil, createErr
+		}
+		if _, writeErr := io.Copy(w, bytes.NewReader(content)); writeErr != nil {
+			_ = zw.Close()
+			return nil, "", nil, writeErr
+		}
+	}
+	if err := zw.Close(); err != nil {
+		return nil, "", nil, err
+	}
+	return skill, fmt.Sprintf("%s.zip", skill.Name), buf.Bytes(), nil
+}
+
+// detectSkillFileType 从 repository 记录推断注册类型
+// FR-5: content 注册的 manifest 仅有 SKILL.md 一条记录，zip 注册有更多文件
+func detectSkillFileType(skill *model.SkillRepositoryDB) string {
+	manifest := utils.JSONToObject[[]*interfaces.SkillFileSummary](skill.FileManifest)
+	if len(manifest) == 0 {
+		return "content"
+	}
+	if len(manifest) == 1 && manifest[0].RelPath == SkillMD && skill.SkillContent != "" {
+		return "content"
+	}
+	return "zip"
+}

--- a/adp/execution-factory/operator-integration/server/logics/skill/mgmt_reader.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/mgmt_reader.go
@@ -252,7 +252,7 @@ func (r *skillManagementReader) DownloadManagementSkill(ctx context.Context, req
 		return nil, err
 	}
 
-	skill, zipName, content, err := buildArchiveFromFiles(ctx, r.assetStore, skill, files)
+	_, zipName, content, err := buildArchiveFromFiles(ctx, r.assetStore, skill, files)
 	if err != nil {
 		r.Logger.WithContext(ctx).Errorf("build management archive failed: %v", err)
 		return nil, err

--- a/adp/execution-factory/operator-integration/server/logics/skill/mgmt_reader.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/mgmt_reader.go
@@ -119,7 +119,6 @@ func (r *skillManagementReader) GetManagementContent(ctx context.Context, req *i
 	// 根据 response_mode 填充 Content:
 	//   url(默认) — Content 为空，客户端通过 URL 下载
 	//   content  — 优先用 DB 中的 skill_content，zip 类型从 OSS 下载 SKILL.md
-	//   auto     — 仅 content 注册类型填充（向后兼容）
 	switch req.ResponseMode {
 	case "content":
 		if skill.SkillContent != "" {
@@ -134,10 +133,6 @@ func (r *skillManagementReader) GetManagementContent(ctx context.Context, req *i
 			} else {
 				resp.Content = string(ossContent)
 			}
-		}
-	case "auto":
-		if resp.FileType == "content" {
-			resp.Content = skill.SkillContent
 		}
 		// default(""/"url"): Content 保持零值，omitempty 跳过
 	}

--- a/adp/execution-factory/operator-integration/server/logics/skill/mgmt_reader_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/mgmt_reader_test.go
@@ -1,0 +1,592 @@
+package skill
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/common"
+	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/errors"
+	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/infra/logger"
+	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/interfaces"
+	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/interfaces/model"
+	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/mocks"
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+)
+
+func TestSkillManagementReader(t *testing.T) {
+	Convey("SkillManagementReader", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		validRepo := &model.SkillRepositoryDB{
+			SkillID:      "skill-1",
+			Version:      "v1",
+			Name:         "test-skill",
+			Description:  "test description",
+			Status:       interfaces.BizStatusEditing.String(),
+			Source:       "custom",
+			FileManifest: `[{"rel_path":"scripts/main.py","file_type":"script","size":1024,"mime_type":"text/x-python"}]`,
+		}
+
+		Convey("GetManagementContent returns SKILL.md URL and files for zip registration", func() {
+			mockFileRepo := mocks.NewMockISkillFileIndex(ctrl)
+			mockAssetStore := mocks.NewMockskillAssetStore(ctrl)
+			mockAuthService := mocks.NewMockIAuthorizationService(ctrl)
+			mockBusinessDomainService := mocks.NewMockIBusinessDomainService(ctrl)
+			reader := &skillManagementReader{
+				skillRepo: &stubSkillRepo{
+					selectByID: func(ctx context.Context, tx *sql.Tx, skillID string) (*model.SkillRepositoryDB, error) {
+						return validRepo, nil
+					},
+				},
+				fileRepo:              mockFileRepo,
+				assetStore:            mockAssetStore,
+				AuthService:           mockAuthService,
+				BusinessDomainService: mockBusinessDomainService,
+				Logger:                logger.DefaultLogger(),
+			}
+
+			mockFileRepo.EXPECT().SelectSkillFileByPath(gomock.Any(), gomock.Nil(), "skill-1", "v1", SkillMD).
+				Return(&model.SkillFileIndexDB{
+					SkillID:      "skill-1",
+					SkillVersion: "v1",
+					RelPath:      SkillMD,
+					StorageKey:   testBuildObjectKey("skill-1", "v1", SkillMD),
+				}, nil)
+			mockAssetStore.EXPECT().GetDownloadURL(gomock.Any(), gomock.Any()).
+				Return("https://download/skill-1/SKILL.md", nil)
+
+			resp, err := reader.GetManagementContent(context.Background(), &interfaces.GetManagementContentReq{
+				BusinessDomainID: "bd-1",
+				SkillID:          "skill-1",
+			})
+
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.SkillID, ShouldEqual, "skill-1")
+			So(resp.Name, ShouldEqual, "test-skill")
+			So(resp.URL, ShouldEqual, "https://download/skill-1/SKILL.md")
+			So(resp.FileType, ShouldEqual, "zip")
+			So(len(resp.Files), ShouldEqual, 1)
+			So(resp.Files[0].RelPath, ShouldEqual, "scripts/main.py")
+			So(resp.Files[0].FileType, ShouldEqual, "script")
+			So(resp.Content, ShouldEqual, "")  // url(default) mode: content is empty
+		})
+
+		Convey("GetManagementContent returns empty URL for content registration without OSS file", func() {
+			mockFileRepo := mocks.NewMockISkillFileIndex(ctrl)
+			mockFileRepo.EXPECT().SelectSkillFileByPath(gomock.Any(), gomock.Nil(), "skill-2", "v1", SkillMD).
+				Return(nil, nil)
+			reader := &skillManagementReader{
+				skillRepo: &stubSkillRepo{
+					selectByID: func(ctx context.Context, tx *sql.Tx, skillID string) (*model.SkillRepositoryDB, error) {
+						return &model.SkillRepositoryDB{
+							SkillID:      "skill-2",
+							Version:      "v1",
+							Name:         "content-skill",
+							Description:  "content desc",
+							Status:       interfaces.BizStatusUnpublish.String(),
+							Source:       "custom",
+							SkillContent: "some body text",
+						}, nil
+					},
+				},
+				fileRepo:              mockFileRepo,
+				assetStore:            mocks.NewMockskillAssetStore(ctrl),
+				AuthService:           mocks.NewMockIAuthorizationService(ctrl),
+				BusinessDomainService: mocks.NewMockIBusinessDomainService(ctrl),
+				Logger:                logger.DefaultLogger(),
+			}
+
+			resp, err := reader.GetManagementContent(context.Background(), &interfaces.GetManagementContentReq{
+				BusinessDomainID: "bd-1",
+				SkillID:          "skill-2",
+				ResponseMode:     "auto",
+			})
+
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.URL, ShouldEqual, "")
+			So(resp.Content, ShouldEqual, "some body text")
+			So(resp.FileType, ShouldEqual, "content")
+			So(resp.Files, ShouldNotBeNil)
+			So(len(resp.Files), ShouldEqual, 0)
+		})
+
+		Convey("GetManagementContent returns 404 for deleted skill", func() {
+			reader := &skillManagementReader{
+				skillRepo: &stubSkillRepo{
+					selectByID: func(ctx context.Context, tx *sql.Tx, skillID string) (*model.SkillRepositoryDB, error) {
+						return &model.SkillRepositoryDB{
+							SkillID:   "skill-deleted",
+							IsDeleted: true,
+						}, nil
+					},
+				},
+				fileRepo:              mocks.NewMockISkillFileIndex(ctrl),
+				assetStore:            mocks.NewMockskillAssetStore(ctrl),
+				AuthService:           mocks.NewMockIAuthorizationService(ctrl),
+				BusinessDomainService: mocks.NewMockIBusinessDomainService(ctrl),
+				Logger:                logger.DefaultLogger(),
+			}
+
+			resp, err := reader.GetManagementContent(context.Background(), &interfaces.GetManagementContentReq{
+				BusinessDomainID: "bd-1",
+				SkillID:          "skill-deleted",
+			})
+
+			So(resp, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+			httpErr, ok := err.(*errors.HTTPError)
+			So(ok, ShouldBeTrue)
+			So(httpErr.HTTPCode, ShouldEqual, http.StatusNotFound)
+		})
+
+		Convey("GetManagementContent checks view permission for public API", func() {
+			mockAuthService := mocks.NewMockIAuthorizationService(ctrl)
+			mockFileRepo := mocks.NewMockISkillFileIndex(ctrl)
+			mockAssetStore := mocks.NewMockskillAssetStore(ctrl)
+			reader := &skillManagementReader{
+				skillRepo: &stubSkillRepo{
+					selectByID: func(ctx context.Context, tx *sql.Tx, skillID string) (*model.SkillRepositoryDB, error) {
+						return validRepo, nil
+					},
+				},
+				fileRepo:              mockFileRepo,
+				assetStore:            mockAssetStore,
+				AuthService:           mockAuthService,
+				BusinessDomainService: mocks.NewMockIBusinessDomainService(ctrl),
+				Logger:                logger.DefaultLogger(),
+			}
+
+			ctx := common.SetPublicAPIToCtx(context.Background(), true)
+			mockAuthService.EXPECT().GetAccessor(gomock.Any(), "user-view").
+				Return(&interfaces.AuthAccessor{ID: "user-view"}, nil)
+			mockAuthService.EXPECT().OperationCheckAny(gomock.Any(), gomock.Any(), "skill-1",
+				interfaces.AuthResourceTypeSkill,
+				interfaces.AuthOperationTypeView, interfaces.AuthOperationTypeModify).
+				Return(true, nil)
+			mockFileRepo.EXPECT().SelectSkillFileByPath(gomock.Any(), gomock.Nil(), "skill-1", "v1", SkillMD).
+				Return(&model.SkillFileIndexDB{
+					SkillID: "skill-1", SkillVersion: "v1", RelPath: SkillMD,
+					StorageKey: testBuildObjectKey("skill-1", "v1", SkillMD),
+				}, nil)
+			mockAssetStore.EXPECT().GetDownloadURL(gomock.Any(), gomock.Any()).
+				Return("https://download/skill-1/SKILL.md", nil)
+
+			resp, err := reader.GetManagementContent(ctx, &interfaces.GetManagementContentReq{
+				BusinessDomainID: "bd-1",
+				UserID:           "user-view",
+				SkillID:          "skill-1",
+			})
+
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.URL, ShouldEqual, "https://download/skill-1/SKILL.md")
+		})
+
+		Convey("GetManagementContent returns 403 for unauthorized public API", func() {
+			mockAuthService := mocks.NewMockIAuthorizationService(ctrl)
+			reader := &skillManagementReader{
+				skillRepo: &stubSkillRepo{
+					selectByID: func(ctx context.Context, tx *sql.Tx, skillID string) (*model.SkillRepositoryDB, error) {
+						return validRepo, nil
+					},
+				},
+				fileRepo:              mocks.NewMockISkillFileIndex(ctrl),
+				assetStore:            mocks.NewMockskillAssetStore(ctrl),
+				AuthService:           mockAuthService,
+				BusinessDomainService: mocks.NewMockIBusinessDomainService(ctrl),
+				Logger:                logger.DefaultLogger(),
+			}
+
+			ctx := common.SetPublicAPIToCtx(context.Background(), true)
+			mockAuthService.EXPECT().GetAccessor(gomock.Any(), "no-perm-user").
+				Return(&interfaces.AuthAccessor{ID: "no-perm-user"}, nil)
+			mockAuthService.EXPECT().OperationCheckAny(gomock.Any(), gomock.Any(), "skill-1",
+				interfaces.AuthResourceTypeSkill,
+				interfaces.AuthOperationTypeView, interfaces.AuthOperationTypeModify).
+				Return(false, nil)
+
+			resp, err := reader.GetManagementContent(ctx, &interfaces.GetManagementContentReq{
+				BusinessDomainID: "bd-1",
+				UserID:           "no-perm-user",
+				SkillID:          "skill-1",
+			})
+
+			So(resp, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+			httpErr, ok := err.(*errors.HTTPError)
+			So(ok, ShouldBeTrue)
+			So(httpErr.HTTPCode, ShouldEqual, http.StatusForbidden)
+		})
+
+		Convey("GetManagementContent returns 404 for non-existent skill", func() {
+			reader := &skillManagementReader{
+				skillRepo: &stubSkillRepo{
+					selectByID: func(ctx context.Context, tx *sql.Tx, skillID string) (*model.SkillRepositoryDB, error) {
+						return nil, nil
+					},
+				},
+				fileRepo:              mocks.NewMockISkillFileIndex(ctrl),
+				assetStore:            mocks.NewMockskillAssetStore(ctrl),
+				AuthService:           mocks.NewMockIAuthorizationService(ctrl),
+				BusinessDomainService: mocks.NewMockIBusinessDomainService(ctrl),
+				Logger:                logger.DefaultLogger(),
+			}
+
+			resp, err := reader.GetManagementContent(context.Background(), &interfaces.GetManagementContentReq{
+				BusinessDomainID: "bd-1",
+				SkillID:          "skill-nonexistent",
+			})
+
+			So(resp, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+			httpErr, ok := err.(*errors.HTTPError)
+			So(ok, ShouldBeTrue)
+			So(httpErr.HTTPCode, ShouldEqual, http.StatusNotFound)
+		})
+
+		Convey("GetManagementContent internal API skips auth check", func() {
+			mockFileRepo := mocks.NewMockISkillFileIndex(ctrl)
+			mockAssetStore := mocks.NewMockskillAssetStore(ctrl)
+			reader := &skillManagementReader{
+				skillRepo: &stubSkillRepo{
+					selectByID: func(ctx context.Context, tx *sql.Tx, skillID string) (*model.SkillRepositoryDB, error) {
+						return validRepo, nil
+					},
+				},
+				fileRepo:              mockFileRepo,
+				assetStore:            mockAssetStore,
+				AuthService:           mocks.NewMockIAuthorizationService(ctrl),
+				BusinessDomainService: mocks.NewMockIBusinessDomainService(ctrl),
+				Logger:                logger.DefaultLogger(),
+			}
+
+			mockFileRepo.EXPECT().SelectSkillFileByPath(gomock.Any(), gomock.Nil(), "skill-1", "v1", SkillMD).
+				Return(&model.SkillFileIndexDB{
+					SkillID: "skill-1", SkillVersion: "v1", RelPath: SkillMD,
+					StorageKey: testBuildObjectKey("skill-1", "v1", SkillMD),
+				}, nil)
+			mockAssetStore.EXPECT().GetDownloadURL(gomock.Any(), gomock.Any()).
+				Return("https://download/skill-1/SKILL.md", nil)
+
+			resp, err := reader.GetManagementContent(context.Background(), &interfaces.GetManagementContentReq{
+				BusinessDomainID: "bd-1",
+				SkillID:          "skill-1",
+			})
+
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.URL, ShouldEqual, "https://download/skill-1/SKILL.md")
+		})
+
+		Convey("GetManagementContent zip registration + content mode returns OSS content", func() {
+			mockFileRepo := mocks.NewMockISkillFileIndex(ctrl)
+			mockAssetStore := mocks.NewMockskillAssetStore(ctrl)
+			mockAuthService := mocks.NewMockIAuthorizationService(ctrl)
+			reader := &skillManagementReader{
+				skillRepo: &stubSkillRepo{
+					selectByID: func(ctx context.Context, tx *sql.Tx, skillID string) (*model.SkillRepositoryDB, error) {
+						return validRepo, nil
+					},
+				},
+				fileRepo:              mockFileRepo,
+				assetStore:            mockAssetStore,
+				AuthService:           mockAuthService,
+				BusinessDomainService: mocks.NewMockIBusinessDomainService(ctrl),
+				Logger:                logger.DefaultLogger(),
+			}
+
+			mockFileRepo.EXPECT().SelectSkillFileByPath(gomock.Any(), gomock.Nil(), "skill-1", "v1", SkillMD).
+				Return(&model.SkillFileIndexDB{
+					SkillID: "skill-1", SkillVersion: "v1", RelPath: SkillMD,
+					StorageKey: testBuildObjectKey("skill-1", "v1", SkillMD),
+				}, nil)
+			mockAssetStore.EXPECT().GetDownloadURL(gomock.Any(), gomock.Any()).
+				Return("https://download/skill-1/SKILL.md", nil)
+			mockAssetStore.EXPECT().Download(gomock.Any(), gomock.Any()).
+				Return([]byte("# SKILL.md from OSS"), nil)
+
+			resp, err := reader.GetManagementContent(context.Background(), &interfaces.GetManagementContentReq{
+				BusinessDomainID: "bd-1",
+				SkillID:          "skill-1",
+				ResponseMode:     "content",
+			})
+
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.URL, ShouldEqual, "https://download/skill-1/SKILL.md")
+			So(resp.Content, ShouldEqual, "# SKILL.md from OSS")
+			So(resp.FileType, ShouldEqual, "zip")
+		})
+
+		Convey("GetManagementContent content registration + content mode returns DB content", func() {
+			mockFileRepo := mocks.NewMockISkillFileIndex(ctrl)
+			mockFileRepo.EXPECT().SelectSkillFileByPath(gomock.Any(), gomock.Nil(), "skill-2", "v1", SkillMD).
+				Return(nil, nil)
+			reader := &skillManagementReader{
+				skillRepo: &stubSkillRepo{
+					selectByID: func(ctx context.Context, tx *sql.Tx, skillID string) (*model.SkillRepositoryDB, error) {
+						return &model.SkillRepositoryDB{
+							SkillID:      "skill-2",
+							Version:      "v1",
+							Name:         "content-skill",
+							Description:  "content desc",
+							Status:       interfaces.BizStatusUnpublish.String(),
+							Source:       "custom",
+							SkillContent: "some body text",
+						}, nil
+					},
+				},
+				fileRepo:              mockFileRepo,
+				assetStore:            mocks.NewMockskillAssetStore(ctrl),
+				AuthService:           mocks.NewMockIAuthorizationService(ctrl),
+				BusinessDomainService: mocks.NewMockIBusinessDomainService(ctrl),
+				Logger:                logger.DefaultLogger(),
+			}
+
+			resp, err := reader.GetManagementContent(context.Background(), &interfaces.GetManagementContentReq{
+				BusinessDomainID: "bd-1",
+				SkillID:          "skill-2",
+				ResponseMode:     "content",
+			})
+
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.URL, ShouldEqual, "")
+			So(resp.Content, ShouldEqual, "some body text")
+			So(resp.FileType, ShouldEqual, "content")
+		})
+
+		Convey("GetManagementContent content registration + url mode returns empty content", func() {
+			mockFileRepo := mocks.NewMockISkillFileIndex(ctrl)
+			mockFileRepo.EXPECT().SelectSkillFileByPath(gomock.Any(), gomock.Nil(), "skill-2", "v1", SkillMD).
+				Return(nil, nil)
+			reader := &skillManagementReader{
+				skillRepo: &stubSkillRepo{
+					selectByID: func(ctx context.Context, tx *sql.Tx, skillID string) (*model.SkillRepositoryDB, error) {
+						return &model.SkillRepositoryDB{
+							SkillID:      "skill-2",
+							Version:      "v1",
+							Name:         "content-skill",
+							Description:  "content desc",
+							Status:       interfaces.BizStatusUnpublish.String(),
+							Source:       "custom",
+							SkillContent: "some body text",
+						}, nil
+					},
+				},
+				fileRepo:              mockFileRepo,
+				assetStore:            mocks.NewMockskillAssetStore(ctrl),
+				AuthService:           mocks.NewMockIAuthorizationService(ctrl),
+				BusinessDomainService: mocks.NewMockIBusinessDomainService(ctrl),
+				Logger:                logger.DefaultLogger(),
+			}
+
+			resp, err := reader.GetManagementContent(context.Background(), &interfaces.GetManagementContentReq{
+				BusinessDomainID: "bd-1",
+				SkillID:          "skill-2",
+				ResponseMode:     "url",
+			})
+
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.URL, ShouldEqual, "")
+			So(resp.Content, ShouldEqual, "")  // url mode: content is empty
+			So(resp.FileType, ShouldEqual, "content")
+		})
+
+		Convey("ReadManagementFile returns presigned URL for valid path", func() {
+			mockFileRepo := mocks.NewMockISkillFileIndex(ctrl)
+			mockAssetStore := mocks.NewMockskillAssetStore(ctrl)
+			reader := &skillManagementReader{
+				skillRepo: &stubSkillRepo{
+					selectByID: func(ctx context.Context, tx *sql.Tx, skillID string) (*model.SkillRepositoryDB, error) {
+						return validRepo, nil
+					},
+				},
+				fileRepo:              mockFileRepo,
+				assetStore:            mockAssetStore,
+				AuthService:           mocks.NewMockIAuthorizationService(ctrl),
+				BusinessDomainService: mocks.NewMockIBusinessDomainService(ctrl),
+				Logger:                logger.DefaultLogger(),
+			}
+
+			mockFileRepo.EXPECT().SelectSkillFileByPath(gomock.Any(), gomock.Nil(), "skill-1", "v1", "scripts/main.py").
+				Return(&model.SkillFileIndexDB{
+					SkillID: "skill-1", SkillVersion: "v1",
+					RelPath: "scripts/main.py", FileType: "script", MimeType: "text/x-python", Size: 1024,
+					StorageKey: testBuildObjectKey("skill-1", "v1", "scripts/main.py"),
+				}, nil)
+			mockAssetStore.EXPECT().GetDownloadURL(gomock.Any(), gomock.Any()).
+				Return("https://download/skill-1/scripts/main.py", nil)
+
+			resp, err := reader.ReadManagementFile(context.Background(), &interfaces.ReadManagementFileReq{
+				BusinessDomainID: "bd-1",
+				SkillID:          "skill-1",
+				RelPath:          "scripts/main.py",
+			})
+
+			So(err, ShouldBeNil)
+			So(resp.URL, ShouldEqual, "https://download/skill-1/scripts/main.py")
+			So(resp.MimeType, ShouldEqual, "text/x-python")
+			So(resp.FileType, ShouldEqual, "script")
+			So(resp.Size, ShouldEqual, 1024)
+		})
+
+		Convey("ReadManagementFile rejects path traversal", func() {
+			reader := &skillManagementReader{
+				skillRepo: &stubSkillRepo{
+					selectByID: func(ctx context.Context, tx *sql.Tx, skillID string) (*model.SkillRepositoryDB, error) {
+						return validRepo, nil
+					},
+				},
+				fileRepo:              mocks.NewMockISkillFileIndex(ctrl),
+				assetStore:            mocks.NewMockskillAssetStore(ctrl),
+				AuthService:           mocks.NewMockIAuthorizationService(ctrl),
+				BusinessDomainService: mocks.NewMockIBusinessDomainService(ctrl),
+				Logger:                logger.DefaultLogger(),
+			}
+
+			resp, err := reader.ReadManagementFile(context.Background(), &interfaces.ReadManagementFileReq{
+				BusinessDomainID: "bd-1",
+				SkillID:          "skill-1",
+				RelPath:          "../../etc/passwd",
+			})
+
+			So(resp, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+			httpErr, ok := err.(*errors.HTTPError)
+			So(ok, ShouldBeTrue)
+			So(httpErr.HTTPCode, ShouldEqual, http.StatusBadRequest)
+		})
+
+		Convey("ReadManagementFile returns 404 for non-existent file", func() {
+			mockFileRepo := mocks.NewMockISkillFileIndex(ctrl)
+			reader := &skillManagementReader{
+				skillRepo: &stubSkillRepo{
+					selectByID: func(ctx context.Context, tx *sql.Tx, skillID string) (*model.SkillRepositoryDB, error) {
+						return validRepo, nil
+					},
+				},
+				fileRepo:              mockFileRepo,
+				assetStore:            mocks.NewMockskillAssetStore(ctrl),
+				AuthService:           mocks.NewMockIAuthorizationService(ctrl),
+				BusinessDomainService: mocks.NewMockIBusinessDomainService(ctrl),
+				Logger:                logger.DefaultLogger(),
+			}
+
+			mockFileRepo.EXPECT().SelectSkillFileByPath(gomock.Any(), gomock.Nil(), "skill-1", "v1", "missing.py").
+				Return(nil, nil)
+
+			resp, err := reader.ReadManagementFile(context.Background(), &interfaces.ReadManagementFileReq{
+				BusinessDomainID: "bd-1",
+				SkillID:          "skill-1",
+				RelPath:          "missing.py",
+			})
+
+			So(resp, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+			httpErr, ok := err.(*errors.HTTPError)
+			So(ok, ShouldBeTrue)
+			So(httpErr.HTTPCode, ShouldEqual, http.StatusNotFound)
+		})
+	})
+}
+
+// stubSkillRepo provides a minimal ISkillRepository stub for testing
+type stubSkillRepo struct {
+	model.ISkillRepository
+	selectByID func(ctx context.Context, tx *sql.Tx, skillID string) (*model.SkillRepositoryDB, error)
+}
+
+func (s *stubSkillRepo) SelectSkillByID(ctx context.Context, tx *sql.Tx, skillID string) (*model.SkillRepositoryDB, error) {
+	if s.selectByID != nil {
+		return s.selectByID(ctx, tx, skillID)
+	}
+	return nil, nil
+}
+
+func TestDetectSkillFileType(t *testing.T) {
+	Convey("detectSkillFileType", t, func() {
+		Convey("zip registration with multiple files in manifest", func() {
+			ft := detectSkillFileType(&model.SkillRepositoryDB{
+				FileManifest: `[{"rel_path":"SKILL.md"},{"rel_path":"scripts/main.py"}]`,
+			})
+			So(ft, ShouldEqual, "zip")
+		})
+		Convey("content registration without manifest", func() {
+			ft := detectSkillFileType(&model.SkillRepositoryDB{
+				SkillContent: "body text",
+			})
+			So(ft, ShouldEqual, "content")
+		})
+		Convey("content registration with SKILL.md-only manifest (FR-5)", func() {
+			ft := detectSkillFileType(&model.SkillRepositoryDB{
+				SkillContent: "body text",
+				FileManifest: `[{"rel_path":"SKILL.md","file_type":"reference","size":42,"mime_type":"text/markdown"}]`,
+			})
+			So(ft, ShouldEqual, "content")
+		})
+		Convey("no manifest and no content defaults to content", func() {
+			ft := detectSkillFileType(&model.SkillRepositoryDB{})
+			So(ft, ShouldEqual, "content")
+		})
+	})
+}
+
+func TestBuildArchiveFromFiles(t *testing.T) {
+	Convey("buildArchiveFromFiles", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		Convey("builds ZIP from files successfully", func() {
+			mockAssetStore := mocks.NewMockskillAssetStore(ctrl)
+			skill := &model.SkillRepositoryDB{
+				SkillID: "skill-1",
+				Name:    "test-skill",
+				Version: "v1",
+			}
+			files := []*model.SkillFileIndexDB{
+				{
+					RelPath:    "SKILL.md",
+					StorageKey: "key/skill-1/v1/SKILL.md",
+				},
+			}
+
+			mockAssetStore.EXPECT().Download(gomock.Any(), gomock.Any()).
+				Return([]byte("skill content"), nil)
+
+			resultSkill, zipName, content, err := buildArchiveFromFiles(context.Background(), mockAssetStore, skill, files)
+			So(err, ShouldBeNil)
+			So(resultSkill, ShouldEqual, skill)
+			So(zipName, ShouldEqual, "test-skill.zip")
+			So(len(content), ShouldBeGreaterThan, 0)
+		})
+
+		Convey("returns error when OSS download fails", func() {
+			mockAssetStore := mocks.NewMockskillAssetStore(ctrl)
+			skill := &model.SkillRepositoryDB{
+				SkillID: "skill-1", Name: "test-skill", Version: "v1",
+			}
+			files := []*model.SkillFileIndexDB{
+				{RelPath: "SKILL.md", StorageKey: "key1"},
+				{RelPath: "scripts/main.py", StorageKey: "key2"},
+			}
+
+			mockAssetStore.EXPECT().Download(gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("oss download failed"))
+
+			resultSkill, zipName, content, err := buildArchiveFromFiles(context.Background(), mockAssetStore, skill, files)
+			So(err, ShouldNotBeNil)
+			So(resultSkill, ShouldBeNil)
+			So(zipName, ShouldEqual, "")
+			So(content, ShouldBeNil)
+		})
+	})
+}

--- a/adp/execution-factory/operator-integration/server/logics/skill/mgmt_reader_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/mgmt_reader_test.go
@@ -307,8 +307,6 @@ func TestSkillManagementReader(t *testing.T) {
 					SkillID: "skill-1", SkillVersion: "v1", RelPath: SkillMD,
 					StorageKey: testBuildObjectKey("skill-1", "v1", SkillMD),
 				}, nil)
-			mockAssetStore.EXPECT().GetDownloadURL(gomock.Any(), gomock.Any()).
-				Return("https://download/skill-1/SKILL.md", nil)
 			mockAssetStore.EXPECT().Download(gomock.Any(), gomock.Any()).
 				Return([]byte("# SKILL.md from OSS"), nil)
 
@@ -320,7 +318,7 @@ func TestSkillManagementReader(t *testing.T) {
 
 			So(err, ShouldBeNil)
 			So(resp, ShouldNotBeNil)
-			So(resp.URL, ShouldEqual, "https://download/skill-1/SKILL.md")
+			So(resp.URL, ShouldEqual, "") // content mode: url is empty
 			So(resp.Content, ShouldEqual, "# SKILL.md from OSS")
 			So(resp.FileType, ShouldEqual, "zip")
 		})

--- a/adp/execution-factory/operator-integration/server/logics/skill/mgmt_reader_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/mgmt_reader_test.go
@@ -74,7 +74,7 @@ func TestSkillManagementReader(t *testing.T) {
 			So(len(resp.Files), ShouldEqual, 1)
 			So(resp.Files[0].RelPath, ShouldEqual, "scripts/main.py")
 			So(resp.Files[0].FileType, ShouldEqual, "script")
-			So(resp.Content, ShouldEqual, "")  // url(default) mode: content is empty
+			So(resp.Content, ShouldEqual, "") // url(default) mode: content is empty
 		})
 
 		Convey("GetManagementContent returns empty URL for content registration without OSS file", func() {
@@ -105,7 +105,7 @@ func TestSkillManagementReader(t *testing.T) {
 			resp, err := reader.GetManagementContent(context.Background(), &interfaces.GetManagementContentReq{
 				BusinessDomainID: "bd-1",
 				SkillID:          "skill-2",
-				ResponseMode:     "auto",
+				ResponseMode:     "content",
 			})
 
 			So(err, ShouldBeNil)
@@ -397,7 +397,7 @@ func TestSkillManagementReader(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(resp, ShouldNotBeNil)
 			So(resp.URL, ShouldEqual, "")
-			So(resp.Content, ShouldEqual, "")  // url mode: content is empty
+			So(resp.Content, ShouldEqual, "") // url mode: content is empty
 			So(resp.FileType, ShouldEqual, "content")
 		})
 

--- a/adp/execution-factory/operator-integration/server/logics/skill/parser.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/parser.go
@@ -53,7 +53,20 @@ func (p *skillParser) parseRegisterReq(req *interfaces.RegisterSkillReq) (skillD
 		if err != nil {
 			return nil, nil, nil, err
 		}
-		return skill, nil, nil, nil
+		// FR-5: 为 content 注册的 SKILL.md 生成 asset 和 file_summary
+		files = append(files, &interfaces.SkillFileSummary{
+			RelPath:  SkillMD,
+			FileType: detectFileType(SkillMD),
+			Size:     int64(len(content)),
+			MimeType: detectMimeType(SkillMD),
+		})
+		assets = append(assets, &skillAsset{
+			RelPath:  SkillMD,
+			FileType: detectFileType(SkillMD),
+			MimeType: detectMimeType(SkillMD),
+			Content:  []byte(content),
+		})
+		return skill, files, assets, nil
 	case "zip":
 		content, files, assets, err := p.parseSkillZip(req)
 		if err != nil {

--- a/adp/execution-factory/operator-integration/server/logics/skill/parser_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/parser_test.go
@@ -36,8 +36,11 @@ Use this skill carefully.`),
 		_, parseErr := uuid.Parse(skill.Version)
 		So(parseErr, ShouldBeNil)
 		So(skill.SkillContent, ShouldEqual, "Use this skill carefully.")
-		So(len(files), ShouldEqual, 0)
-		So(len(assets), ShouldEqual, 0)
+		// FR-5: content 注册也返回 SKILL.md 的 file 和 asset
+		So(len(files), ShouldEqual, 1)
+		So(files[0].RelPath, ShouldEqual, SkillMD)
+		So(len(assets), ShouldEqual, 1)
+		So(assets[0].RelPath, ShouldEqual, SkillMD)
 	})
 }
 

--- a/adp/execution-factory/operator-integration/server/logics/skill/reader_registry_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/reader_registry_test.go
@@ -792,11 +792,13 @@ func TestSkillReaderAndRegistry(t *testing.T) {
 			mockSkillRepo := mocks.NewMockISkillRepository(ctrl)
 			mockAuthService := mocks.NewMockIAuthorizationService(ctrl)
 			mockUserMgnt := mocks.NewMockUserManagement(ctrl)
+			mockCategoryManager := mocks.NewMockCategoryManager(ctrl)
 			registry := &skillRegistry{
-				skillRepo:   mockSkillRepo,
-				AuthService: mockAuthService,
-				UserMgnt:    mockUserMgnt,
-				Logger:      logger.DefaultLogger(),
+				skillRepo:       mockSkillRepo,
+				AuthService:     mockAuthService,
+				UserMgnt:        mockUserMgnt,
+				CategoryManager: mockCategoryManager,
+				Logger:          logger.DefaultLogger(),
 			}
 			mockSkillRepo.EXPECT().SelectSkillByID(gomock.Any(), gomock.Nil(), "skill-7").Return(&model.SkillRepositoryDB{
 				SkillID:      "skill-7",
@@ -809,6 +811,7 @@ func TestSkillReaderAndRegistry(t *testing.T) {
 			mockAuthService.EXPECT().GetAccessor(gomock.Any(), "").Return(&interfaces.AuthAccessor{ID: "viewer"}, nil)
 			mockAuthService.EXPECT().CheckViewPermission(gomock.Any(), gomock.Any(), "skill-7", interfaces.AuthResourceTypeSkill).Return(nil)
 			mockUserMgnt.EXPECT().GetUsersName(gomock.Any(), gomock.Any()).Return(map[string]string{}, nil)
+			mockCategoryManager.EXPECT().GetCategoryName(gomock.Any(), gomock.Any()).Return("").AnyTimes()
 
 			resp, err := registry.GetSkillDetail(context.Background(), &interfaces.GetSkillDetailReq{
 				BusinessDomainID: "bd-1",
@@ -829,11 +832,13 @@ func TestSkillReaderAndRegistry(t *testing.T) {
 			mockSkillRepo := mocks.NewMockISkillRepository(ctrl)
 			mockAuthService := mocks.NewMockIAuthorizationService(ctrl)
 			mockUserMgnt := mocks.NewMockUserManagement(ctrl)
+			mockCategoryManager := mocks.NewMockCategoryManager(ctrl)
 			registry := &skillRegistry{
-				skillRepo:   mockSkillRepo,
-				AuthService: mockAuthService,
-				UserMgnt:    mockUserMgnt,
-				Logger:      logger.DefaultLogger(),
+				skillRepo:       mockSkillRepo,
+				AuthService:     mockAuthService,
+				UserMgnt:        mockUserMgnt,
+				CategoryManager: mockCategoryManager,
+				Logger:          logger.DefaultLogger(),
 			}
 			mockSkillRepo.EXPECT().SelectSkillByID(gomock.Any(), gomock.Nil(), "skill-7b").Return(&model.SkillRepositoryDB{
 				SkillID: "skill-7b", Status: interfaces.BizStatusOffline.String(),
@@ -841,6 +846,7 @@ func TestSkillReaderAndRegistry(t *testing.T) {
 			mockAuthService.EXPECT().GetAccessor(gomock.Any(), "").Return(&interfaces.AuthAccessor{ID: "viewer"}, nil)
 			mockAuthService.EXPECT().CheckViewPermission(gomock.Any(), gomock.Any(), "skill-7b", interfaces.AuthResourceTypeSkill).Return(nil)
 			mockUserMgnt.EXPECT().GetUsersName(gomock.Any(), gomock.Any()).Return(map[string]string{}, nil)
+			mockCategoryManager.EXPECT().GetCategoryName(gomock.Any(), gomock.Any()).Return("").AnyTimes()
 
 			resp, err := registry.GetSkillDetail(context.Background(), &interfaces.GetSkillDetailReq{
 				BusinessDomainID: "bd-1",
@@ -1177,6 +1183,7 @@ func TestSkillReaderAndRegistry(t *testing.T) {
 		Convey("GetSkillMarketDetail checks public access and business domain visibility", func() {
 			mockAuthService := mocks.NewMockIAuthorizationService(ctrl)
 			mockUserMgnt := mocks.NewMockUserManagement(ctrl)
+			mockCategoryManager := mocks.NewMockCategoryManager(ctrl)
 			registry := &skillRegistry{
 				releaseRepo: &stubSkillReleaseRepo{
 					selectBySkillID: func(ctx context.Context, tx *sql.Tx, skillID string) (*model.SkillReleaseDB, error) {
@@ -1192,13 +1199,15 @@ func TestSkillReaderAndRegistry(t *testing.T) {
 						}, nil
 					},
 				},
-				AuthService: mockAuthService,
-				UserMgnt:    mockUserMgnt,
-				Logger:      logger.DefaultLogger(),
+				AuthService:     mockAuthService,
+				UserMgnt:        mockUserMgnt,
+				CategoryManager: mockCategoryManager,
+				Logger:          logger.DefaultLogger(),
 			}
 			mockAuthService.EXPECT().GetAccessor(gomock.Any(), "").Return(&interfaces.AuthAccessor{ID: "viewer"}, nil)
 			mockAuthService.EXPECT().CheckPublicAccessPermission(gomock.Any(), gomock.Any(), "skill-m-detail", interfaces.AuthResourceTypeSkill).Return(nil)
 			mockUserMgnt.EXPECT().GetUsersName(gomock.Any(), gomock.Any()).Return(map[string]string{}, nil)
+			mockCategoryManager.EXPECT().GetCategoryName(gomock.Any(), gomock.Any()).Return("").AnyTimes()
 
 			resp, err := registry.GetSkillMarketDetail(context.Background(), &interfaces.GetSkillMarketDetailReq{
 				BusinessDomainID: "bd-1",
@@ -1217,6 +1226,7 @@ func TestSkillReaderAndRegistry(t *testing.T) {
 		Convey("GetSkillMarketDetail prefers published release snapshot", func() {
 			mockAuthService := mocks.NewMockIAuthorizationService(ctrl)
 			mockUserMgnt := mocks.NewMockUserManagement(ctrl)
+			mockCategoryManager := mocks.NewMockCategoryManager(ctrl)
 			registry := &skillRegistry{
 				releaseRepo: &stubSkillReleaseRepo{
 					selectBySkillID: func(ctx context.Context, tx *sql.Tx, skillID string) (*model.SkillReleaseDB, error) {
@@ -1232,15 +1242,17 @@ func TestSkillReaderAndRegistry(t *testing.T) {
 						}, nil
 					},
 				},
-				AuthService: mockAuthService,
-				UserMgnt:    mockUserMgnt,
-				Logger:      logger.DefaultLogger(),
+				AuthService:     mockAuthService,
+				UserMgnt:        mockUserMgnt,
+				CategoryManager: mockCategoryManager,
+				Logger:          logger.DefaultLogger(),
 			}
 			mockAuthService.EXPECT().GetAccessor(gomock.Any(), "").Return(&interfaces.AuthAccessor{ID: "viewer"}, nil)
 			mockAuthService.EXPECT().CheckPublicAccessPermission(gomock.Any(), gomock.Any(), "skill-release-detail", interfaces.AuthResourceTypeSkill).Return(nil)
 			mockUserMgnt.EXPECT().GetUsersName(gomock.Any(), gomock.Any()).Return(map[string]string{
 				"publisher": "Publisher",
 			}, nil)
+			mockCategoryManager.EXPECT().GetCategoryName(gomock.Any(), gomock.Any()).Return("").AnyTimes()
 
 			resp, err := registry.GetSkillMarketDetail(context.Background(), &interfaces.GetSkillMarketDetailReq{
 				BusinessDomainID: "bd-1",

--- a/adp/execution-factory/operator-integration/server/logics/skill/reader_registry_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/reader_registry_test.go
@@ -370,6 +370,9 @@ func TestSkillReaderAndRegistry(t *testing.T) {
 			mockAuthService.EXPECT().CheckCreatePermission(gomock.Any(), gomock.Any(), interfaces.AuthResourceTypeSkill).Return(nil)
 			mockDBTx.EXPECT().GetTx(gomock.Any()).Return(tx, nil)
 			mockSkillRepo.EXPECT().InsertSkill(gomock.Any(), tx, gomock.Any()).Return("skill-registered", nil)
+			mockAssetStore.EXPECT().Upload(gomock.Any(), "skill-registered", gomock.Any(), "SKILL.md", gomock.Any()).
+				Return(&interfaces.OssObject{StorageID: "s1", StorageKey: "k1"}, "checksum", nil)
+			mockFileRepo.EXPECT().BatchInsertSkillFiles(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			mockBusinessDomainService.EXPECT().AssociateResource(gomock.Any(), "bd-1", "skill-registered", interfaces.AuthResourceTypeSkill).Return(nil)
 			mockAuthService.EXPECT().CreateOwnerPolicy(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
@@ -425,6 +428,8 @@ func TestSkillReaderAndRegistry(t *testing.T) {
 
 		Convey("UpdateSkillMetadata moves published draft back to editing without changing version", func() {
 			mockSkillRepo := mocks.NewMockISkillRepository(ctrl)
+			mockFileRepo := mocks.NewMockISkillFileIndex(ctrl)
+			mockAssetStore := mocks.NewMockskillAssetStore(ctrl)
 			mockDBTx := mocks.NewMockDBTx(ctrl)
 			mockAuthService := mocks.NewMockIAuthorizationService(ctrl)
 			mockCategoryManager := mocks.NewMockCategoryManager(ctrl)
@@ -432,6 +437,8 @@ func TestSkillReaderAndRegistry(t *testing.T) {
 			defer patchTxMethods()()
 			registry := &skillRegistry{
 				skillRepo:       mockSkillRepo,
+				fileRepo:        mockFileRepo,
+				assetStore:      mockAssetStore,
 				dbTx:            mockDBTx,
 				AuthService:     mockAuthService,
 				CategoryManager: mockCategoryManager,
@@ -457,6 +464,8 @@ func TestSkillReaderAndRegistry(t *testing.T) {
 					return nil
 				},
 			)
+			mockFileRepo.EXPECT().SelectSkillFileByPath(gomock.Any(), gomock.Nil(), "skill-meta-1", "v1", SkillMD).
+				Return(nil, nil)
 
 			resp, err := registry.UpdateSkillMetadata(context.Background(), &interfaces.UpdateSkillMetadataReq{
 				BusinessDomainID: "bd-1",

--- a/adp/execution-factory/operator-integration/server/logics/skill/registry.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/registry.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/logics/sandbox"
 	"github.com/kweaver-ai/adp/execution-factory/operator-integration/server/utils"
 	o11y "github.com/kweaver-ai/kweaver-go-lib/observability"
+	"gopkg.in/yaml.v3"
 )
 
 type skillRegistry struct {
@@ -204,6 +205,11 @@ func (r *skillRegistry) UpdateSkillMetadata(ctx context.Context, req *interfaces
 			fmt.Sprintf(" %s category not found", req.Category))
 	}
 
+	// FR-6: 判断元数据是否有变更，决定是否需要重写 OSS SKILL.md
+	nameChanged := req.Name != skill.Name
+	descChanged := req.Description != skill.Description
+	needsRewrite := nameChanged || descChanged
+
 	tx, err := r.dbTx.GetTx(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("get tx failed: %w", err)
@@ -217,6 +223,12 @@ func (r *skillRegistry) UpdateSkillMetadata(ctx context.Context, req *interfaces
 			commitErr := tx.Commit()
 			if commitErr != nil {
 				r.Logger.WithContext(ctx).Errorf("commit skill metadata update failed, skill_id=%s, err=%v", req.SkillID, commitErr)
+			}
+			// FR-6: 事务提交成功后，重写 OSS SKILL.md 的 frontmatter
+			if needsRewrite {
+				if rewriteErr := r.rewriteSkillMDFrontmatter(ctx, skill.SkillID, skill.Version, req.Name, req.Description); rewriteErr != nil {
+					r.Logger.WithContext(ctx).Errorf("rewrite SKILL.md frontmatter failed, skill_id=%s, err=%v", skill.SkillID, rewriteErr)
+				}
 			}
 		}
 	}()
@@ -1468,4 +1480,66 @@ func (r *skillRegistry) deletePublishedSkillSnapshot(ctx context.Context, tx *sq
 		return err
 	}
 	return nil
+}
+
+// ========== FR-6: OSS SKILL.md Frontmatter Rewrite ==========
+
+// rewriteSkillMDFrontmatter 重写 OSS 中 SKILL.md 的 name/description
+// 在 UpdateSkillMetadata 事务提交成功后调用
+// 失败只记录日志，不阻塞主流程
+func (r *skillRegistry) rewriteSkillMDFrontmatter(ctx context.Context, skillID, version, newName, newDesc string) error {
+	skillFile, err := r.fileRepo.SelectSkillFileByPath(ctx, nil, skillID, version, SkillMD)
+	if err != nil {
+		return fmt.Errorf("query SKILL.md file_index failed: %w", err)
+	}
+	if skillFile == nil {
+		return fmt.Errorf("SKILL.md not found in file_index: skill_id=%s, version=%s", skillID, version)
+	}
+
+	content, err := r.assetStore.Download(ctx, &interfaces.OssObject{
+		StorageID:  skillFile.StorageID,
+		StorageKey: skillFile.StorageKey,
+	})
+	if err != nil {
+		return fmt.Errorf("download SKILL.md from OSS failed: %w", err)
+	}
+
+	newContent, err := updateFrontmatterNameDesc(string(content), newName, newDesc)
+	if err != nil {
+		return fmt.Errorf("update SKILL.md frontmatter failed: %w", err)
+	}
+
+	_, _, err = r.assetStore.Upload(ctx, skillID, version, SkillMD, []byte(newContent))
+	if err != nil {
+		return fmt.Errorf("upload rewritten SKILL.md to OSS failed: %w", err)
+	}
+	return nil
+}
+
+// updateFrontmatterNameDesc 只替换 YAML frontmatter 中的 name 和 description
+// 其余所有自定义字段保持不动
+func updateFrontmatterNameDesc(rawMD, newName, newDesc string) (string, error) {
+	parts := strings.SplitN(rawMD, "---", 3)
+	if len(parts) < 3 {
+		return "", fmt.Errorf("invalid SKILL.md format: missing frontmatter")
+	}
+
+	frontmatter := make(map[string]interface{})
+	if err := yaml.Unmarshal([]byte(parts[1]), &frontmatter); err != nil {
+		return "", fmt.Errorf("failed to unmarshal frontmatter: %w", err)
+	}
+
+	if newName != "" {
+		frontmatter["name"] = newName
+	}
+	if newDesc != "" {
+		frontmatter["description"] = newDesc
+	}
+
+	newFrontmatter, err := yaml.Marshal(frontmatter)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal frontmatter: %w", err)
+	}
+
+	return "---\n" + string(newFrontmatter) + "---\n" + strings.TrimPrefix(parts[2], "\n"), nil
 }

--- a/adp/execution-factory/operator-integration/server/logics/skill/registry.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/registry.go
@@ -973,7 +973,7 @@ func (r *skillRegistry) assembleMarketSkillInfoList(ctx context.Context, release
 	var userIDs []string
 	skillInfos = []*interfaces.SkillInfo{}
 	for _, relese := range releaseDB {
-		skillInfos = append(skillInfos, convertSkillMarketDetail(relese))
+		skillInfos = append(skillInfos, convertSkillMarketDetail(relese, r.CategoryManager.GetCategoryName(ctx, interfaces.BizCategory(relese.Category))))
 		userIDs = append(userIDs, relese.CreateUser, relese.UpdateUser, relese.ReleaseUser)
 	}
 	// 获取用户名称
@@ -987,7 +987,6 @@ func (r *skillRegistry) assembleMarketSkillInfoList(ctx context.Context, release
 		skill.UpdateUser = utils.GetValueOrDefault(userMap, skill.UpdateUser, interfaces.UnknownUser)
 		skill.ReleaseUser = utils.GetValueOrDefault(userMap, skill.ReleaseUser, interfaces.UnknownUser)
 		skill.BusinessDomainID = utils.GetValueOrDefault(resourceToBdMap, skill.SkillID, businessDomainIDStr)
-		skill.CategoryName = r.CategoryManager.GetCategoryName(ctx, skill.Category)
 	}
 	return
 }
@@ -997,7 +996,7 @@ func (r *skillRegistry) assembleSkillInfoList(ctx context.Context, skillDBs []*m
 	var userIDs []string
 	skillInfos = []*interfaces.SkillInfo{}
 	for _, skill := range skillDBs {
-		skillInfos = append(skillInfos, convertSkillDetail(skill))
+		skillInfos = append(skillInfos, convertSkillDetail(skill, r.CategoryManager.GetCategoryName(ctx, interfaces.BizCategory(skill.Category))))
 		userIDs = append(userIDs, skill.CreateUser, skill.UpdateUser)
 	}
 	// 获取用户名称
@@ -1010,7 +1009,6 @@ func (r *skillRegistry) assembleSkillInfoList(ctx context.Context, skillDBs []*m
 		skill.CreateUser = utils.GetValueOrDefault(userMap, skill.CreateUser, interfaces.UnknownUser)
 		skill.UpdateUser = utils.GetValueOrDefault(userMap, skill.UpdateUser, interfaces.UnknownUser)
 		skill.BusinessDomainID = utils.GetValueOrDefault(resourceToBdMap, skill.SkillID, businessDomainIDStr)
-		skill.CategoryName = r.CategoryManager.GetCategoryName(ctx, skill.Category)
 	}
 	return
 }
@@ -1289,7 +1287,7 @@ func (r *skillRegistry) GetSkillMarketDetail(ctx context.Context, req *interface
 		err = errors.DefaultHTTPError(ctx, http.StatusNotFound, fmt.Sprintf("skill not found: %s", req.SkillID))
 		return nil, err
 	}
-	skillInfo := convertSkillMarketDetail(release)
+	skillInfo := convertSkillMarketDetail(release, r.CategoryManager.GetCategoryName(ctx, interfaces.BizCategory(release.Category)))
 	userNames, err := r.UserMgnt.GetUsersName(ctx, []string{release.CreateUser, release.UpdateUser, release.ReleaseUser})
 	if err != nil {
 		return nil, err
@@ -1324,7 +1322,7 @@ func (r *skillRegistry) GetSkillDetail(ctx context.Context, req *interfaces.GetS
 	if skill == nil || skill.IsDeleted {
 		return nil, fmt.Errorf("skill not found: %s", req.SkillID)
 	}
-	skillInfo := convertSkillDetail(skill)
+	skillInfo := convertSkillDetail(skill, r.CategoryManager.GetCategoryName(ctx, interfaces.BizCategory(skill.Category)))
 	// 获取用户信息
 	userNames, err := r.UserMgnt.GetUsersName(ctx, []string{skill.CreateUser, skill.UpdateUser})
 	if err != nil {
@@ -1335,12 +1333,14 @@ func (r *skillRegistry) GetSkillDetail(ctx context.Context, req *interfaces.GetS
 	return skillInfo, nil
 }
 
-func convertSkillDetail(skill *model.SkillRepositoryDB) *interfaces.SkillInfo {
+func convertSkillDetail(skill *model.SkillRepositoryDB, categoryName string) *interfaces.SkillInfo {
 	return &interfaces.SkillInfo{
 		SkillID:      skill.SkillID,
 		Name:         skill.Name,
 		Description:  skill.Description,
 		Version:      skill.Version,
+		Category:     interfaces.BizCategory(skill.Category),
+		CategoryName: categoryName,
 		Status:       interfaces.BizStatus(skill.Status),
 		Source:       skill.Source,
 		Dependencies: utils.JSONToObject[map[string]interface{}](skill.Dependencies),
@@ -1352,12 +1352,14 @@ func convertSkillDetail(skill *model.SkillRepositoryDB) *interfaces.SkillInfo {
 	}
 }
 
-func convertSkillMarketDetail(skill *model.SkillReleaseDB) *interfaces.SkillInfo {
+func convertSkillMarketDetail(skill *model.SkillReleaseDB, categoryName string) *interfaces.SkillInfo {
 	return &interfaces.SkillInfo{
 		SkillID:      skill.SkillID,
 		Name:         skill.Name,
 		Description:  skill.Description,
 		Version:      skill.Version,
+		Category:     interfaces.BizCategory(skill.Category),
+		CategoryName: categoryName,
 		Status:       interfaces.BizStatus(skill.Status),
 		Source:       skill.Source,
 		Dependencies: utils.JSONToObject[map[string]interface{}](skill.Dependencies),

--- a/adp/execution-factory/operator-integration/server/logics/skill/registry.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/registry.go
@@ -195,11 +195,6 @@ func (r *skillRegistry) UpdateSkillMetadata(ctx context.Context, req *interfaces
 	if err = r.AuthService.CheckModifyPermission(ctx, accessor, req.SkillID, interfaces.AuthResourceTypeSkill); err != nil {
 		return nil, err
 	}
-	if req.Name != skill.Name {
-		if err = r.checkSkillDuplicateName(ctx, req.Name, req.SkillID); err != nil {
-			return nil, err
-		}
-	}
 	if req.Category != "" && !r.CategoryManager.CheckCategory(req.Category) {
 		return nil, errors.NewHTTPError(ctx, http.StatusBadRequest, errors.ErrExtSkillCategoryNotFound,
 			fmt.Sprintf(" %s category not found", req.Category))
@@ -292,11 +287,6 @@ func (r *skillRegistry) UpdateSkillPackage(ctx context.Context, req *interfaces.
 	})
 	if err != nil {
 		return nil, err
-	}
-	if parsedSkill.Name != skill.Name {
-		if err = r.checkSkillDuplicateName(ctx, parsedSkill.Name, req.SkillID); err != nil {
-			return nil, err
-		}
 	}
 	replaceCurrentVersion := skill.Status == interfaces.BizStatusEditing.String() ||
 		skill.Status == interfaces.BizStatusUnpublish.String()


### PR DESCRIPTION
## Summary

实现 Skill Content Management Read 功能，支持管理态 SKILL.md 内容读取、URL/Content 响应模式切换及 OSS 同步。

### 主要变更

- **管理态读取接口**: GetManagementContent / ReadManagementFile / DownloadManagementSkill
- **响应模式**: url（默认返回 OSS 预签名 URL） / content（直接返回文件内容），两者互斥
- **OSS 同步**: 注册/更新时自动同步 SKILL.md 到 OSS
- **分类字段修复**: 详情接口补充 category / category_name 字段映射
- **重名校验规则**: 仅在发布时校验名称唯一性，编辑态不再拦截
- **API 文档**: 补充 public/private API 定义

### 修复

- Secret 独立挂载路径，修复 Pod 启动失败
- ResponseMode url/content 互斥，移除 auto 模式
- 详情接口返回分类为空的问题

## Test plan

- [x] 单元测试通过
- [x] ResponseMode url/content 互斥覆盖测试
- [x] 管理态内容读取覆盖测试
- [x] 重名校验规则调整后测试