### PR TITLE
refactor(driveradapters): 统一链路追踪与查询参数校验

### DIFF
--- a/adp/vega/vega-backend/server/driveradapters/build_task_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/build_task_handler.go
@@ -17,7 +17,6 @@ import (
 	"github.com/kweaver-ai/kweaver-go-lib/logger"
 	"github.com/kweaver-ai/kweaver-go-lib/otel/oteltrace"
 	"github.com/kweaver-ai/kweaver-go-lib/rest"
-	"go.opentelemetry.io/otel/trace"
 
 	"vega-backend/common/visitor"
 	verrors "vega-backend/errors"
@@ -37,26 +36,23 @@ type buildTaskListQuery struct {
 
 // CreateBuildTaskByEx handles POST /api/vega-backend/v1/build-tasks (External).
 func (r *restHandler) CreateBuildTaskByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.createBuildTask(c, ctx, span, visitor)
+	r.createBuildTask(c, visitor)
 }
 
 // CreateBuildTaskByIn handles POST /api/vega-backend/in/v1/build-tasks (Internal).
 func (r *restHandler) CreateBuildTaskByIn(c *gin.Context) {
+	visitor := visitor.GenerateVisitor(c)
+	r.createBuildTask(c, visitor)
+}
+
+func (r *restHandler) createBuildTask(c *gin.Context, visitor hydra.Visitor) {
 	ctx, span := oteltrace.StartServerSpan(c)
 	defer span.End()
 
-	visitor := visitor.GenerateVisitor(c)
-	r.createBuildTask(c, ctx, span, visitor)
-}
-
-func (r *restHandler) createBuildTask(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
 	accountInfo := interfaces.AccountInfo{
 		ID:   visitor.ID,
 		Type: string(visitor.Type),
@@ -141,25 +137,22 @@ func (r *restHandler) createBuildTask(c *gin.Context, ctx context.Context, span 
 // =========================== GET /build-tasks/:id ===========================
 
 func (r *restHandler) GetBuildTaskByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.getBuildTask(c, ctx, span, visitor)
+	r.getBuildTask(c, visitor)
 }
 
 func (r *restHandler) GetBuildTaskByIn(c *gin.Context) {
+	visitor := visitor.GenerateVisitor(c)
+	r.getBuildTask(c, visitor)
+}
+
+func (r *restHandler) getBuildTask(c *gin.Context, visitor hydra.Visitor) {
 	ctx, span := oteltrace.StartServerSpan(c)
 	defer span.End()
 
-	visitor := visitor.GenerateVisitor(c)
-	r.getBuildTask(c, ctx, span, visitor)
-}
-
-func (r *restHandler) getBuildTask(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
 	accountInfo := interfaces.AccountInfo{
 		ID:   visitor.ID,
 		Type: string(visitor.Type),
@@ -183,25 +176,22 @@ func (r *restHandler) getBuildTask(c *gin.Context, ctx context.Context, span tra
 // =========================== GET /build-tasks ===========================
 
 func (r *restHandler) ListBuildTasksByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.listBuildTasks(c, ctx, span, visitor)
+	r.listBuildTasks(c, visitor)
 }
 
 func (r *restHandler) ListBuildTasksByIn(c *gin.Context) {
+	visitor := visitor.GenerateVisitor(c)
+	r.listBuildTasks(c, visitor)
+}
+
+func (r *restHandler) listBuildTasks(c *gin.Context, visitor hydra.Visitor) {
 	ctx, span := oteltrace.StartServerSpan(c)
 	defer span.End()
 
-	visitor := visitor.GenerateVisitor(c)
-	r.listBuildTasks(c, ctx, span, visitor)
-}
-
-func (r *restHandler) listBuildTasks(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
 	accountInfo := interfaces.AccountInfo{
 		ID:   visitor.ID,
 		Type: string(visitor.Type),
@@ -268,25 +258,22 @@ func (r *restHandler) listBuildTasks(c *gin.Context, ctx context.Context, span t
 // DeleteBuildTasksByEx handles DELETE /build-tasks/:ids (External).
 // `ids` is a comma-separated list. Optional query: ?ignore_missing=true
 func (r *restHandler) DeleteBuildTasksByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.deleteBuildTasks(c, ctx, span, visitor)
+	r.deleteBuildTasks(c, visitor)
 }
 
 func (r *restHandler) DeleteBuildTasksByIn(c *gin.Context) {
+	visitor := visitor.GenerateVisitor(c)
+	r.deleteBuildTasks(c, visitor)
+}
+
+func (r *restHandler) deleteBuildTasks(c *gin.Context, visitor hydra.Visitor) {
 	ctx, span := oteltrace.StartServerSpan(c)
 	defer span.End()
 
-	visitor := visitor.GenerateVisitor(c)
-	r.deleteBuildTasks(c, ctx, span, visitor)
-}
-
-func (r *restHandler) deleteBuildTasks(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
 	accountInfo := interfaces.AccountInfo{
 		ID:   visitor.ID,
 		Type: string(visitor.Type),
@@ -331,25 +318,22 @@ func (r *restHandler) deleteBuildTasks(c *gin.Context, ctx context.Context, span
 // =========================== POST /build-tasks/:id/start ===========================
 
 func (r *restHandler) StartBuildTaskByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.startBuildTask(c, ctx, span, visitor)
+	r.startBuildTask(c, visitor)
 }
 
 func (r *restHandler) StartBuildTaskByIn(c *gin.Context) {
+	visitor := visitor.GenerateVisitor(c)
+	r.startBuildTask(c, visitor)
+}
+
+func (r *restHandler) startBuildTask(c *gin.Context, visitor hydra.Visitor) {
 	ctx, span := oteltrace.StartServerSpan(c)
 	defer span.End()
 
-	visitor := visitor.GenerateVisitor(c)
-	r.startBuildTask(c, ctx, span, visitor)
-}
-
-func (r *restHandler) startBuildTask(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
 	accountInfo := interfaces.AccountInfo{
 		ID:   visitor.ID,
 		Type: string(visitor.Type),
@@ -380,25 +364,22 @@ func (r *restHandler) startBuildTask(c *gin.Context, ctx context.Context, span t
 // =========================== POST /build-tasks/:id/stop ===========================
 
 func (r *restHandler) StopBuildTaskByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.stopBuildTask(c, ctx, span, visitor)
+	r.stopBuildTask(c, visitor)
 }
 
 func (r *restHandler) StopBuildTaskByIn(c *gin.Context) {
+	visitor := visitor.GenerateVisitor(c)
+	r.stopBuildTask(c, visitor)
+}
+
+func (r *restHandler) stopBuildTask(c *gin.Context, visitor hydra.Visitor) {
 	ctx, span := oteltrace.StartServerSpan(c)
 	defer span.End()
 
-	visitor := visitor.GenerateVisitor(c)
-	r.stopBuildTask(c, ctx, span, visitor)
-}
-
-func (r *restHandler) stopBuildTask(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
 	accountInfo := interfaces.AccountInfo{
 		ID:   visitor.ID,
 		Type: string(visitor.Type),

--- a/adp/vega/vega-backend/server/driveradapters/catalog_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/catalog_handler.go
@@ -23,11 +23,9 @@ import (
 	"github.com/kweaver-ai/kweaver-go-lib/otel/oteltrace"
 	"github.com/kweaver-ai/kweaver-go-lib/rest"
 	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/trace"
 
 	verrors "vega-backend/errors"
 	"vega-backend/interfaces"
-	"vega-backend/logics/extensions"
 )
 
 // Helper function to validate strategies array
@@ -49,29 +47,26 @@ func validateStrategies(strategies []string) error {
 
 // ListCatalogsByEx handles GET /api/vega-backend/v1/catalogs (External)
 func (r *restHandler) ListCatalogsByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 外网接口：校验token
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.listCatalogs(c, ctx, span, visitor)
+	r.listCatalogs(c, visitor)
 }
 
 // ListCatalogsByIn handles GET /api/vega-backend/in/v1/catalogs (Internal)
 func (r *restHandler) ListCatalogsByIn(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 内网接口：user_id从header中取
 	visitor := visitor.GenerateVisitor(c)
-	r.listCatalogs(c, ctx, span, visitor)
+	r.listCatalogs(c, visitor)
 }
 
 // listCatalogs is the shared implementation
-func (r *restHandler) listCatalogs(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
+func (r *restHandler) listCatalogs(c *gin.Context, visitor hydra.Visitor) {
+	ctx, span := oteltrace.StartServerSpan(c)
+	defer span.End()
+
 	accountInfo := interfaces.AccountInfo{
 		ID:   visitor.ID,
 		Type: string(visitor.Type),
@@ -103,14 +98,6 @@ func (r *restHandler) listCatalogs(c *gin.Context, ctx context.Context, span tra
 
 	extKeys := c.QueryArray("extension_key")
 	extVals := c.QueryArray("extension_value")
-	if err := extensions.ValidateExtensionQueryPairs(ctx, extKeys, extVals); err != nil {
-		httpErr := err.(*rest.HTTPError)
-		otellog.LogError(ctx, fmt.Sprintf("%s. %v", httpErr.BaseError.Description,
-			httpErr.BaseError.ErrorDetails), nil)
-		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
-		rest.ReplyError(c, httpErr)
-		return
-	}
 	includeExt := strings.EqualFold(strings.TrimSpace(c.Query("include_extensions")), "true")
 	includeExtKeys := strings.TrimSpace(c.Query("include_extension_keys"))
 
@@ -123,6 +110,15 @@ func (r *restHandler) listCatalogs(c *gin.Context, ctx context.Context, span tra
 		ExtensionValues:       extVals,
 		IncludeExtensions:     includeExt,
 		IncludeExtensionKeys:  includeExtKeys,
+	}
+
+	if err := ValidateCatalogListQueryParams(ctx, params); err != nil {
+		httpErr := err.(*rest.HTTPError)
+		otellog.LogError(ctx, fmt.Sprintf("%s. %v", httpErr.BaseError.Description,
+			httpErr.BaseError.ErrorDetails), nil)
+		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
+		rest.ReplyError(c, httpErr)
+		return
 	}
 
 	entries, total, err := r.cs.List(ctx, params)
@@ -147,29 +143,26 @@ func (r *restHandler) listCatalogs(c *gin.Context, ctx context.Context, span tra
 
 // CreateCatalogByEx handles POST /api/vega-backend/v1/catalogs (External)
 func (r *restHandler) CreateCatalogByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 外网接口：校验token
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.createCatalog(c, ctx, span, visitor)
+	r.createCatalog(c, visitor)
 }
 
 // CreateCatalogByIn handles POST /api/vega-backend/in/v1/catalogs (Internal)
 func (r *restHandler) CreateCatalogByIn(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 内网接口：user_id从header中取
 	visitor := visitor.GenerateVisitor(c)
-	r.createCatalog(c, ctx, span, visitor)
+	r.createCatalog(c, visitor)
 }
 
 // createCatalog is the shared implementation
-func (r *restHandler) createCatalog(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
+func (r *restHandler) createCatalog(c *gin.Context, visitor hydra.Visitor) {
+	ctx, span := oteltrace.StartServerSpan(c)
+	defer span.End()
+
 	accountInfo := interfaces.AccountInfo{
 		ID:   visitor.ID,
 		Type: string(visitor.Type),
@@ -252,29 +245,26 @@ func (r *restHandler) createCatalog(c *gin.Context, ctx context.Context, span tr
 
 // GetCatalogsByEx handles GET /api/vega-backend/v1/catalogs/:ids (External)
 func (r *restHandler) GetCatalogsByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 外网接口：校验token
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.getCatalogs(c, ctx, span, visitor)
+	r.getCatalogs(c, visitor)
 }
 
 // GetCatalogsByIn handles GET /api/vega-backend/in/v1/catalogs/:ids (Internal)
 func (r *restHandler) GetCatalogsByIn(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 内网接口：user_id从header中取
 	visitor := visitor.GenerateVisitor(c)
-	r.getCatalogs(c, ctx, span, visitor)
+	r.getCatalogs(c, visitor)
 }
 
 // getCatalogs is the shared implementation
-func (r *restHandler) getCatalogs(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
+func (r *restHandler) getCatalogs(c *gin.Context, visitor hydra.Visitor) {
+	ctx, span := oteltrace.StartServerSpan(c)
+	defer span.End()
+
 	accountInfo := interfaces.AccountInfo{
 		ID:   visitor.ID,
 		Type: string(visitor.Type),
@@ -323,29 +313,26 @@ func (r *restHandler) getCatalogs(c *gin.Context, ctx context.Context, span trac
 
 // UpdateCatalogByEx handles PUT /api/vega-backend/v1/catalogs/:id (External)
 func (r *restHandler) UpdateCatalogByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 外网接口：校验token
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.updateCatalog(c, ctx, span, visitor)
+	r.updateCatalog(c, visitor)
 }
 
 // UpdateCatalogByIn handles PUT /api/vega-backend/in/v1/catalogs/:id (Internal)
 func (r *restHandler) UpdateCatalogByIn(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 内网接口：user_id从header中取
 	visitor := visitor.GenerateVisitor(c)
-	r.updateCatalog(c, ctx, span, visitor)
+	r.updateCatalog(c, visitor)
 }
 
 // updateCatalog is the shared implementation
-func (r *restHandler) updateCatalog(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
+func (r *restHandler) updateCatalog(c *gin.Context, visitor hydra.Visitor) {
+	ctx, span := oteltrace.StartServerSpan(c)
+	defer span.End()
+
 	accountInfo := interfaces.AccountInfo{
 		ID:   visitor.ID,
 		Type: string(visitor.Type),
@@ -487,29 +474,26 @@ func (r *restHandler) updateCatalog(c *gin.Context, ctx context.Context, span tr
 
 // DeleteCatalogsByEx handles DELETE /api/vega-backend/v1/catalogs/:ids (External)
 func (r *restHandler) DeleteCatalogsByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 外网接口：校验token
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.deleteCatalogs(c, ctx, span, visitor)
+	r.deleteCatalogs(c, visitor)
 }
 
 // DeleteCatalogsByIn handles DELETE /api/vega-backend/in/v1/catalogs/:ids (Internal)
 func (r *restHandler) DeleteCatalogsByIn(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 内网接口：user_id从header中取
 	visitor := visitor.GenerateVisitor(c)
-	r.deleteCatalogs(c, ctx, span, visitor)
+	r.deleteCatalogs(c, visitor)
 }
 
 // deleteCatalogs is the shared implementation
-func (r *restHandler) deleteCatalogs(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
+func (r *restHandler) deleteCatalogs(c *gin.Context, visitor hydra.Visitor) {
+	ctx, span := oteltrace.StartServerSpan(c)
+	defer span.End()
+
 	accountInfo := interfaces.AccountInfo{
 		ID:   visitor.ID,
 		Type: string(visitor.Type),
@@ -592,29 +576,26 @@ func (r *restHandler) deleteCatalogs(c *gin.Context, ctx context.Context, span t
 
 // GetCatalogHealthStatusByEx handles GET /api/vega-backend/v1/catalogs/:id/health-status (External)
 func (r *restHandler) GetCatalogHealthStatusByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 外网接口：校验token
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.getCatalogHealthStatus(c, ctx, span, visitor)
+	r.getCatalogHealthStatus(c, visitor)
 }
 
 // GetCatalogHealthStatusByIn handles GET /api/vega-backend/in/v1/catalogs/:id/health-status (Internal)
 func (r *restHandler) GetCatalogHealthStatusByIn(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 内网接口：user_id从header中取
 	visitor := visitor.GenerateVisitor(c)
-	r.getCatalogHealthStatus(c, ctx, span, visitor)
+	r.getCatalogHealthStatus(c, visitor)
 }
 
 // getCatalogHealthStatus is the shared implementation
-func (r *restHandler) getCatalogHealthStatus(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
+func (r *restHandler) getCatalogHealthStatus(c *gin.Context, visitor hydra.Visitor) {
+	ctx, span := oteltrace.StartServerSpan(c)
+	defer span.End()
+
 	accountInfo := interfaces.AccountInfo{
 		ID:   visitor.ID,
 		Type: string(visitor.Type),
@@ -649,29 +630,26 @@ func (r *restHandler) getCatalogHealthStatus(c *gin.Context, ctx context.Context
 
 // TestConnectionByEx handles POST /api/vega-backend/v1/catalogs/:id/test-connection (External)
 func (r *restHandler) TestConnectionByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 外网接口：校验token
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.testConnection(c, ctx, span, visitor)
+	r.testConnection(c, visitor)
 }
 
 // TestConnectionByIn handles POST /api/vega-backend/in/v1/catalogs/:id/test-connection (Internal)
 func (r *restHandler) TestConnectionByIn(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 内网接口：user_id从header中取
 	visitor := visitor.GenerateVisitor(c)
-	r.testConnection(c, ctx, span, visitor)
+	r.testConnection(c, visitor)
 }
 
 // testConnection is the shared implementation
-func (r *restHandler) testConnection(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
+func (r *restHandler) testConnection(c *gin.Context, visitor hydra.Visitor) {
+	ctx, span := oteltrace.StartServerSpan(c)
+	defer span.End()
+
 	accountInfo := interfaces.AccountInfo{
 		ID:   visitor.ID,
 		Type: string(visitor.Type),
@@ -715,29 +693,26 @@ func (r *restHandler) testConnection(c *gin.Context, ctx context.Context, span t
 
 // DiscoverCatalogResourcesByEx handles POST /api/vega-backend/v1/catalogs/:id/discover (External)
 func (r *restHandler) DiscoverCatalogResourcesByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 外网接口：校验token
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.discoverCatalogResources(c, ctx, span, visitor)
+	r.discoverCatalogResources(c, visitor)
 }
 
 // DiscoverCatalogResourcesByIn handles POST /api/vega-backend/in/v1/catalogs/:id/discover (Internal)
 func (r *restHandler) DiscoverCatalogResourcesByIn(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 内网接口：user_id从header中取
 	visitor := visitor.GenerateVisitor(c)
-	r.discoverCatalogResources(c, ctx, span, visitor)
+	r.discoverCatalogResources(c, visitor)
 }
 
 // discoverCatalogResources is the shared implementation
-func (r *restHandler) discoverCatalogResources(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
+func (r *restHandler) discoverCatalogResources(c *gin.Context, visitor hydra.Visitor) {
+	ctx, span := oteltrace.StartServerSpan(c)
+	defer span.End()
+
 	accountInfo := interfaces.AccountInfo{
 		ID:   visitor.ID,
 		Type: string(visitor.Type),
@@ -786,19 +761,19 @@ func (r *restHandler) discoverCatalogResources(c *gin.Context, ctx context.Conte
 
 // ListCatalogSrcsByEx catalog resource list (External)
 func (r *restHandler) ListCatalogSrcsByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 外网接口：校验token
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.listCatalogSrcs(c, ctx, span, visitor)
+	r.listCatalogSrcs(c, visitor)
 }
 
 // listCatalogSrcs is the shared implementation
-func (r *restHandler) listCatalogSrcs(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
+func (r *restHandler) listCatalogSrcs(c *gin.Context, visitor hydra.Visitor) {
+	ctx, span := oteltrace.StartServerSpan(c)
+	defer span.End()
+
 	accountInfo := interfaces.AccountInfo{
 		ID:   visitor.ID,
 		Type: string(visitor.Type),

--- a/adp/vega/vega-backend/server/driveradapters/catalog_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/catalog_handler_test.go
@@ -1,0 +1,75 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package driveradapters
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+
+	"vega-backend/common"
+	"vega-backend/interfaces"
+	vmock "vega-backend/interfaces/mock"
+)
+
+func Test_CatalogRestHandler_ListCatalogs(t *testing.T) {
+	Convey("Test CatalogHandler ListCatalogs\n", t, func() {
+		test := setGinMode()
+		defer test()
+
+		engine := gin.New()
+		engine.Use(gin.Recovery())
+
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		cs := vmock.NewMockCatalogService(mockCtrl)
+		handler := MockNewRestHandler(&common.AppSetting{}, nil, cs, nil, nil, nil, nil, nil, nil, nil, nil)
+		handler.RegisterPublic(engine)
+
+		url := "/api/vega-backend/in/v1/catalogs"
+
+		Convey("Invalid type\n", func() {
+			req := httptest.NewRequest(http.MethodGet, url+"?type=unknown", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+			So(w.Body.String(), ShouldContainSubstring, "VegaBackend.Catalog.InvalidParameter.Type")
+			So(w.Body.String(), ShouldContainSubstring, "invalid type: unknown")
+		})
+
+		Convey("Invalid health check status\n", func() {
+			req := httptest.NewRequest(http.MethodGet, url+"?health_check_status=unknown", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+			So(w.Body.String(), ShouldContainSubstring, "VegaBackend.Catalog.InvalidParameter")
+			So(w.Body.String(), ShouldContainSubstring, "invalid health_check_status: unknown")
+		})
+
+		Convey("Success list catalogs with type and health check status\n", func() {
+			cs.EXPECT().List(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, params interfaces.CatalogsQueryParams) ([]*interfaces.Catalog, int64, error) {
+					So(params.Type, ShouldEqual, interfaces.CatalogTypePhysical)
+					So(params.HealthCheckStatus, ShouldEqual, interfaces.CatalogHealthStatusHealthy)
+					return []*interfaces.Catalog{}, int64(0), nil
+				})
+
+			req := httptest.NewRequest(http.MethodGet, url+"?type=physical&health_check_status=healthy", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusOK)
+		})
+	})
+}

--- a/adp/vega/vega-backend/server/driveradapters/connector_type_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/connector_type_handler.go
@@ -28,14 +28,14 @@ import (
 
 // ListConnectorTypes handles GET /api/vega-backend/v1/connector-types
 func (r *restHandler) ListConnectorTypes(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 校验token
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
+
+	ctx, span := oteltrace.StartServerSpan(c)
+	defer span.End()
 	accountInfo := interfaces.AccountInfo{
 		ID:   visitor.ID,
 		Type: string(visitor.Type),
@@ -49,9 +49,14 @@ func (r *restHandler) ListConnectorTypes(c *gin.Context) {
 	var enabled *bool
 	if enabledStr := c.Query("enabled"); enabledStr != "" {
 		b, err := strconv.ParseBool(enabledStr)
-		if err == nil {
-			enabled = &b
+		if err != nil {
+			httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_ConnectorType_InvalidParameter).
+				WithErrorDetails(fmt.Sprintf("invalid enabled: %s", enabledStr))
+			oteltrace.AddHttpAttrs4HttpError(span, httpErr)
+			rest.ReplyError(c, httpErr)
+			return
 		}
+		enabled = &b
 	}
 	mode := c.Query("mode")
 	category := c.Query("category")
@@ -84,6 +89,15 @@ func (r *restHandler) ListConnectorTypes(c *gin.Context) {
 		Enabled:               enabled,
 	}
 
+	if err := ValidateConnectorTypeListQueryParams(ctx, params); err != nil {
+		httpErr := err.(*rest.HTTPError)
+		otellog.LogError(ctx, fmt.Sprintf("%s. %v", httpErr.BaseError.Description,
+			httpErr.BaseError.ErrorDetails), nil)
+		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
+		rest.ReplyError(c, httpErr)
+		return
+	}
+
 	entries, total, err := r.cts.List(ctx, params)
 	if err != nil {
 		httpErr := err.(*rest.HTTPError)
@@ -104,14 +118,14 @@ func (r *restHandler) ListConnectorTypes(c *gin.Context) {
 
 // CreateConnectorType handles POST /api/vega-backend/v1/connector-types
 func (r *restHandler) RegisterConnectorType(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 校验token
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
+
+	ctx, span := oteltrace.StartServerSpan(c)
+	defer span.End()
 	accountInfo := interfaces.AccountInfo{
 		ID:   visitor.ID,
 		Type: string(visitor.Type),
@@ -173,14 +187,14 @@ func (r *restHandler) RegisterConnectorType(c *gin.Context) {
 
 // GetConnectorType handles GET /api/vega-backend/v1/connector-types/:type
 func (r *restHandler) GetConnectorType(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 校验token
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
+
+	ctx, span := oteltrace.StartServerSpan(c)
+	defer span.End()
 	accountInfo := interfaces.AccountInfo{
 		ID:   visitor.ID,
 		Type: string(visitor.Type),
@@ -212,14 +226,14 @@ func (r *restHandler) GetConnectorType(c *gin.Context) {
 
 // UpdateConnectorType handles PUT /api/vega-backend/v1/connector-types/:type
 func (r *restHandler) UpdateConnectorType(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 校验token
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
+
+	ctx, span := oteltrace.StartServerSpan(c)
+	defer span.End()
 	accountInfo := interfaces.AccountInfo{
 		ID:   visitor.ID,
 		Type: string(visitor.Type),
@@ -303,14 +317,14 @@ func (r *restHandler) UpdateConnectorType(c *gin.Context) {
 
 // DeleteConnectorType handles DELETE /api/vega-backend/v1/connector-types/:type
 func (r *restHandler) DeleteConnectorType(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 校验token
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
+
+	ctx, span := oteltrace.StartServerSpan(c)
+	defer span.End()
 	accountInfo := interfaces.AccountInfo{
 		ID:   visitor.ID,
 		Type: string(visitor.Type),
@@ -363,13 +377,14 @@ func (r *restHandler) DisableConnectorType(c *gin.Context) {
 }
 
 func (r *restHandler) setConnectorTypeEnabled(c *gin.Context, value bool, spanName string) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
+
+	ctx, span := oteltrace.StartServerSpan(c)
+	defer span.End()
+
 	accountInfo := interfaces.AccountInfo{
 		ID:   visitor.ID,
 		Type: string(visitor.Type),

--- a/adp/vega/vega-backend/server/driveradapters/connector_type_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/connector_type_handler_test.go
@@ -6,91 +6,196 @@
 package driveradapters
 
 import (
+	"bytes"
+	"context"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
+	"github.com/bytedance/sonic"
 	"github.com/gin-gonic/gin"
 	"github.com/kweaver-ai/kweaver-go-lib/hydra"
+	. "github.com/smartystreets/goconvey/convey"
 	"go.uber.org/mock/gomock"
 
+	"vega-backend/common"
 	"vega-backend/interfaces"
-	mock_interfaces "vega-backend/interfaces/mock"
+	vmock "vega-backend/interfaces/mock"
 )
 
-// putUpdateConnectorType 构造 PUT /connector-types/:type 的测试上下文，驱动 handler。
-func putUpdateConnectorType(t *testing.T, pathType, body string, ctsSetup func(m *mock_interfaces.MockConnectorTypeService)) *httptest.ResponseRecorder {
-	t.Helper()
-	gin.SetMode(gin.TestMode)
+func Test_ConnectorTypeRestHandler_UpdateConnectorType(t *testing.T) {
+	Convey("Test ConnectorTypeHandler UpdateConnectorType\n", t, func() {
+		test := setGinMode()
+		defer test()
 
-	ctrl := gomock.NewController(t)
-	t.Cleanup(ctrl.Finish)
+		engine := gin.New()
+		engine.Use(gin.Recovery())
 
-	mockAuth := mock_interfaces.NewMockAuthService(ctrl)
-	mockAuth.EXPECT().VerifyToken(gomock.Any(), gomock.Any()).
-		Return(hydra.Visitor{ID: "u1", Type: hydra.VisitorType_User}, nil).
-		AnyTimes()
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
 
-	mockCTS := mock_interfaces.NewMockConnectorTypeService(ctrl)
-	if ctsSetup != nil {
-		ctsSetup(mockCTS)
-	}
+		as := vmock.NewMockAuthService(mockCtrl)
+		cts := vmock.NewMockConnectorTypeService(mockCtrl)
+		handler := MockNewRestHandler(&common.AppSetting{}, as, nil, nil, nil, nil, cts, nil, nil, nil, nil)
+		handler.RegisterPublic(engine)
 
-	r := &restHandler{as: mockAuth, cts: mockCTS}
+		as.EXPECT().VerifyToken(gomock.Any(), gomock.Any()).AnyTimes().
+			Return(hydra.Visitor{ID: "u1", Type: hydra.VisitorType_User}, nil)
 
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Params = gin.Params{{Key: "type", Value: pathType}}
-	c.Request = httptest.NewRequest(http.MethodPut, "/api/vega-backend/v1/connector-types/"+pathType,
-		strings.NewReader(body))
-	c.Request.Header.Set("Content-Type", "application/json")
+		tp := "mysql"
+		url := "/api/vega-backend/v1/connector-types/" + tp
 
-	r.UpdateConnectorType(c)
-	return w
+		Convey("Body type mismatch\n", func() {
+			reqData := interfaces.ConnectorTypeReq{
+				Type:     "postgres",
+				Name:     "MySQL",
+				Mode:     interfaces.ConnectorModeLocal,
+				Category: interfaces.ConnectorCategoryTable,
+			}
+			reqParamByte, _ := sonic.Marshal(reqData)
+			req := httptest.NewRequest(http.MethodPut, url, bytes.NewReader(reqParamByte))
+			req.Header.Set(interfaces.CONTENT_TYPE_NAME, interfaces.CONTENT_TYPE_JSON)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusConflict)
+			So(w.Body.String(), ShouldContainSubstring, "VegaBackend.ConnectorType.TypeMismatch")
+		})
+
+		Convey("Success update connector type\n", func() {
+			reqData := interfaces.ConnectorTypeReq{
+				Type:     tp,
+				Name:     "MySQL",
+				Mode:     interfaces.ConnectorModeLocal,
+				Category: interfaces.ConnectorCategoryTable,
+			}
+			cts.EXPECT().GetByType(gomock.Any(), tp).
+				Return(&interfaces.ConnectorType{
+					Type:     tp,
+					Name:     "MySQL",
+					Mode:     interfaces.ConnectorModeLocal,
+					Category: interfaces.ConnectorCategoryTable,
+				}, nil)
+			cts.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
+
+			reqParamByte, _ := sonic.Marshal(reqData)
+			req := httptest.NewRequest(http.MethodPut, url, bytes.NewReader(reqParamByte))
+			req.Header.Set(interfaces.CONTENT_TYPE_NAME, interfaces.CONTENT_TYPE_JSON)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusNoContent)
+		})
+
+		Convey("Success update fileset connector type\n", func() {
+			reqData := interfaces.ConnectorTypeReq{
+				Type:     tp,
+				Name:     "AnyShare",
+				Mode:     interfaces.ConnectorModeLocal,
+				Category: interfaces.ConnectorCategoryFileset,
+			}
+			cts.EXPECT().GetByType(gomock.Any(), tp).
+				Return(&interfaces.ConnectorType{
+					Type:     tp,
+					Name:     "AnyShare",
+					Mode:     interfaces.ConnectorModeLocal,
+					Category: interfaces.ConnectorCategoryFileset,
+				}, nil)
+			cts.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
+
+			reqParamByte, _ := sonic.Marshal(reqData)
+			req := httptest.NewRequest(http.MethodPut, url, bytes.NewReader(reqParamByte))
+			req.Header.Set(interfaces.CONTENT_TYPE_NAME, interfaces.CONTENT_TYPE_JSON)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusNoContent)
+		})
+
+		Convey("Body type omitted\n", func() {
+			reqData := map[string]any{
+				"name":     "MySQL",
+				"mode":     interfaces.ConnectorModeLocal,
+				"category": interfaces.ConnectorCategoryTable,
+			}
+			reqParamByte, _ := sonic.Marshal(reqData)
+			req := httptest.NewRequest(http.MethodPut, url, bytes.NewReader(reqParamByte))
+			req.Header.Set(interfaces.CONTENT_TYPE_NAME, interfaces.CONTENT_TYPE_JSON)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+			So(w.Body.String(), ShouldContainSubstring, "VegaBackend.ConnectorType.InvalidParameter.Type")
+		})
+	})
 }
 
-// case 3：请求体 type 与路径不一致 → 409 + TypeMismatch
-func TestUpdateConnectorType_BodyTypeMismatch_409(t *testing.T) {
-	body := `{"type":"postgres","name":"MySQL","mode":"local","category":"table"}`
-	w := putUpdateConnectorType(t, "mysql", body, func(m *mock_interfaces.MockConnectorTypeService) {
-		// 冲突应在调用任何 service 方法前返回，此处无 EXPECT。
+func Test_ConnectorTypeRestHandler_ListConnectorTypes(t *testing.T) {
+	Convey("Test ConnectorTypeHandler ListConnectorTypes\n", t, func() {
+		test := setGinMode()
+		defer test()
+
+		engine := gin.New()
+		engine.Use(gin.Recovery())
+
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		as := vmock.NewMockAuthService(mockCtrl)
+		cts := vmock.NewMockConnectorTypeService(mockCtrl)
+		handler := MockNewRestHandler(&common.AppSetting{}, as, nil, nil, nil, nil, cts, nil, nil, nil, nil)
+		handler.RegisterPublic(engine)
+
+		as.EXPECT().VerifyToken(gomock.Any(), gomock.Any()).AnyTimes().
+			Return(hydra.Visitor{ID: "u1", Type: hydra.VisitorType_User}, nil)
+
+		url := "/api/vega-backend/v1/connector-types"
+
+		Convey("Invalid enabled\n", func() {
+			req := httptest.NewRequest(http.MethodGet, url+"?enabled=maybe", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+			So(w.Body.String(), ShouldContainSubstring, "VegaBackend.ConnectorType.InvalidParameter")
+			So(w.Body.String(), ShouldContainSubstring, "invalid enabled: maybe")
+		})
+
+		Convey("Invalid mode\n", func() {
+			req := httptest.NewRequest(http.MethodGet, url+"?mode=unknown", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+			So(w.Body.String(), ShouldContainSubstring, "VegaBackend.ConnectorType.InvalidParameter.Mode")
+			So(w.Body.String(), ShouldContainSubstring, "invalid mode: unknown")
+		})
+
+		Convey("Invalid category\n", func() {
+			req := httptest.NewRequest(http.MethodGet, url+"?category=unknown", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+			So(w.Body.String(), ShouldContainSubstring, "VegaBackend.ConnectorType.InvalidParameter.Category")
+			So(w.Body.String(), ShouldContainSubstring, "invalid category: unknown")
+		})
+
+		Convey("Success list connector types with mode category and enabled\n", func() {
+			cts.EXPECT().List(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, params interfaces.ConnectorTypesQueryParams) ([]*interfaces.ConnectorType, int64, error) {
+					So(params.Mode, ShouldEqual, interfaces.ConnectorModeLocal)
+					So(params.Category, ShouldEqual, interfaces.ConnectorCategoryFileset)
+					So(params.Enabled, ShouldNotBeNil)
+					So(*params.Enabled, ShouldBeTrue)
+					return []*interfaces.ConnectorType{}, int64(0), nil
+				})
+
+			req := httptest.NewRequest(http.MethodGet, url+"?mode=local&category=fileset&enabled=true", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusOK)
+		})
 	})
-
-	if w.Code != http.StatusConflict {
-		t.Fatalf("expected 409, got %d, body=%s", w.Code, w.Body.String())
-	}
-	if !strings.Contains(w.Body.String(), "VegaBackend.ConnectorType.TypeMismatch") {
-		t.Fatalf("expected TypeMismatch error_code, got body=%s", w.Body.String())
-	}
-}
-
-// case 1：请求体 type == 路径 → 跳过冲突，进入正常更新流程
-func TestUpdateConnectorType_BodyTypeMatchesPath_OK(t *testing.T) {
-	body := `{"type":"mysql","name":"MySQL","mode":"local","category":"table"}`
-	w := putUpdateConnectorType(t, "mysql", body, func(m *mock_interfaces.MockConnectorTypeService) {
-		m.EXPECT().GetByType(gomock.Any(), "mysql").
-			Return(&interfaces.ConnectorType{Type: "mysql", Name: "MySQL", Mode: "local", Category: "table"}, nil)
-		// name 未变化，故不调用 CheckExistByName
-		m.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
-	})
-
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("expected 204, got %d, body=%s", w.Code, w.Body.String())
-	}
-}
-
-// case 2：请求体省略 type → 400 InvalidParameter.Type（K8s 风格严格契约）
-func TestUpdateConnectorType_BodyTypeOmitted_400(t *testing.T) {
-	body := `{"name":"MySQL","mode":"local","category":"table"}`
-	w := putUpdateConnectorType(t, "mysql", body, func(m *mock_interfaces.MockConnectorTypeService) {
-		// 校验失败应在调用任何 service 方法前返回，此处无 EXPECT。
-	})
-
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d, body=%s", w.Code, w.Body.String())
-	}
-	if !strings.Contains(w.Body.String(), "VegaBackend.ConnectorType.InvalidParameter.Type") {
-		t.Fatalf("expected InvalidParameter.Type error_code, got body=%s", w.Body.String())
-	}
 }

--- a/adp/vega/vega-backend/server/driveradapters/discover_schedule_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/discover_schedule_handler.go
@@ -29,26 +29,23 @@ import (
 
 // CreateDiscoverScheduleByEx handles POST /api/vega-backend/v1/discover-schedules (External).
 func (r *restHandler) CreateDiscoverScheduleByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.createDiscoverSchedule(c, ctx, span, visitor)
+	r.createDiscoverSchedule(c, visitor)
 }
 
 // CreateDiscoverScheduleByIn handles POST /api/vega-backend/in/v1/discover-schedules (Internal).
 func (r *restHandler) CreateDiscoverScheduleByIn(c *gin.Context) {
+	visitor := visitor.GenerateVisitor(c)
+	r.createDiscoverSchedule(c, visitor)
+}
+
+func (r *restHandler) createDiscoverSchedule(c *gin.Context, visitor hydra.Visitor) {
 	ctx, span := oteltrace.StartServerSpan(c)
 	defer span.End()
 
-	visitor := visitor.GenerateVisitor(c)
-	r.createDiscoverSchedule(c, ctx, span, visitor)
-}
-
-func (r *restHandler) createDiscoverSchedule(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
 	accountInfo := interfaces.AccountInfo{ID: visitor.ID, Type: string(visitor.Type)}
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, accountInfo)
 	oteltrace.AddHttpAttrs4API(span, oteltrace.GetAttrsByGinCtx(c))
@@ -115,26 +112,23 @@ func (r *restHandler) createDiscoverSchedule(c *gin.Context, ctx context.Context
 
 // ListDiscoverSchedulesByEx handles GET /api/vega-backend/v1/discover-schedules (External).
 func (r *restHandler) ListDiscoverSchedulesByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.listDiscoverSchedules(c, ctx, span, visitor)
+	r.listDiscoverSchedules(c, visitor)
 }
 
 // ListDiscoverSchedulesByIn handles GET /api/vega-backend/in/v1/discover-schedules (Internal).
 func (r *restHandler) ListDiscoverSchedulesByIn(c *gin.Context) {
+	visitor := visitor.GenerateVisitor(c)
+	r.listDiscoverSchedules(c, visitor)
+}
+
+func (r *restHandler) listDiscoverSchedules(c *gin.Context, visitor hydra.Visitor) {
 	ctx, span := oteltrace.StartServerSpan(c)
 	defer span.End()
 
-	visitor := visitor.GenerateVisitor(c)
-	r.listDiscoverSchedules(c, ctx, span, visitor)
-}
-
-func (r *restHandler) listDiscoverSchedules(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
 	accountInfo := interfaces.AccountInfo{ID: visitor.ID, Type: string(visitor.Type)}
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, accountInfo)
 	oteltrace.AddHttpAttrs4API(span, oteltrace.GetAttrsByGinCtx(c))
@@ -171,26 +165,23 @@ func (r *restHandler) listDiscoverSchedules(c *gin.Context, ctx context.Context,
 
 // GetDiscoverScheduleByEx handles GET /api/vega-backend/v1/discover-schedules/:id (External).
 func (r *restHandler) GetDiscoverScheduleByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.getDiscoverSchedule(c, ctx, span, visitor)
+	r.getDiscoverSchedule(c, visitor)
 }
 
 // GetDiscoverScheduleByIn handles GET /api/vega-backend/in/v1/discover-schedules/:id (Internal).
 func (r *restHandler) GetDiscoverScheduleByIn(c *gin.Context) {
+	visitor := visitor.GenerateVisitor(c)
+	r.getDiscoverSchedule(c, visitor)
+}
+
+func (r *restHandler) getDiscoverSchedule(c *gin.Context, visitor hydra.Visitor) {
 	ctx, span := oteltrace.StartServerSpan(c)
 	defer span.End()
 
-	visitor := visitor.GenerateVisitor(c)
-	r.getDiscoverSchedule(c, ctx, span, visitor)
-}
-
-func (r *restHandler) getDiscoverSchedule(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
 	accountInfo := interfaces.AccountInfo{ID: visitor.ID, Type: string(visitor.Type)}
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, accountInfo)
 	oteltrace.AddHttpAttrs4API(span, oteltrace.GetAttrsByGinCtx(c))
@@ -219,26 +210,23 @@ func (r *restHandler) getDiscoverSchedule(c *gin.Context, ctx context.Context, s
 
 // UpdateDiscoverScheduleByEx handles PUT /api/vega-backend/v1/discover-schedules/:id (External).
 func (r *restHandler) UpdateDiscoverScheduleByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.updateDiscoverSchedule(c, ctx, span, visitor)
+	r.updateDiscoverSchedule(c, visitor)
 }
 
 // UpdateDiscoverScheduleByIn handles PUT /api/vega-backend/in/v1/discover-schedules/:id (Internal).
 func (r *restHandler) UpdateDiscoverScheduleByIn(c *gin.Context) {
+	visitor := visitor.GenerateVisitor(c)
+	r.updateDiscoverSchedule(c, visitor)
+}
+
+func (r *restHandler) updateDiscoverSchedule(c *gin.Context, visitor hydra.Visitor) {
 	ctx, span := oteltrace.StartServerSpan(c)
 	defer span.End()
 
-	visitor := visitor.GenerateVisitor(c)
-	r.updateDiscoverSchedule(c, ctx, span, visitor)
-}
-
-func (r *restHandler) updateDiscoverSchedule(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
 	accountInfo := interfaces.AccountInfo{ID: visitor.ID, Type: string(visitor.Type)}
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, accountInfo)
 	oteltrace.AddHttpAttrs4API(span, oteltrace.GetAttrsByGinCtx(c))
@@ -327,26 +315,23 @@ func (r *restHandler) updateDiscoverSchedule(c *gin.Context, ctx context.Context
 
 // DeleteDiscoverScheduleByEx handles DELETE /api/vega-backend/v1/discover-schedules/:id (External).
 func (r *restHandler) DeleteDiscoverScheduleByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.deleteDiscoverSchedule(c, ctx, span, visitor)
+	r.deleteDiscoverSchedule(c, visitor)
 }
 
 // DeleteDiscoverScheduleByIn handles DELETE /api/vega-backend/in/v1/discover-schedules/:id (Internal).
 func (r *restHandler) DeleteDiscoverScheduleByIn(c *gin.Context) {
+	visitor := visitor.GenerateVisitor(c)
+	r.deleteDiscoverSchedule(c, visitor)
+}
+
+func (r *restHandler) deleteDiscoverSchedule(c *gin.Context, visitor hydra.Visitor) {
 	ctx, span := oteltrace.StartServerSpan(c)
 	defer span.End()
 
-	visitor := visitor.GenerateVisitor(c)
-	r.deleteDiscoverSchedule(c, ctx, span, visitor)
-}
-
-func (r *restHandler) deleteDiscoverSchedule(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
 	accountInfo := interfaces.AccountInfo{ID: visitor.ID, Type: string(visitor.Type)}
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, accountInfo)
 	oteltrace.AddHttpAttrs4API(span, oteltrace.GetAttrsByGinCtx(c))
@@ -390,49 +375,40 @@ func (r *restHandler) deleteDiscoverSchedule(c *gin.Context, ctx context.Context
 
 // EnableDiscoverScheduleByEx handles POST /api/vega-backend/v1/discover-schedules/:id/enable (External).
 func (r *restHandler) EnableDiscoverScheduleByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.toggleDiscoverSchedule(c, ctx, span, visitor, true)
+	r.toggleDiscoverSchedule(c, visitor, true)
 }
 
 // EnableDiscoverScheduleByIn handles POST /api/vega-backend/in/v1/discover-schedules/:id/enable (Internal).
 func (r *restHandler) EnableDiscoverScheduleByIn(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	visitor := visitor.GenerateVisitor(c)
-	r.toggleDiscoverSchedule(c, ctx, span, visitor, true)
+	r.toggleDiscoverSchedule(c, visitor, true)
 }
 
 // DisableDiscoverScheduleByEx handles POST /api/vega-backend/v1/discover-schedules/:id/disable (External).
 func (r *restHandler) DisableDiscoverScheduleByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.toggleDiscoverSchedule(c, ctx, span, visitor, false)
+	r.toggleDiscoverSchedule(c, visitor, false)
 }
 
 // DisableDiscoverScheduleByIn handles POST /api/vega-backend/in/v1/discover-schedules/:id/disable (Internal).
 func (r *restHandler) DisableDiscoverScheduleByIn(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	visitor := visitor.GenerateVisitor(c)
-	r.toggleDiscoverSchedule(c, ctx, span, visitor, false)
+	r.toggleDiscoverSchedule(c, visitor, false)
 }
 
 // toggleDiscoverSchedule shared logic for enable / disable.
 // Idempotent: re-enable an enabled schedule (or re-disable a disabled one) returns 204 without error.
-func (r *restHandler) toggleDiscoverSchedule(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor, enable bool) {
+func (r *restHandler) toggleDiscoverSchedule(c *gin.Context, visitor hydra.Visitor, enable bool) {
+	ctx, span := oteltrace.StartServerSpan(c)
+	defer span.End()
+
 	accountInfo := interfaces.AccountInfo{ID: visitor.ID, Type: string(visitor.Type)}
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, accountInfo)
 	oteltrace.AddHttpAttrs4API(span, oteltrace.GetAttrsByGinCtx(c))

--- a/adp/vega/vega-backend/server/driveradapters/discover_task_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/discover_task_handler.go
@@ -18,7 +18,6 @@ import (
 	"github.com/kweaver-ai/kweaver-go-lib/logger"
 	"github.com/kweaver-ai/kweaver-go-lib/otel/oteltrace"
 	"github.com/kweaver-ai/kweaver-go-lib/rest"
-	"go.opentelemetry.io/otel/trace"
 
 	"vega-backend/common/visitor"
 	verrors "vega-backend/errors"
@@ -29,26 +28,23 @@ import (
 
 // ListDiscoverTasksByEx handles GET /api/vega-backend/v1/discover-tasks (External)
 func (r *restHandler) ListDiscoverTasksByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.listDiscoverTasks(c, ctx, span, visitor)
+	r.listDiscoverTasks(c, visitor)
 }
 
 // ListDiscoverTasksByIn handles GET /api/vega-backend/in/v1/discover-tasks (Internal)
 func (r *restHandler) ListDiscoverTasksByIn(c *gin.Context) {
+	visitor := visitor.GenerateVisitor(c)
+	r.listDiscoverTasks(c, visitor)
+}
+
+func (r *restHandler) listDiscoverTasks(c *gin.Context, visitor hydra.Visitor) {
 	ctx, span := oteltrace.StartServerSpan(c)
 	defer span.End()
 
-	visitor := visitor.GenerateVisitor(c)
-	r.listDiscoverTasks(c, ctx, span, visitor)
-}
-
-func (r *restHandler) listDiscoverTasks(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
 	accountInfo := interfaces.AccountInfo{ID: visitor.ID, Type: string(visitor.Type)}
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, accountInfo)
 	oteltrace.AddHttpAttrs4API(span, oteltrace.GetAttrsByGinCtx(c))
@@ -94,26 +90,23 @@ func (r *restHandler) listDiscoverTasks(c *gin.Context, ctx context.Context, spa
 
 // GetDiscoverTaskByEx handles GET /api/vega-backend/v1/discover-tasks/:id (External)
 func (r *restHandler) GetDiscoverTaskByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.getDiscoverTask(c, ctx, span, visitor)
+	r.getDiscoverTask(c, visitor)
 }
 
 // GetDiscoverTaskByIn handles GET /api/vega-backend/in/v1/discover-tasks/:id (Internal)
 func (r *restHandler) GetDiscoverTaskByIn(c *gin.Context) {
+	visitor := visitor.GenerateVisitor(c)
+	r.getDiscoverTask(c, visitor)
+}
+
+func (r *restHandler) getDiscoverTask(c *gin.Context, visitor hydra.Visitor) {
 	ctx, span := oteltrace.StartServerSpan(c)
 	defer span.End()
 
-	visitor := visitor.GenerateVisitor(c)
-	r.getDiscoverTask(c, ctx, span, visitor)
-}
-
-func (r *restHandler) getDiscoverTask(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
 	accountInfo := interfaces.AccountInfo{ID: visitor.ID, Type: string(visitor.Type)}
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, accountInfo)
 	oteltrace.AddHttpAttrs4API(span, oteltrace.GetAttrsByGinCtx(c))
@@ -144,26 +137,23 @@ func (r *restHandler) getDiscoverTask(c *gin.Context, ctx context.Context, span 
 // DeleteDiscoverTasksByEx handles DELETE /api/vega-backend/v1/discover-tasks/:ids (External).
 // `ids` is comma-separated. Optional query: ?ignore_missing=true
 func (r *restHandler) DeleteDiscoverTasksByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.deleteDiscoverTasks(c, ctx, span, visitor)
+	r.deleteDiscoverTasks(c, visitor)
 }
 
 // DeleteDiscoverTasksByIn handles DELETE /api/vega-backend/in/v1/discover-tasks/:ids (Internal)
 func (r *restHandler) DeleteDiscoverTasksByIn(c *gin.Context) {
+	visitor := visitor.GenerateVisitor(c)
+	r.deleteDiscoverTasks(c, visitor)
+}
+
+func (r *restHandler) deleteDiscoverTasks(c *gin.Context, visitor hydra.Visitor) {
 	ctx, span := oteltrace.StartServerSpan(c)
 	defer span.End()
 
-	visitor := visitor.GenerateVisitor(c)
-	r.deleteDiscoverTasks(c, ctx, span, visitor)
-}
-
-func (r *restHandler) deleteDiscoverTasks(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
 	accountInfo := interfaces.AccountInfo{ID: visitor.ID, Type: string(visitor.Type)}
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, accountInfo)
 	oteltrace.AddHttpAttrs4API(span, oteltrace.GetAttrsByGinCtx(c))

--- a/adp/vega/vega-backend/server/driveradapters/driveradapters_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/driveradapters_test.go
@@ -1,0 +1,50 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package driveradapters
+
+import (
+	"vega-backend/common"
+	"vega-backend/interfaces"
+	"vega-backend/worker"
+
+	"github.com/gin-gonic/gin"
+)
+
+func setGinMode() func() {
+	oldMode := gin.Mode()
+	gin.SetMode(gin.TestMode)
+	return func() {
+		gin.SetMode(oldMode)
+	}
+}
+
+func MockNewRestHandler(
+	appSetting *common.AppSetting,
+	as interfaces.AuthService,
+	cs interfaces.CatalogService,
+	rs interfaces.ResourceService,
+	bts interfaces.BuildTaskService,
+	ds interfaces.DatasetService,
+	cts interfaces.ConnectorTypeService,
+	dts interfaces.DiscoverTaskService,
+	dss interfaces.DiscoverScheduleService,
+	rds interfaces.ResourceDataService,
+	sw *worker.ScheduleWorker,
+) *restHandler {
+	return &restHandler{
+		appSetting: appSetting,
+		as:         as,
+		cs:         cs,
+		rs:         rs,
+		bts:        bts,
+		ds:         ds,
+		cts:        cts,
+		dts:        dts,
+		dss:        dss,
+		rds:        rds,
+		sw:         sw,
+	}
+}

--- a/adp/vega/vega-backend/server/driveradapters/query_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/query_handler.go
@@ -15,7 +15,6 @@ import (
 	"github.com/kweaver-ai/kweaver-go-lib/otel/otellog"
 	"github.com/kweaver-ai/kweaver-go-lib/otel/oteltrace"
 	"github.com/kweaver-ai/kweaver-go-lib/rest"
-	"go.opentelemetry.io/otel/trace"
 
 	"vega-backend/common/visitor"
 	"vega-backend/errors"
@@ -25,29 +24,26 @@ import (
 
 // RawQueryByEx handles POST /api/vega-backend/v1/resources/query (External)
 func (r *restHandler) RawQueryByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 外网接口：校验token
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.rawQuery(c, ctx, span, visitor)
+	r.rawQuery(c, visitor)
 }
 
 // RawQueryByIn handles POST /api/vega-backend/in/v1/resources/query (Internal)
 func (r *restHandler) RawQueryByIn(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 内网接口：user_id从header中取
 	visitor := visitor.GenerateVisitor(c)
-	r.rawQuery(c, ctx, span, visitor)
+	r.rawQuery(c, visitor)
 }
 
 // sqlQuery is the shared implementation for SQL query
-func (r *restHandler) rawQuery(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
+func (r *restHandler) rawQuery(c *gin.Context, visitor hydra.Visitor) {
+	ctx, span := oteltrace.StartServerSpan(c)
+	defer span.End()
+
 	accountInfo := interfaces.AccountInfo{
 		ID:   visitor.ID,
 		Type: string(visitor.Type),

--- a/adp/vega/vega-backend/server/driveradapters/resource_data_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_data_handler.go
@@ -34,28 +34,25 @@ import (
 //	POST   → batch create documents (dataset category only)
 //	DELETE → delete documents by filter (dataset category only)
 func (r *restHandler) PostResourceDataByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.postResourceData(c, ctx, span, visitor)
+	r.postResourceData(c, visitor)
 }
 
 // PostResourceDataByIn handles POST /api/vega-backend/in/v1/resources/:id/data (Internal).
 func (r *restHandler) PostResourceDataByIn(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	visitor := visitor.GenerateVisitor(c)
-	r.postResourceData(c, ctx, span, visitor)
+	r.postResourceData(c, visitor)
 }
 
 // postResourceData dispatches POST /resources/:id/data to the right branch based on
 // X-HTTP-Method-Override header.
-func (r *restHandler) postResourceData(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
+func (r *restHandler) postResourceData(c *gin.Context, visitor hydra.Visitor) {
+	ctx, span := oteltrace.StartServerSpan(c)
+	defer span.End()
+
 	accountInfo := interfaces.AccountInfo{ID: visitor.ID, Type: string(visitor.Type)}
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, accountInfo)
 	oteltrace.AddHttpAttrs4API(span, oteltrace.GetAttrsByGinCtx(c))
@@ -226,26 +223,23 @@ func (r *restHandler) deleteResourceDataByQuery(c *gin.Context, ctx context.Cont
 // PutResourceDataByEx handles PUT /api/vega-backend/v1/resources/:id/data (External).
 // Batch upsert documents; dataset category only. Each document must carry an `id` field.
 func (r *restHandler) PutResourceDataByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.putResourceData(c, ctx, span, visitor)
+	r.putResourceData(c, visitor)
 }
 
 // PutResourceDataByIn handles PUT /api/vega-backend/in/v1/resources/:id/data (Internal).
 func (r *restHandler) PutResourceDataByIn(c *gin.Context) {
+	visitor := visitor.GenerateVisitor(c)
+	r.putResourceData(c, visitor)
+}
+
+func (r *restHandler) putResourceData(c *gin.Context, visitor hydra.Visitor) {
 	ctx, span := oteltrace.StartServerSpan(c)
 	defer span.End()
 
-	visitor := visitor.GenerateVisitor(c)
-	r.putResourceData(c, ctx, span, visitor)
-}
-
-func (r *restHandler) putResourceData(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
 	accountInfo := interfaces.AccountInfo{ID: visitor.ID, Type: string(visitor.Type)}
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, accountInfo)
 	oteltrace.AddHttpAttrs4API(span, oteltrace.GetAttrsByGinCtx(c))
@@ -306,26 +300,23 @@ func (r *restHandler) putResourceData(c *gin.Context, ctx context.Context, span 
 
 // GetResourceDataDocByEx handles GET /api/vega-backend/v1/resources/:id/data/:doc_id (External).
 func (r *restHandler) GetResourceDataDocByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.getResourceDataDoc(c, ctx, span, visitor)
+	r.getResourceDataDoc(c, visitor)
 }
 
 // GetResourceDataDocByIn handles GET /api/vega-backend/in/v1/resources/:id/data/:doc_id (Internal).
 func (r *restHandler) GetResourceDataDocByIn(c *gin.Context) {
+	visitor := visitor.GenerateVisitor(c)
+	r.getResourceDataDoc(c, visitor)
+}
+
+func (r *restHandler) getResourceDataDoc(c *gin.Context, visitor hydra.Visitor) {
 	ctx, span := oteltrace.StartServerSpan(c)
 	defer span.End()
 
-	visitor := visitor.GenerateVisitor(c)
-	r.getResourceDataDoc(c, ctx, span, visitor)
-}
-
-func (r *restHandler) getResourceDataDoc(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
 	accountInfo := interfaces.AccountInfo{ID: visitor.ID, Type: string(visitor.Type)}
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, accountInfo)
 	oteltrace.AddHttpAttrs4API(span, oteltrace.GetAttrsByGinCtx(c))
@@ -360,26 +351,23 @@ func (r *restHandler) getResourceDataDoc(c *gin.Context, ctx context.Context, sp
 // PutResourceDataDocByEx handles PUT /api/vega-backend/v1/resources/:id/data/:doc_id (External).
 // Single-document update; doc_id from path takes precedence over any `id` field in body.
 func (r *restHandler) PutResourceDataDocByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.putResourceDataDoc(c, ctx, span, visitor)
+	r.putResourceDataDoc(c, visitor)
 }
 
 // PutResourceDataDocByIn handles PUT /api/vega-backend/in/v1/resources/:id/data/:doc_id (Internal).
 func (r *restHandler) PutResourceDataDocByIn(c *gin.Context) {
+	visitor := visitor.GenerateVisitor(c)
+	r.putResourceDataDoc(c, visitor)
+}
+
+func (r *restHandler) putResourceDataDoc(c *gin.Context, visitor hydra.Visitor) {
 	ctx, span := oteltrace.StartServerSpan(c)
 	defer span.End()
 
-	visitor := visitor.GenerateVisitor(c)
-	r.putResourceDataDoc(c, ctx, span, visitor)
-}
-
-func (r *restHandler) putResourceDataDoc(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
 	accountInfo := interfaces.AccountInfo{ID: visitor.ID, Type: string(visitor.Type)}
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, accountInfo)
 	oteltrace.AddHttpAttrs4API(span, oteltrace.GetAttrsByGinCtx(c))
@@ -426,26 +414,23 @@ func (r *restHandler) putResourceDataDoc(c *gin.Context, ctx context.Context, sp
 // DeleteResourceDataByEx handles DELETE /api/vega-backend/v1/resources/:id/data/:doc_ids (External).
 // Best-effort batch delete by IDs; missing IDs are silently skipped.
 func (r *restHandler) DeleteResourceDataByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.deleteResourceData(c, ctx, span, visitor)
+	r.deleteResourceData(c, visitor)
 }
 
 // DeleteResourceDataByIn handles DELETE /api/vega-backend/in/v1/resources/:id/data/:doc_ids (Internal).
 func (r *restHandler) DeleteResourceDataByIn(c *gin.Context) {
+	visitor := visitor.GenerateVisitor(c)
+	r.deleteResourceData(c, visitor)
+}
+
+func (r *restHandler) deleteResourceData(c *gin.Context, visitor hydra.Visitor) {
 	ctx, span := oteltrace.StartServerSpan(c)
 	defer span.End()
 
-	visitor := visitor.GenerateVisitor(c)
-	r.deleteResourceData(c, ctx, span, visitor)
-}
-
-func (r *restHandler) deleteResourceData(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
 	accountInfo := interfaces.AccountInfo{ID: visitor.ID, Type: string(visitor.Type)}
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, accountInfo)
 	oteltrace.AddHttpAttrs4API(span, oteltrace.GetAttrsByGinCtx(c))

--- a/adp/vega/vega-backend/server/driveradapters/resource_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_handler.go
@@ -22,40 +22,35 @@ import (
 	"github.com/kweaver-ai/kweaver-go-lib/otel/oteltrace"
 	"github.com/kweaver-ai/kweaver-go-lib/rest"
 	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/trace"
 
 	verrors "vega-backend/errors"
 	"vega-backend/interfaces"
-	"vega-backend/logics/extensions"
 )
 
 // ========== ListResources ==========
 
 // ListResourcesByEx handles GET /api/vega-backend/v1/resources (External)
 func (r *restHandler) ListResourcesByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 外网接口：校验token
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.listResources(c, ctx, span, visitor)
+	r.listResources(c, visitor)
 }
 
 // ListResourcesByIn handles GET /api/vega-backend/in/v1/resources (Internal)
 func (r *restHandler) ListResourcesByIn(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 内网接口：user_id从header中取
 	visitor := visitor.GenerateVisitor(c)
-	r.listResources(c, ctx, span, visitor)
+	r.listResources(c, visitor)
 }
 
 // listResources is the shared implementation
-func (r *restHandler) listResources(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
+func (r *restHandler) listResources(c *gin.Context, visitor hydra.Visitor) {
+	ctx, span := oteltrace.StartServerSpan(c)
+	defer span.End()
+
 	accountInfo := interfaces.AccountInfo{
 		ID:   visitor.ID,
 		Type: string(visitor.Type),
@@ -87,14 +82,6 @@ func (r *restHandler) listResources(c *gin.Context, ctx context.Context, span tr
 
 	extKeys := c.QueryArray("extension_key")
 	extVals := c.QueryArray("extension_value")
-	if err := extensions.ValidateExtensionQueryPairs(ctx, extKeys, extVals); err != nil {
-		httpErr := err.(*rest.HTTPError)
-		otellog.LogError(ctx, fmt.Sprintf("%s. %v", httpErr.BaseError.Description,
-			httpErr.BaseError.ErrorDetails), nil)
-		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
-		rest.ReplyError(c, httpErr)
-		return
-	}
 	includeExt := strings.EqualFold(strings.TrimSpace(c.Query("include_extensions")), "true")
 	includeExtKeys := strings.TrimSpace(c.Query("include_extension_keys"))
 
@@ -108,6 +95,15 @@ func (r *restHandler) listResources(c *gin.Context, ctx context.Context, span tr
 		ExtensionValues:       extVals,
 		IncludeExtensions:     includeExt,
 		IncludeExtensionKeys:  includeExtKeys,
+	}
+
+	if err := ValidateResourceListQueryParams(ctx, params); err != nil {
+		httpErr := err.(*rest.HTTPError)
+		otellog.LogError(ctx, fmt.Sprintf("%s. %v", httpErr.BaseError.Description,
+			httpErr.BaseError.ErrorDetails), nil)
+		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
+		rest.ReplyError(c, httpErr)
+		return
 	}
 
 	entries, total, err := r.rs.List(ctx, params)
@@ -132,29 +128,26 @@ func (r *restHandler) listResources(c *gin.Context, ctx context.Context, span tr
 
 // CreateResourceByEx handles POST /api/vega-backend/v1/resources (External)
 func (r *restHandler) CreateResourceByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 外网接口：校验token
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.createResource(c, ctx, span, visitor)
+	r.createResource(c, visitor)
 }
 
 // CreateResourceByIn handles POST /api/vega-backend/in/v1/resources (Internal)
 func (r *restHandler) CreateResourceByIn(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 内网接口：user_id从header中取
 	visitor := visitor.GenerateVisitor(c)
-	r.createResource(c, ctx, span, visitor)
+	r.createResource(c, visitor)
 }
 
 // createResource is the shared implementation
-func (r *restHandler) createResource(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
+func (r *restHandler) createResource(c *gin.Context, visitor hydra.Visitor) {
+	ctx, span := oteltrace.StartServerSpan(c)
+	defer span.End()
+
 	accountInfo := interfaces.AccountInfo{
 		ID:   visitor.ID,
 		Type: string(visitor.Type),
@@ -254,29 +247,26 @@ func (r *restHandler) createResource(c *gin.Context, ctx context.Context, span t
 
 // GetResourcesByEx handles GET /api/vega-backend/v1/resources/:ids (External)
 func (r *restHandler) GetResourcesByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 外网接口：校验token
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.getResources(c, ctx, span, visitor)
+	r.getResources(c, visitor)
 }
 
 // GetResourcesByIn handles GET /api/vega-backend/in/v1/resources/:ids (Internal)
 func (r *restHandler) GetResourcesByIn(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 内网接口：user_id从header中取
 	visitor := visitor.GenerateVisitor(c)
-	r.getResources(c, ctx, span, visitor)
+	r.getResources(c, visitor)
 }
 
 // getResources is the shared implementation
-func (r *restHandler) getResources(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
+func (r *restHandler) getResources(c *gin.Context, visitor hydra.Visitor) {
+	ctx, span := oteltrace.StartServerSpan(c)
+	defer span.End()
+
 	accountInfo := interfaces.AccountInfo{
 		ID:   visitor.ID,
 		Type: string(visitor.Type),
@@ -325,29 +315,26 @@ func (r *restHandler) getResources(c *gin.Context, ctx context.Context, span tra
 
 // UpdateResourceByEx handles PUT /api/vega-backend/v1/resources/:id (External)
 func (r *restHandler) UpdateResourceByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 外网接口：校验token
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.updateResource(c, ctx, span, visitor)
+	r.updateResource(c, visitor)
 }
 
 // UpdateResourceByIn handles PUT /api/vega-backend/in/v1/resources/:id (Internal)
 func (r *restHandler) UpdateResourceByIn(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 内网接口：user_id从header中取
 	visitor := visitor.GenerateVisitor(c)
-	r.updateResource(c, ctx, span, visitor)
+	r.updateResource(c, visitor)
 }
 
 // updateResource is the shared implementation
-func (r *restHandler) updateResource(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
+func (r *restHandler) updateResource(c *gin.Context, visitor hydra.Visitor) {
+	ctx, span := oteltrace.StartServerSpan(c)
+	defer span.End()
+
 	accountInfo := interfaces.AccountInfo{
 		ID:   visitor.ID,
 		Type: string(visitor.Type),
@@ -422,29 +409,26 @@ func (r *restHandler) updateResource(c *gin.Context, ctx context.Context, span t
 
 // DeleteResourcesByEx handles DELETE /api/vega-backend/v1/resources/:ids (External)
 func (r *restHandler) DeleteResourcesByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 外网接口：校验token
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.deleteResources(c, ctx, span, visitor)
+	r.deleteResources(c, visitor)
 }
 
 // DeleteResourcesByIn handles DELETE /api/vega-backend/in/v1/resources/:ids (Internal)
 func (r *restHandler) DeleteResourcesByIn(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 内网接口：user_id从header中取
 	visitor := visitor.GenerateVisitor(c)
-	r.deleteResources(c, ctx, span, visitor)
+	r.deleteResources(c, visitor)
 }
 
 // deleteResources is the shared implementation
-func (r *restHandler) deleteResources(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
+func (r *restHandler) deleteResources(c *gin.Context, visitor hydra.Visitor) {
+	ctx, span := oteltrace.StartServerSpan(c)
+	defer span.End()
+
 	accountInfo := interfaces.AccountInfo{
 		ID:   visitor.ID,
 		Type: string(visitor.Type),
@@ -506,19 +490,19 @@ func (r *restHandler) deleteResources(c *gin.Context, ctx context.Context, span 
 
 // ListResourceSrcsByEx resource source list (External)
 func (r *restHandler) ListResourceSrcsByEx(c *gin.Context) {
-	ctx, span := oteltrace.StartServerSpan(c)
-	defer span.End()
-
 	// 外网接口：校验token
-	visitor, err := r.verifyOAuth(ctx, c)
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
 		return
 	}
-	r.listResourceSrcs(c, ctx, span, visitor)
+	r.listResourceSrcs(c, visitor)
 }
 
 // listResourceSrcs is the shared implementation
-func (r *restHandler) listResourceSrcs(c *gin.Context, ctx context.Context, span trace.Span, visitor hydra.Visitor) {
+func (r *restHandler) listResourceSrcs(c *gin.Context, visitor hydra.Visitor) {
+	ctx, span := oteltrace.StartServerSpan(c)
+	defer span.End()
+
 	accountInfo := interfaces.AccountInfo{
 		ID:   visitor.ID,
 		Type: string(visitor.Type),

--- a/adp/vega/vega-backend/server/driveradapters/resource_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_handler_test.go
@@ -1,0 +1,75 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package driveradapters
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+
+	"vega-backend/common"
+	"vega-backend/interfaces"
+	vmock "vega-backend/interfaces/mock"
+)
+
+func Test_ResourceRestHandler_ListResources(t *testing.T) {
+	Convey("Test ResourceHandler ListResources\n", t, func() {
+		test := setGinMode()
+		defer test()
+
+		engine := gin.New()
+		engine.Use(gin.Recovery())
+
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		rs := vmock.NewMockResourceService(mockCtrl)
+		handler := MockNewRestHandler(&common.AppSetting{}, nil, nil, rs, nil, nil, nil, nil, nil, nil, nil)
+		handler.RegisterPublic(engine)
+
+		url := "/api/vega-backend/in/v1/resources"
+
+		Convey("Invalid category\n", func() {
+			req := httptest.NewRequest(http.MethodGet, url+"?category=unknown", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+			So(w.Body.String(), ShouldContainSubstring, "VegaBackend.Resource.InvalidParameter")
+			So(w.Body.String(), ShouldContainSubstring, "invalid category: unknown")
+		})
+
+		Convey("Invalid status\n", func() {
+			req := httptest.NewRequest(http.MethodGet, url+"?status=unknown", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+			So(w.Body.String(), ShouldContainSubstring, "VegaBackend.Resource.InvalidParameter")
+			So(w.Body.String(), ShouldContainSubstring, "invalid status: unknown")
+		})
+
+		Convey("Success list resources with category and status\n", func() {
+			rs.EXPECT().List(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, params interfaces.ResourcesQueryParams) ([]*interfaces.Resource, int64, error) {
+					So(params.Category, ShouldEqual, interfaces.ResourceCategoryDataset)
+					So(params.Status, ShouldEqual, interfaces.ResourceStatusActive)
+					return []*interfaces.Resource{}, int64(0), nil
+				})
+
+			req := httptest.NewRequest(http.MethodGet, url+"?category=dataset&status=active", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusOK)
+		})
+	})
+}

--- a/adp/vega/vega-backend/server/driveradapters/validate_catalog.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_catalog.go
@@ -7,7 +7,12 @@ package driveradapters
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 
+	"github.com/kweaver-ai/kweaver-go-lib/rest"
+
+	verrors "vega-backend/errors"
 	"vega-backend/interfaces"
 	"vega-backend/logics/extensions"
 )
@@ -31,4 +36,50 @@ func ValidateCatalogRequest(ctx context.Context, req *interfaces.CatalogRequest)
 		}
 	}
 	return nil
+}
+
+func ValidateCatalogListQueryParams(ctx context.Context, params interfaces.CatalogsQueryParams) error {
+	if err := validateCatalogTypeQueryParam(ctx, params.Type); err != nil {
+		return err
+	}
+	if err := validateCatalogHealthCheckStatusQueryParam(ctx, params.HealthCheckStatus); err != nil {
+		return err
+	}
+	if err := extensions.ValidateExtensionQueryPairs(ctx, params.ExtensionKeys, params.ExtensionValues); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateCatalogTypeQueryParam(ctx context.Context, typ string) error {
+	if typ == "" {
+		return nil
+	}
+
+	switch typ {
+	case interfaces.CatalogTypePhysical,
+		interfaces.CatalogTypeLogical:
+		return nil
+	default:
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Catalog_InvalidParameter_Type).
+			WithErrorDetails(fmt.Sprintf("invalid type: %s", typ))
+	}
+}
+
+func validateCatalogHealthCheckStatusQueryParam(ctx context.Context, status string) error {
+	if status == "" {
+		return nil
+	}
+
+	switch status {
+	case interfaces.CatalogHealthStatusHealthy,
+		interfaces.CatalogHealthStatusDegraded,
+		interfaces.CatalogHealthStatusUnhealthy,
+		interfaces.CatalogHealthStatusOffline,
+		interfaces.CatalogHealthStatusDisabled:
+		return nil
+	default:
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Catalog_InvalidParameter).
+			WithErrorDetails(fmt.Sprintf("invalid health_check_status: %s", status))
+	}
 }

--- a/adp/vega/vega-backend/server/driveradapters/validate_connector_type.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_connector_type.go
@@ -7,6 +7,7 @@ package driveradapters
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/kweaver-ai/kweaver-go-lib/rest"
@@ -32,15 +33,33 @@ func ValidateConnectorTypeReq(ctx context.Context, req *interfaces.ConnectorType
 	return nil
 }
 
+func ValidateConnectorTypeListQueryParams(ctx context.Context, params interfaces.ConnectorTypesQueryParams) error {
+	if err := ValidateOptionalConnectorMode(ctx, params.Mode); err != nil {
+		return err
+	}
+	if err := ValidateOptionalConnectorCategory(ctx, params.Category); err != nil {
+		return err
+	}
+	return nil
+}
+
 func ValidateConnectorMode(ctx context.Context, mode string) error {
 	if mode == "" {
 		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_ConnectorType_InvalidParameter_Mode)
+	}
+	return ValidateOptionalConnectorMode(ctx, mode)
+}
+
+func ValidateOptionalConnectorMode(ctx context.Context, mode string) error {
+	if mode == "" {
+		return nil
 	}
 	switch mode {
 	case interfaces.ConnectorModeLocal:
 	case interfaces.ConnectorModeRemote:
 	default:
-		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_ConnectorType_InvalidParameter_Mode)
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_ConnectorType_InvalidParameter_Mode).
+			WithErrorDetails(fmt.Sprintf("invalid mode: %s", mode))
 	}
 	return nil
 }
@@ -49,11 +68,24 @@ func ValidateConnectorCategory(ctx context.Context, category string) error {
 	if category == "" {
 		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_ConnectorType_InvalidParameter_Category)
 	}
+	return ValidateOptionalConnectorCategory(ctx, category)
+}
+
+func ValidateOptionalConnectorCategory(ctx context.Context, category string) error {
+	if category == "" {
+		return nil
+	}
 	switch category {
 	case interfaces.ConnectorCategoryTable:
 	case interfaces.ConnectorCategoryIndex:
+	case interfaces.ConnectorCategoryTopic:
+	case interfaces.ConnectorCategoryFile:
+	case interfaces.ConnectorCategoryFileset:
+	case interfaces.ConnectorCategoryMetric:
+	case interfaces.ConnectorCategoryAPI:
 	default:
-		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_ConnectorType_InvalidParameter_Category)
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_ConnectorType_InvalidParameter_Category).
+			WithErrorDetails(fmt.Sprintf("invalid category: %s", category))
 	}
 	return nil
 }

--- a/adp/vega/vega-backend/server/driveradapters/validate_resource.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_resource.go
@@ -50,6 +50,58 @@ func ValidateResourceRequest(ctx context.Context, req *interfaces.ResourceReques
 	}
 }
 
+func ValidateResourceListQueryParams(ctx context.Context, params interfaces.ResourcesQueryParams) error {
+	if err := validateResourceCategoryQueryParam(ctx, params.Category); err != nil {
+		return err
+	}
+	if err := validateResourceStatusQueryParam(ctx, params.Status); err != nil {
+		return err
+	}
+	if err := extensions.ValidateExtensionQueryPairs(ctx, params.ExtensionKeys, params.ExtensionValues); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateResourceCategoryQueryParam(ctx context.Context, category string) error {
+	if category == "" {
+		return nil
+	}
+
+	switch category {
+	case interfaces.ResourceCategoryTable,
+		interfaces.ResourceCategoryFile,
+		interfaces.ResourceCategoryFileset,
+		interfaces.ResourceCategoryAPI,
+		interfaces.ResourceCategoryMetric,
+		interfaces.ResourceCategoryTopic,
+		interfaces.ResourceCategoryIndex,
+		interfaces.ResourceCategoryLogicView,
+		interfaces.ResourceCategoryDataset:
+		return nil
+	default:
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Resource_InvalidParameter).
+			WithErrorDetails(fmt.Sprintf("invalid category: %s", category))
+	}
+}
+
+func validateResourceStatusQueryParam(ctx context.Context, status string) error {
+	if status == "" {
+		return nil
+	}
+
+	switch status {
+	case interfaces.ResourceStatusActive,
+		interfaces.ResourceStatusDisabled,
+		interfaces.ResourceStatusDeprecated,
+		interfaces.ResourceStatusStale:
+		return nil
+	default:
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Resource_InvalidParameter).
+			WithErrorDetails(fmt.Sprintf("invalid status: %s", status))
+	}
+}
+
 func validateLogicViewRequest(ctx context.Context, req *interfaces.ResourceRequest) error {
 	outputFields, err := validateLogicDefinition(ctx, req.LogicDefinition)
 	if err != nil {

--- a/adp/vega/vega-backend/server/driveradapters/validate_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_test.go
@@ -10,246 +10,197 @@ import (
 	"strings"
 	"testing"
 
+	. "github.com/smartystreets/goconvey/convey"
+
 	"vega-backend/interfaces"
 )
-
-// ===== validateName =====
-
-func TestValidateName_Valid(t *testing.T) {
-	if err := validateName(context.Background(), "test-catalog"); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestValidateName_Empty(t *testing.T) {
-	err := validateName(context.Background(), "")
-	if err == nil {
-		t.Fatal("expected error for empty name")
-	}
-}
-
-func TestValidateName_MaxLength(t *testing.T) {
-	name := strings.Repeat("a", interfaces.NAME_MAX_LENGTH)
-	if err := validateName(context.Background(), name); err != nil {
-		t.Fatalf("unexpected error for max length name: %v", err)
-	}
-}
-
-func TestValidateName_ExceedsMaxLength(t *testing.T) {
-	name := strings.Repeat("a", interfaces.NAME_MAX_LENGTH+1)
-	err := validateName(context.Background(), name)
-	if err == nil {
-		t.Fatal("expected error for name exceeding max length")
-	}
-}
-
-func TestValidateName_UTF8(t *testing.T) {
-	// 中文字符，每个占3字节但算1个rune
-	name := strings.Repeat("中", interfaces.NAME_MAX_LENGTH)
-	if err := validateName(context.Background(), name); err != nil {
-		t.Fatalf("unexpected error for UTF-8 name at max rune count: %v", err)
-	}
-
-	name = strings.Repeat("中", interfaces.NAME_MAX_LENGTH+1)
-	err := validateName(context.Background(), name)
-	if err == nil {
-		t.Fatal("expected error for UTF-8 name exceeding max rune count")
-	}
-}
-
-// ===== ValidateTags =====
-
-func TestValidateTags_Valid(t *testing.T) {
-	tags := []string{"tag1", "tag2"}
-	if err := ValidateTags(context.Background(), tags); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestValidateTags_Empty(t *testing.T) {
-	if err := ValidateTags(context.Background(), []string{}); err != nil {
-		t.Fatalf("unexpected error for empty tags: %v", err)
-	}
-}
-
-func TestValidateTags_ExceedsMaxNumber(t *testing.T) {
-	tags := make([]string, interfaces.TAGS_MAX_NUMBER+1)
-	for i := range tags {
-		tags[i] = "tag"
-	}
-	err := ValidateTags(context.Background(), tags)
-	if err == nil {
-		t.Fatal("expected error for exceeding max tag count")
-	}
-}
-
-func TestValidateTags_InvalidTagInList(t *testing.T) {
-	tags := []string{"good-tag", "bad/tag"}
-	err := ValidateTags(context.Background(), tags)
-	if err == nil {
-		t.Fatal("expected error for invalid tag character")
-	}
-}
-
-// ===== validateTag =====
-
-func TestValidateTag_Valid(t *testing.T) {
-	if err := validateTag(context.Background(), "my-tag"); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestValidateTag_Empty(t *testing.T) {
-	err := validateTag(context.Background(), "")
-	if err == nil {
-		t.Fatal("expected error for empty tag")
-	}
-}
-
-func TestValidateTag_OnlySpaces(t *testing.T) {
-	err := validateTag(context.Background(), "   ")
-	if err == nil {
-		t.Fatal("expected error for whitespace-only tag")
-	}
-}
-
-func TestValidateTag_ExceedsMaxLength(t *testing.T) {
-	tag := strings.Repeat("a", interfaces.TAG_MAX_LENGTH+1)
-	err := validateTag(context.Background(), tag)
-	if err == nil {
-		t.Fatal("expected error for tag exceeding max length")
-	}
-}
-
-func TestValidateTag_SpecialChars(t *testing.T) {
-	invalidChars := []string{"/", ":", "?", "\\", "\"", "<", ">", "|", "#", "%", "&", "*", "$", "^", "!", "=", "."}
-	for _, ch := range invalidChars {
-		err := validateTag(context.Background(), "tag"+ch+"name")
-		if err == nil {
-			t.Errorf("expected error for tag containing '%s'", ch)
-		}
-	}
-}
-
-func TestValidateTag_TrimSpaces(t *testing.T) {
-	// 两端空格应被 trim 后正常通过
-	if err := validateTag(context.Background(), "  valid-tag  "); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-// ===== validateDescription =====
-
-func TestValidateDescription_Valid(t *testing.T) {
-	if err := validateDescription(context.Background(), "A valid description"); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestValidateDescription_Empty(t *testing.T) {
-	if err := validateDescription(context.Background(), ""); err != nil {
-		t.Fatalf("unexpected error for empty description: %v", err)
-	}
-}
-
-func TestValidateDescription_ExceedsMaxLength(t *testing.T) {
-	desc := strings.Repeat("a", interfaces.DESCRIPTION_MAX_LENGTH+1)
-	err := validateDescription(context.Background(), desc)
-	if err == nil {
-		t.Fatal("expected error for description exceeding max length")
-	}
-}
-
-// ===== validatePaginationQueryParams =====
 
 var testSortTypes = map[string]string{
 	"name":        "f_name",
 	"create_time": "f_create_time",
 }
 
-func TestPagination_Valid(t *testing.T) {
-	params, err := validatePaginationQueryParams(context.Background(),
-		"0", "10", "name", "asc", testSortTypes)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if params.Offset != 0 {
-		t.Errorf("expected offset 0, got %d", params.Offset)
-	}
-	if params.Limit != 10 {
-		t.Errorf("expected limit 10, got %d", params.Limit)
-	}
-	if params.Sort != "f_name" {
-		t.Errorf("expected sort 'f_name', got '%s'", params.Sort)
-	}
-	if params.Direction != "asc" {
-		t.Errorf("expected direction 'asc', got '%s'", params.Direction)
-	}
+func Test_Validate_Name(t *testing.T) {
+	Convey("Test validateName\n", t, func() {
+		Convey("Valid name\n", func() {
+			err := validateName(context.Background(), "test-catalog")
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Empty name\n", func() {
+			err := validateName(context.Background(), "")
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Max length name\n", func() {
+			name := strings.Repeat("a", interfaces.NAME_MAX_LENGTH)
+			err := validateName(context.Background(), name)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Exceeds max length\n", func() {
+			name := strings.Repeat("a", interfaces.NAME_MAX_LENGTH+1)
+			err := validateName(context.Background(), name)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("UTF-8 name length\n", func() {
+			name := strings.Repeat("中", interfaces.NAME_MAX_LENGTH)
+			err := validateName(context.Background(), name)
+			So(err, ShouldBeNil)
+
+			name = strings.Repeat("中", interfaces.NAME_MAX_LENGTH+1)
+			err = validateName(context.Background(), name)
+			So(err, ShouldNotBeNil)
+		})
+	})
 }
 
-func TestPagination_NoLimit(t *testing.T) {
-	params, err := validatePaginationQueryParams(context.Background(),
-		"0", "-1", "name", "desc", testSortTypes)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if params.Limit != -1 {
-		t.Errorf("expected limit -1, got %d", params.Limit)
-	}
+func Test_Validate_Tags(t *testing.T) {
+	Convey("Test ValidateTags\n", t, func() {
+		Convey("Valid tags\n", func() {
+			err := ValidateTags(context.Background(), []string{"tag1", "tag2"})
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Empty tags\n", func() {
+			err := ValidateTags(context.Background(), []string{})
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Exceeds max number\n", func() {
+			tags := make([]string, interfaces.TAGS_MAX_NUMBER+1)
+			for i := range tags {
+				tags[i] = "tag"
+			}
+			err := ValidateTags(context.Background(), tags)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Invalid tag in list\n", func() {
+			err := ValidateTags(context.Background(), []string{"good-tag", "bad/tag"})
+			So(err, ShouldNotBeNil)
+		})
+	})
 }
 
-func TestPagination_InvalidOffset(t *testing.T) {
-	_, err := validatePaginationQueryParams(context.Background(),
-		"abc", "10", "name", "asc", testSortTypes)
-	if err == nil {
-		t.Fatal("expected error for non-numeric offset")
-	}
+func Test_Validate_Tag(t *testing.T) {
+	Convey("Test validateTag\n", t, func() {
+		Convey("Valid tag\n", func() {
+			err := validateTag(context.Background(), "my-tag")
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Empty tag\n", func() {
+			err := validateTag(context.Background(), "")
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Only spaces\n", func() {
+			err := validateTag(context.Background(), "   ")
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Exceeds max length\n", func() {
+			tag := strings.Repeat("a", interfaces.TAG_MAX_LENGTH+1)
+			err := validateTag(context.Background(), tag)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Special chars\n", func() {
+			invalidChars := []string{"/", ":", "?", "\\", "\"", "<", ">", "|", "#", "%", "&", "*", "$", "^", "!", "=", "."}
+			for _, ch := range invalidChars {
+				err := validateTag(context.Background(), "tag"+ch+"name")
+				So(err, ShouldNotBeNil)
+			}
+		})
+
+		Convey("Trim spaces\n", func() {
+			err := validateTag(context.Background(), "  valid-tag  ")
+			So(err, ShouldBeNil)
+		})
+	})
 }
 
-func TestPagination_NegativeOffset(t *testing.T) {
-	_, err := validatePaginationQueryParams(context.Background(),
-		"-1", "10", "name", "asc", testSortTypes)
-	if err == nil {
-		t.Fatal("expected error for negative offset")
-	}
+func Test_Validate_Description(t *testing.T) {
+	Convey("Test validateDescription\n", t, func() {
+		Convey("Valid description\n", func() {
+			err := validateDescription(context.Background(), "A valid description")
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Empty description\n", func() {
+			err := validateDescription(context.Background(), "")
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Exceeds max length\n", func() {
+			desc := strings.Repeat("a", interfaces.DESCRIPTION_MAX_LENGTH+1)
+			err := validateDescription(context.Background(), desc)
+			So(err, ShouldNotBeNil)
+		})
+	})
 }
 
-func TestPagination_InvalidLimit(t *testing.T) {
-	_, err := validatePaginationQueryParams(context.Background(),
-		"0", "abc", "name", "asc", testSortTypes)
-	if err == nil {
-		t.Fatal("expected error for non-numeric limit")
-	}
-}
+func Test_Validate_PaginationQueryParams(t *testing.T) {
+	Convey("Test validatePaginationQueryParams\n", t, func() {
+		Convey("Valid pagination\n", func() {
+			params, err := validatePaginationQueryParams(context.Background(),
+				"0", "10", "name", "asc", testSortTypes)
+			So(err, ShouldBeNil)
+			So(params.Offset, ShouldEqual, 0)
+			So(params.Limit, ShouldEqual, 10)
+			So(params.Sort, ShouldEqual, "f_name")
+			So(params.Direction, ShouldEqual, "asc")
+		})
 
-func TestPagination_LimitTooSmall(t *testing.T) {
-	_, err := validatePaginationQueryParams(context.Background(),
-		"0", "0", "name", "asc", testSortTypes)
-	if err == nil {
-		t.Fatal("expected error for limit below minimum")
-	}
-}
+		Convey("No limit\n", func() {
+			params, err := validatePaginationQueryParams(context.Background(),
+				"0", "-1", "name", "desc", testSortTypes)
+			So(err, ShouldBeNil)
+			So(params.Limit, ShouldEqual, -1)
+		})
 
-func TestPagination_LimitTooLarge(t *testing.T) {
-	_, err := validatePaginationQueryParams(context.Background(),
-		"0", "1001", "name", "asc", testSortTypes)
-	if err == nil {
-		t.Fatal("expected error for limit exceeding maximum")
-	}
-}
+		Convey("Invalid offset\n", func() {
+			_, err := validatePaginationQueryParams(context.Background(),
+				"abc", "10", "name", "asc", testSortTypes)
+			So(err, ShouldNotBeNil)
+		})
 
-func TestPagination_InvalidSort(t *testing.T) {
-	_, err := validatePaginationQueryParams(context.Background(),
-		"0", "10", "unknown_sort", "asc", testSortTypes)
-	if err == nil {
-		t.Fatal("expected error for unsupported sort type")
-	}
-}
+		Convey("Negative offset\n", func() {
+			_, err := validatePaginationQueryParams(context.Background(),
+				"-1", "10", "name", "asc", testSortTypes)
+			So(err, ShouldNotBeNil)
+		})
 
-func TestPagination_InvalidDirection(t *testing.T) {
-	_, err := validatePaginationQueryParams(context.Background(),
-		"0", "10", "name", "up", testSortTypes)
-	if err == nil {
-		t.Fatal("expected error for invalid sort direction")
-	}
+		Convey("Invalid limit\n", func() {
+			_, err := validatePaginationQueryParams(context.Background(),
+				"0", "abc", "name", "asc", testSortTypes)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Limit too small\n", func() {
+			_, err := validatePaginationQueryParams(context.Background(),
+				"0", "0", "name", "asc", testSortTypes)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Limit too large\n", func() {
+			_, err := validatePaginationQueryParams(context.Background(),
+				"0", "1001", "name", "asc", testSortTypes)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Invalid sort\n", func() {
+			_, err := validatePaginationQueryParams(context.Background(),
+				"0", "10", "unknown_sort", "asc", testSortTypes)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Invalid direction\n", func() {
+			_, err := validatePaginationQueryParams(context.Background(),
+				"0", "10", "name", "up", testSortTypes)
+			So(err, ShouldNotBeNil)
+		})
+	})
 }


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] 重构多个 driveradapters handler，将链路追踪逻辑收敛到共享入口方法中，减少 `ctx` / `span` 参数层层传递
- [x] 新增 catalog、resource、connector type 列表查询参数校验，并补充 invalid query 的错误详情
- [x] 优化 `ListConnectorTypes` 查询参数处理，新增 `enabled` 参数校验和统一查询校验流程
- [x] 新增 driveradapters 测试工具方法，并补充 catalog、resource、connector type 和 validate 相关单元测试

---

## Why

- Related Issue: #413
- Related Feature: driveradapters REST API
- Background: 外部/内部接口共享逻辑较多，原实现需要在入口与共享方法之间传递 tracing 上下文；同时列表查询参数缺少统一校验，容易让非法参数进入后续逻辑。

---

## How

- Key implementation points:
  - 外部接口仍先使用 `rest.GetLanguageCtx(c)` 完成 OAuth 校验，内部接口生成 visitor 后进入共享处理方法
  - 在共享处理方法内部创建 server span，统一处理 tracing attr 和错误响应
  - 新增 `ValidateCatalogListQueryParams`、`ValidateResourceListQueryParams`、`ValidateConnectorTypeListQueryParams` 等校验入口
  - 扩展 connector category/mode 的可选参数校验，并为非法 query value 添加 error details
  - 补充 handler 和 validation 层单元测试覆盖
- Breaking changes (API, config, database, etc.): 无预期 breaking changes；非法查询参数会更早返回 400。

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `go test ./adp/vega/vega-backend/server/driveradapters`

---

## Risk & Rollback

- Potential risks: tracing span 创建位置调整后，需要关注外部 OAuth 失败场景是否仍满足链路追踪预期；列表 query 参数校验收紧后，历史上依赖非法参数被忽略的调用会收到 400。当前 PR mergeable_state 为 blocked，需要合并前确认阻塞原因。
- Rollback plan: 回滚本 PR 对 driveradapters handler、query validation 和对应测试的变更即可恢复旧行为。

---

## Additional Notes

- Changed files: 16 files under `adp/vega/vega-backend/server/driveradapters/`
- Additions/deletions: +1011 / -718
