### PR TITLE
refactor(resource_data_service): 统一查询参数准备流程

### DIFF
--- a/adp/vega/vega-backend/server/logics/resource_data/resource_data_service.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/resource_data_service.go
@@ -191,6 +191,9 @@ func (rds *resourceDataService) Query(ctx context.Context, resource *interfaces.
 	case interfaces.ResourceCategoryLogicView:
 		// 准备 sort参数
 		params = rds.prepareSortParams(resource, params)
+		// 准备 output
+		params = rds.prepareOutputFieldsParams(resource, params)
+
 		// 逻辑视图查询数据
 		data, total, err := rds.lvs.Query(ctx, resource, params)
 		if err != nil {
@@ -203,6 +206,11 @@ func (rds *resourceDataService) Query(ctx context.Context, resource *interfaces.
 		return data, total, nil
 
 	case interfaces.ResourceCategoryFileset:
+		// 准备 sort参数
+		params = rds.prepareSortParams(resource, params)
+		// 准备 output
+		params = rds.prepareOutputFieldsParams(resource, params)
+
 		data, total, err := rds.QueryData(ctx, catalog, resource, params)
 		if err != nil {
 			otellog.LogError(ctx, "Query fileset data failed", err)


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] 在逻辑视图查询路径中补充 `prepareOutputFieldsParams` 调用，确保输出字段参数在查询前完成准备
- [x] 在文件集查询路径中统一补充 `prepareSortParams` 和 `prepareOutputFieldsParams` 调用
- [x] 调整排序参数处理位置，让逻辑视图和文件集查询前的参数准备流程保持一致

---

## Why

- Related Issue: #439
- Related Feature: 资源数据查询
- Background: 逻辑视图和文件集查询都依赖统一的查询参数准备逻辑；补齐输出字段和排序参数处理后，可以避免不同资源类型在查询行为上出现不一致。

---

## How

- Key implementation points:
  - 在 `resourceDataService.Query` 的 `ResourceCategoryLogicView` 分支中，于查询前调用 `prepareOutputFieldsParams`
  - 在 `ResourceCategoryFileset` 分支中，于 `QueryData` 前调用 `prepareSortParams` 和 `prepareOutputFieldsParams`
- Breaking changes (API, config, database, etc.): 无

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `go test ./adp/vega/vega-backend/server/logics/resource_data`

---

## Risk & Rollback

- Potential risks: 查询参数准备顺序变化可能影响依赖原始参数透传的边界场景，需要关注逻辑视图和文件集的排序、输出字段组合查询。
- Rollback plan: 回滚本 PR 中对 `resource_data_service.go` 的参数准备调用调整即可恢复旧行为。

---

## Additional Notes

- 本 PR 仅修改 `adp/vega/vega-backend/server/logics/resource_data/resource_data_service.go`。
