### PR TITLE
fix(vega-backend): 统一 catalog/resource ID 校验逻辑并修正错误码文档

### DIFF
--- a/adp/bkn/bkn-backend/server/interfaces/common.go
+++ b/adp/bkn/bkn-backend/server/interfaces/common.go
@@ -6,10 +6,11 @@
 package interfaces
 
 import (
-	"bkn-backend/interfaces/data_type"
 	"fmt"
 
 	"github.com/kweaver-ai/kweaver-go-lib/audit"
+
+	"bkn-backend/interfaces/data_type"
 )
 
 type contextKey string // 自定义专属的key类型

--- a/adp/docs/api/vega/vega-backend-api/catalog.yaml
+++ b/adp/docs/api/vega/vega-backend-api/catalog.yaml
@@ -257,7 +257,7 @@ paths:
         全量更新指定 catalog。catalog 由路径参数 `id` 唯一确定（主键不可改）。
 
         请求体的 `id` 字段**必填**，且必须与路径参数完全一致：
-        - 缺失 → 400 `VegaBackend.Catalog.InvalidParameter.ID`。
+        - 缺失 / 格式非法 → 400 `VegaBackend.InvalidParameter.ID`。
         - 不一致 → 409 `VegaBackend.Catalog.IDMismatch`。
 
         `name` 改动后若新名称已被其它 catalog 占用，返回 409 `VegaBackend.Catalog.NameExists`。
@@ -349,7 +349,9 @@ components:
   responses:
     BadRequest:
       description: |
-        请求参数 / 请求体非法。与 `extensions` 相关的常见 errcode（命名以合入代码为准）：
+        请求参数 / 请求体非法。常见 errcode（命名以合入代码为准）：
+        - `VegaBackend.InvalidParameter.RequestBody`：body schema 不合法
+        - `VegaBackend.InvalidParameter.ID`：`id` 缺失或格式非法（小写字母/数字/`_`/`-`，首字符须为字母或数字，长度 ≤40）
         - `VegaBackend.Extensions.InvalidFormat`：`extensions` 非 object 或 key/value 非 string
         - `VegaBackend.Extensions.QuotaExceeded`：条数或长度超限
         - `VegaBackend.Extensions.ReservedKey`：key 以 `vega_` 开头
@@ -526,7 +528,7 @@ components:
         catalog 创建 / 更新请求体。
 
         - POST：`id` 可省略，由后端生成；若携带且已存在，返回 409 `VegaBackend.Catalog.IdExists`。
-        - PUT：`id` **必填**，且必须与路径参数 `id` 完全一致。缺失返回 400 `VegaBackend.Catalog.InvalidParameter.ID`，不一致返回 409 `VegaBackend.Catalog.IDMismatch`。
+        - PUT：`id` **必填**，且必须与路径参数 `id` 完全一致。缺失或格式非法返回 400 `VegaBackend.InvalidParameter.ID`，不一致返回 409 `VegaBackend.Catalog.IDMismatch`。
 
         可选 **`extensions`**（见 `EntityExtensions`）：写入规则见 `info.description`。
       type: object

--- a/adp/vega/vega-backend/server/driveradapters/validate.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate.go
@@ -26,11 +26,11 @@ func validateID(ctx context.Context, ID string) error {
 	}
 
 	// 非内置视图校验逻辑视图 id，只包含小写英文字母和数字和下划线(_)和连字符(-)，且不能以下划线开头，不能超过40个字符
-	re := regexp2.MustCompile(interfaces.RegexPattern_NonBuiltin_ViewID, regexp2.RE2)
+	re := regexp2.MustCompile(interfaces.RegexPattern_NonBuiltin_ID, regexp2.RE2)
 	match, err := re.MatchString(ID)
 	if err != nil || !match {
-		errDetails := `The ID can contain only lowercase letters, digits and underscores(_),
-			it cannot start with underscores and cannot exceed 40 characters`
+		errDetails := `The ID can contain only lowercase letters, digits, underscores(_) and hyphens(-),
+			it must start with a lowercase letter or digit and cannot exceed 40 characters`
 		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_ID).
 			WithErrorDetails(errDetails)
 	}

--- a/adp/vega/vega-backend/server/driveradapters/validate_catalog.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_catalog.go
@@ -18,6 +18,9 @@ import (
 )
 
 func ValidateCatalogRequest(ctx context.Context, req *interfaces.CatalogRequest) error {
+	if err := validateID(ctx, req.ID); err != nil {
+		return err
+	}
 	if err := validateName(ctx, req.Name); err != nil {
 		return err
 	}

--- a/adp/vega/vega-backend/server/driveradapters/validate_resource.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_resource.go
@@ -22,7 +22,6 @@ func ValidateResourceRequest(ctx context.Context, req *interfaces.ResourceReques
 	if err := validateID(ctx, req.ID); err != nil {
 		return err
 	}
-
 	if err := validateName(ctx, req.Name); err != nil {
 		return err
 	}
@@ -32,7 +31,6 @@ func ValidateResourceRequest(ctx context.Context, req *interfaces.ResourceReques
 	if err := validateDescription(ctx, req.Description); err != nil {
 		return err
 	}
-
 	if req.Extensions != nil {
 		if err := extensions.ValidateEntityExtensionsMap(ctx, *req.Extensions); err != nil {
 			return err

--- a/adp/vega/vega-backend/server/driveradapters/validate_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_test.go
@@ -56,6 +56,86 @@ func Test_Validate_Name(t *testing.T) {
 	})
 }
 
+func Test_Validate_ID(t *testing.T) {
+	Convey("Test validateID\n", t, func() {
+		Convey("Empty ID\n", func() {
+			err := validateID(context.Background(), "")
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Valid ID\n", func() {
+			err := validateID(context.Background(), "test-id_123")
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Max length ID\n", func() {
+			id := strings.Repeat("a", 40)
+			err := validateID(context.Background(), id)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Exceeds max length\n", func() {
+			id := strings.Repeat("a", 41)
+			err := validateID(context.Background(), id)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Invalid character\n", func() {
+			err := validateID(context.Background(), "test.id")
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Starts with underscore\n", func() {
+			err := validateID(context.Background(), "_test_id")
+			So(err, ShouldNotBeNil)
+		})
+	})
+}
+
+func Test_Validate_CatalogRequest_ID(t *testing.T) {
+	Convey("Test ValidateCatalogRequest ID\n", t, func() {
+		Convey("Invalid ID\n", func() {
+			req := &interfaces.CatalogRequest{
+				ID:   strings.Repeat("a", 41),
+				Name: "test-catalog",
+			}
+			err := ValidateCatalogRequest(context.Background(), req)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Valid ID\n", func() {
+			req := &interfaces.CatalogRequest{
+				ID:   "test-catalog_1",
+				Name: "test-catalog",
+			}
+			err := ValidateCatalogRequest(context.Background(), req)
+			So(err, ShouldBeNil)
+		})
+	})
+}
+
+func Test_Validate_ResourceRequest_ID(t *testing.T) {
+	Convey("Test ValidateResourceRequest ID\n", t, func() {
+		Convey("Invalid ID\n", func() {
+			req := &interfaces.ResourceRequest{
+				ID:   "test.resource",
+				Name: "test-resource",
+			}
+			err := ValidateResourceRequest(context.Background(), req)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Valid ID\n", func() {
+			req := &interfaces.ResourceRequest{
+				ID:   "test-resource_1",
+				Name: "test-resource",
+			}
+			err := ValidateResourceRequest(context.Background(), req)
+			So(err, ShouldBeNil)
+		})
+	})
+}
+
 func Test_Validate_Tags(t *testing.T) {
 	Convey("Test ValidateTags\n", t, func() {
 		Convey("Valid tags\n", func() {

--- a/adp/vega/vega-backend/server/interfaces/common.go
+++ b/adp/vega/vega-backend/server/interfaces/common.go
@@ -24,21 +24,23 @@ const (
 
 	NAME_MAX_LENGTH        = 255
 	DESCRIPTION_MAX_LENGTH = 1000
-	TAGS_MAX_NUMBER        = 5
-	TAG_MAX_LENGTH         = 40
-	TAG_INVALID_CHARACTER  = "/:?\\\"<>|：？‘’“”！《》,#[]{}%&*$^!=.'"
 
-	DEFAULT_OFFSET = "0"
-	MIN_OFFSET     = 0
-
-	DEFAULT_LIMIT = "20"
-	MIN_LIMIT     = 1
-	MAX_LIMIT     = 1000
-	NO_LIMIT      = "-1"
-
+	DEFAULT_OFFSET    = "0"
+	DEFAULT_LIMIT     = "20"
 	DEFAULT_DIRECTION = "desc"
 	DESC_DIRECTION    = "desc"
 	ASC_DIRECTION     = "asc"
+	MIN_OFFSET        = 0
+	MIN_LIMIT         = 1
+	MAX_LIMIT         = 1000
+	NO_LIMIT          = "-1"
+
+	TAG_INVALID_CHARACTER = "/:?\\\"<>|：？‘’“”！《》,#[]{}%&*$^!=.'"
+	TAG_MAX_LENGTH        = 40
+	TAGS_MAX_NUMBER       = 5
+	// id的校验
+	RegexPattern_Builtin_ID    = "^[a-z0-9_][a-z0-9_-]{0,39}$"
+	RegexPattern_NonBuiltin_ID = "^[a-z0-9][a-z0-9_-]{0,39}$"
 
 	MODULE_TYPE_CATALOG        = "catalog"
 	MODULE_TYPE_RESOURCE       = "resource"

--- a/adp/vega/vega-backend/server/interfaces/logic_view_service.go
+++ b/adp/vega/vega-backend/server/interfaces/logic_view_service.go
@@ -49,8 +49,6 @@ const (
 	MaxLength_ViewPropertyFeatureName        = 255
 	MaxLength_ViewPropertyDescription        = 1000
 	MaxLength_ViewPropertyFeatureDescription = 1000
-
-	RegexPattern_NonBuiltin_ViewID = "^[a-z0-9][a-z0-9_-]{0,39}$"
 )
 
 var (


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] 统一 catalog / resource 等接口的 ID 校验逻辑，将 `RegexPattern_NonBuiltin_ViewID` 重命名为 `RegexPattern_NonBuiltin_ID`，并新增 `RegexPattern_Builtin_ID`
- [x] 为 `ValidateCatalogRequest` 增加 `validateID` 校验，与 resource 行为对齐
- [x] 更新 `validateID` 的错误提示文案，准确反映"允许连字符 `-`、首字符须为字母或数字"的规则
- [x] 补充 `validateID` / `ValidateCatalogRequest` / `ValidateResourceRequest` 的 ID 校验单元测试
- [x] 修正 `catalog.yaml` API 文档中的错误码：统一为 `VegaBackend.InvalidParameter.ID`，并补充 `VegaBackend.InvalidParameter.RequestBody` 等说明
- [x] 调整 `interfaces/common.go` 常量排版与 import 顺序

---

## Why

- Related Issue: #453
- Background:
  - catalog 接口缺失 ID 格式校验，非法 ID 可直达后端
  - ID 正则常量命名仅服务于 logic view，复用到 catalog/resource 时语义不准确
  - API 文档中的错误码命名与代码实际返回的 errcode 不一致（`VegaBackend.Catalog.InvalidParameter.ID` vs 代码中的 `VegaBackend.InvalidParameter.ID`）

---

## How

- 关键实现点：
  - `interfaces/common.go`：新增 `RegexPattern_Builtin_ID` / `RegexPattern_NonBuiltin_ID`，常量按语义分组重排
  - `interfaces/logic_view_service.go`：移除原 `RegexPattern_NonBuiltin_ViewID`
  - `driveradapters/validate.go`：切换为新常量，错误详情同步更新
  - `driveradapters/validate_catalog.go`：在 name 校验前先做 ID 校验
  - `driveradapters/validate_test.go`：新增 `Test_Validate_ID` / `Test_Validate_CatalogRequest_ID` / `Test_Validate_ResourceRequest_ID`
  - `docs/api/vega/vega-backend-api/catalog.yaml`：修正错误码与说明
- Breaking changes：
  - 常量重命名 `RegexPattern_NonBuiltin_ViewID` → `RegexPattern_NonBuiltin_ID`（内部使用，影响范围限于 vega-backend）
  - catalog 接口此前接受的非法 ID 现在会返回 400 `VegaBackend.InvalidParameter.ID`

---

## Testing

- [x] Unit tests passed locally（新增 ID 校验用例覆盖空值 / 合法 / 边界长度 / 越界 / 非法字符 / 非法起始字符）
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes：

- `go test ./adp/vega/vega-backend/server/driveradapters/...`

---

## Risk & Rollback

- 潜在风险：catalog 接口收紧 ID 校验后，历史依赖非法 ID 的调用方会被拒绝；需关注上游对接情况
- 回滚方案：revert 本 PR 即可恢复旧的 ID 校验行为；常量与错误码独立无下游存储变更

---

## Additional Notes

- 相关 commits：
  - refactor(vega-backend): 统一ID校验逻辑并补全相关校验
  - docs(vega-backend-api): update catalog api error code definitions