### PR TITLE
feat(vega-backend): 新增调度时间范围校验并重构 Update 接口签名

### DIFF
--- a/adp/docs/api/vega/vega-backend-api/discover-schedule.yaml
+++ b/adp/docs/api/vega/vega-backend-api/discover-schedule.yaml
@@ -31,6 +31,8 @@ paths:
         - body 中 `enabled=true` 时，创建后立即注册到 cron 引擎；`false` 时仅入库不调度。
         - `cron_expr` 必填，标准 5 字段格式；非法返回 400 `VegaBackend.DiscoverSchedule.InvalidCronExpr`。
         - `strategies` 可空（表示全部）；非空时元素必须是 `insert` / `delete` / `update` 的子集。
+        - `start_time` / `end_time` 均 ≥ 0；`end_time>0` 时要求 `start_time ≤ end_time`；非法返回
+          400 `VegaBackend.DiscoverSchedule.InvalidTimeRange`。
       requestBody:
         required: true
         content:
@@ -114,15 +116,15 @@ paths:
       summary: 严格更新调度
       description: |
         **严格全量替换**，**只允许变更"配置"字段**（`cron_expr` / `strategies` /
-        `start_time` / `end_time`）。下列字段在 body 中携带且与当前不一致时返回 409：
+        `start_time` / `end_time`）。下列字段约束如下：
 
-        | 字段 | errcode | 说明 |
+        | 字段 | 约束 | 失败 errcode |
         |---|---|---|
-        | `id` | `DiscoverSchedule.IdMismatch` | path 为权威来源；body 可省略 |
-        | `catalog_id` | `DiscoverSchedule.CatalogMismatch` | 创建后归属不可改；如要换 catalog 请新建 |
-        | `enabled` | `DiscoverSchedule.EnabledFieldNotAllowed` | 状态切换走 `POST .../enable` `disable` |
+        | `catalog_id` | 必须显式携带且等于当前值（空串 / 缺失同样视为不一致） | `DiscoverSchedule.CatalogMismatch`（409） |
+        | `enabled` | 必须与当前一致；状态切换走 `POST .../enable` `disable` | `DiscoverSchedule.EnabledFieldNotAllowed`（409） |
 
-        其它系统维护字段（`last_run` / `next_run` / 时间戳 / 操作者）携带时静默忽略。
+        `id` 字段在 body 中携带时被忽略，path 为权威来源。其它系统维护字段
+        （`last_run` / `next_run` / 时间戳 / 操作者）携带时静默忽略。
 
         若 schedule 当前 `enabled=true`，更新后调度器会重新注册以应用新 cron。
       requestBody:
@@ -216,6 +218,7 @@ components:
         - `VegaBackend.InvalidParameter.RequestBody`：body schema 不合法
         - `VegaBackend.DiscoverSchedule.InvalidCronExpr`：cron 表达式非法
         - `VegaBackend.DiscoverSchedule.InvalidStrategies`：strategies 元素非法
+        - `VegaBackend.DiscoverSchedule.InvalidTimeRange`：`start_time` / `end_time` 非法
       content:
         application/json:
           schema:
@@ -244,7 +247,6 @@ components:
     Conflict:
       description: |
         PUT 严格更新冲突。errcode：
-        - `VegaBackend.DiscoverSchedule.IdMismatch`
         - `VegaBackend.DiscoverSchedule.CatalogMismatch`
         - `VegaBackend.DiscoverSchedule.EnabledFieldNotAllowed`
       content:
@@ -320,13 +322,19 @@ components:
           description: 标准 5 字段 cron 表达式
           type: string
         start_time:
-          description: 调度生效起始时间，毫秒时间戳
+          description: |
+            调度生效起始时间，毫秒时间戳；0 表示无起始限制。
+            调度器到点触发时，若当前时间小于 `start_time` 则跳过本次执行。
           type: integer
           format: int64
+          minimum: 0
         end_time:
-          description: 调度结束时间，毫秒时间戳；0 表示无结束时间
+          description: |
+            调度结束时间，毫秒时间戳；0 表示无结束时间。
+            调度器到点触发时，若当前时间大于 `end_time` 则**自动 disable** 该 schedule 并从 cron 引擎注销。
           type: integer
           format: int64
+          minimum: 0
         enabled:
           description: |
             是否启用；**只读**输出字段，状态切换走 `POST .../enable` `POST .../disable`
@@ -366,7 +374,8 @@ components:
         创建 / 更新请求体。
 
         - 创建时 `catalog_id` 与 `cron_expr` 必填；`enabled` 默认 false（可同时传 true 一步启用）
-        - PUT 时三个只读字段（id / catalog_id / enabled）允许省略；如携带必须与当前一致
+        - PUT 时 `catalog_id` 必填且必须与当前一致（空串 / 缺失视为不一致 → 409 CatalogMismatch）；
+          `enabled` 必须与当前一致（否则 409 EnabledFieldNotAllowed）；`id` 可省略，携带时被忽略
       type: object
       properties:
         id:
@@ -379,11 +388,17 @@ components:
           description: 标准 5 字段 cron 表达式（必填）
           type: string
         start_time:
+          description: 调度生效起始时间，毫秒时间戳；0 表示无起始限制。须 ≥ 0
           type: integer
           format: int64
+          minimum: 0
         end_time:
+          description: |
+            调度结束时间，毫秒时间戳；0 表示无结束时间。
+            须 ≥ 0，且 `end_time>0` 时要求 `start_time ≤ end_time`
           type: integer
           format: int64
+          minimum: 0
         enabled:
           description: |
             创建时可选（默认 false）；PUT 时必须与当前一致，否则 409 EnabledFieldNotAllowed

--- a/adp/vega/vega-backend/server/driveradapters/catalog_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/catalog_handler.go
@@ -382,7 +382,6 @@ func (r *restHandler) updateCatalog(c *gin.Context, visitor hydra.Visitor) {
 		rest.ReplyError(c, httpErr)
 		return
 	}
-	req.OriginCatalog = catalog
 
 	// Validate immutable fields
 	// connector_type cannot be modified
@@ -452,10 +451,9 @@ func (r *restHandler) updateCatalog(c *gin.Context, visitor hydra.Visitor) {
 			rest.ReplyError(c, httpErr)
 			return
 		}
-		req.IfNameModify = true
 	}
 
-	if err := r.cs.Update(ctx, id, &req); err != nil {
+	if err := r.cs.Update(ctx, catalog, &req); err != nil {
 		httpErr := err.(*rest.HTTPError)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)

--- a/adp/vega/vega-backend/server/driveradapters/connector_type_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/connector_type_handler.go
@@ -280,7 +280,6 @@ func (r *restHandler) UpdateConnectorType(c *gin.Context) {
 		rest.ReplyError(c, httpErr)
 		return
 	}
-	req.OriginConnectorType = connectorType
 
 	// Apply updates
 	if req.Name != connectorType.Name {
@@ -297,10 +296,9 @@ func (r *restHandler) UpdateConnectorType(c *gin.Context) {
 			rest.ReplyError(c, httpErr)
 			return
 		}
-		req.IfNameModify = true
 	}
 
-	if err := r.cts.Update(ctx, &req); err != nil {
+	if err := r.cts.Update(ctx, connectorType, &req); err != nil {
 		httpErr := err.(*rest.HTTPError)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)

--- a/adp/vega/vega-backend/server/driveradapters/connector_type_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/connector_type_handler_test.go
@@ -76,7 +76,7 @@ func Test_ConnectorTypeRestHandler_UpdateConnectorType(t *testing.T) {
 					Mode:     interfaces.ConnectorModeLocal,
 					Category: interfaces.ConnectorCategoryTable,
 				}, nil)
-			cts.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
+			cts.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 			reqParamByte, _ := sonic.Marshal(reqData)
 			req := httptest.NewRequest(http.MethodPut, url, bytes.NewReader(reqParamByte))
@@ -101,7 +101,7 @@ func Test_ConnectorTypeRestHandler_UpdateConnectorType(t *testing.T) {
 					Mode:     interfaces.ConnectorModeLocal,
 					Category: interfaces.ConnectorCategoryFileset,
 				}, nil)
-			cts.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
+			cts.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 			reqParamByte, _ := sonic.Marshal(reqData)
 			req := httptest.NewRequest(http.MethodPut, url, bytes.NewReader(reqParamByte))

--- a/adp/vega/vega-backend/server/driveradapters/discover_schedule_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/discover_schedule_handler.go
@@ -17,8 +17,6 @@ import (
 	"github.com/kweaver-ai/kweaver-go-lib/logger"
 	"github.com/kweaver-ai/kweaver-go-lib/otel/oteltrace"
 	"github.com/kweaver-ai/kweaver-go-lib/rest"
-	"github.com/robfig/cron/v3"
-	"go.opentelemetry.io/otel/trace"
 
 	"vega-backend/common/visitor"
 	verrors "vega-backend/errors"
@@ -59,9 +57,8 @@ func (r *restHandler) createDiscoverSchedule(c *gin.Context, visitor hydra.Visit
 		return
 	}
 
-	if req.CatalogID == "" {
-		httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_RequestBody).
-			WithErrorDetails("catalog_id is required")
+	if err := ValidateDiscoverScheduleRequest(ctx, &req); err != nil {
+		httpErr := err.(*rest.HTTPError)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
 		return
@@ -78,10 +75,6 @@ func (r *restHandler) createDiscoverSchedule(c *gin.Context, visitor hydra.Visit
 		httpErr := rest.NewHTTPError(ctx, http.StatusNotFound, verrors.VegaBackend_Catalog_NotFound)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
-		return
-	}
-
-	if err := validateCronExprAndStrategies(ctx, span, c, req.CronExpr, req.Strategies); err != nil {
 		return
 	}
 
@@ -248,7 +241,7 @@ func (r *restHandler) updateDiscoverSchedule(c *gin.Context, visitor hydra.Visit
 		return
 	}
 
-	var req interfaces.DiscoverSchedule
+	var req interfaces.DiscoverScheduleRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_RequestBody).
 			WithErrorDetails(err.Error())
@@ -257,15 +250,15 @@ func (r *restHandler) updateDiscoverSchedule(c *gin.Context, visitor hydra.Visit
 		return
 	}
 
-	// Strict checks: id / catalog_id / enabled are read-only here.
-	if req.ID != "" && req.ID != id {
-		httpErr := rest.NewHTTPError(ctx, http.StatusConflict, verrors.VegaBackend_DiscoverSchedule_IdMismatch).
-			WithErrorDetails(fmt.Sprintf("body.id=%s does not match path id=%s", req.ID, id))
+	if err := ValidateDiscoverScheduleRequest(ctx, &req); err != nil {
+		httpErr := err.(*rest.HTTPError)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
 		return
 	}
-	if req.CatalogID != "" && req.CatalogID != current.CatalogID {
+
+	// Strict checks: catalog_id / enabled are read-only here.
+	if req.CatalogID != current.CatalogID {
 		httpErr := rest.NewHTTPError(ctx, http.StatusConflict, verrors.VegaBackend_DiscoverSchedule_CatalogMismatch).
 			WithErrorDetails(fmt.Sprintf("catalog_id is read-only; current=%s, body=%s", current.CatalogID, req.CatalogID))
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
@@ -280,16 +273,7 @@ func (r *restHandler) updateDiscoverSchedule(c *gin.Context, visitor hydra.Visit
 		return
 	}
 
-	if err := validateCronExprAndStrategies(ctx, span, c, req.CronExpr, req.Strategies); err != nil {
-		return
-	}
-
-	// Force authoritative fields from path / current state.
-	req.ID = id
-	req.CatalogID = current.CatalogID
-	req.Enabled = current.Enabled
-
-	if err := r.dss.Update(ctx, id, &req); err != nil {
+	if err := r.dss.Update(ctx, current, &req); err != nil {
 		httpErr := rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_DiscoverSchedule_InternalError_UpdateFailed).
 			WithErrorDetails(err.Error())
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
@@ -466,34 +450,4 @@ func (r *restHandler) toggleDiscoverSchedule(c *gin.Context, visitor hydra.Visit
 
 	oteltrace.AddHttpAttrs4Ok(span, http.StatusNoContent)
 	rest.ReplyOK(c, http.StatusNoContent, nil)
-}
-
-// =========================== helpers ===========================
-
-// validateCronExprAndStrategies validates cron expression and strategies; on failure replies error and returns non-nil.
-func validateCronExprAndStrategies(ctx context.Context, span trace.Span, c *gin.Context, cronExpr string, strategies []string) error {
-	if cronExpr == "" {
-		httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_DiscoverSchedule_InvalidCronExpr).
-			WithErrorDetails("cron_expr is required")
-		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
-		rest.ReplyError(c, httpErr)
-		return httpErr
-	}
-	if _, err := cron.ParseStandard(cronExpr); err != nil {
-		httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_DiscoverSchedule_InvalidCronExpr).
-			WithErrorDetails(fmt.Sprintf("invalid cron expression: %v", err))
-		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
-		rest.ReplyError(c, httpErr)
-		return httpErr
-	}
-	if len(strategies) > 0 {
-		if err := validateStrategies(strategies); err != nil {
-			httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_DiscoverSchedule_InvalidStrategies).
-				WithErrorDetails(err.Error())
-			oteltrace.AddHttpAttrs4HttpError(span, httpErr)
-			rest.ReplyError(c, httpErr)
-			return httpErr
-		}
-	}
-	return nil
 }

--- a/adp/vega/vega-backend/server/driveradapters/resource_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_handler.go
@@ -369,7 +369,6 @@ func (r *restHandler) updateResource(c *gin.Context, visitor hydra.Visitor) {
 		rest.ReplyError(c, httpErr)
 		return
 	}
-	req.OriginResource = resource
 
 	// Apply updates
 	if req.Name != resource.Name {
@@ -387,10 +386,9 @@ func (r *restHandler) updateResource(c *gin.Context, visitor hydra.Visitor) {
 			rest.ReplyError(c, httpErr)
 			return
 		}
-		req.IfNameModify = true
 	}
 
-	if err := r.rs.Update(ctx, id, &req); err != nil {
+	if err := r.rs.Update(ctx, resource, &req); err != nil {
 		httpErr := err.(*rest.HTTPError)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)

--- a/adp/vega/vega-backend/server/driveradapters/validate_discover_schedule.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_discover_schedule.go
@@ -1,0 +1,53 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package driveradapters
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/kweaver-ai/kweaver-go-lib/rest"
+	"github.com/robfig/cron/v3"
+
+	verrors "vega-backend/errors"
+	"vega-backend/interfaces"
+)
+
+func ValidateDiscoverScheduleRequest(ctx context.Context, req *interfaces.DiscoverScheduleRequest) error {
+	if req.CatalogID == "" {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_RequestBody).
+			WithErrorDetails("catalog_id is required")
+	}
+	if req.CronExpr == "" {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_DiscoverSchedule_InvalidCronExpr).
+			WithErrorDetails("cron_expr is required")
+	}
+	if _, err := cron.ParseStandard(req.CronExpr); err != nil {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_DiscoverSchedule_InvalidCronExpr).
+			WithErrorDetails(fmt.Sprintf("invalid cron expression: %v", err))
+	}
+	if len(req.Strategies) > 0 {
+		if err := validateStrategies(req.Strategies); err != nil {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_DiscoverSchedule_InvalidStrategies).
+				WithErrorDetails(err.Error())
+		}
+	}
+	var errDetails string
+	switch {
+	case req.StartTime < 0:
+		errDetails = "start_time must be greater than or equal to 0"
+	case req.EndTime < 0:
+		errDetails = "end_time must be greater than or equal to 0"
+	case req.EndTime > 0 && req.StartTime > req.EndTime:
+		errDetails = "start_time must be less than or equal to end_time"
+	}
+	if errDetails != "" {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_DiscoverSchedule_InvalidTimeRange).
+			WithErrorDetails(errDetails)
+	}
+	return nil
+}

--- a/adp/vega/vega-backend/server/driveradapters/validate_discover_schedule_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_discover_schedule_test.go
@@ -1,0 +1,92 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package driveradapters
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"vega-backend/interfaces"
+)
+
+func Test_ValidateDiscoverScheduleRequest(t *testing.T) {
+	Convey("Test ValidateDiscoverScheduleRequest\n", t, func() {
+		validReq := func() *interfaces.DiscoverScheduleRequest {
+			return &interfaces.DiscoverScheduleRequest{
+				CatalogID:  "catalog-1",
+				CronExpr:   "*/5 * * * *",
+				StartTime:  1000,
+				EndTime:    2000,
+				Strategies: []string{"insert", "update"},
+			}
+		}
+
+		Convey("Valid request\n", func() {
+			err := ValidateDiscoverScheduleRequest(context.Background(), validReq())
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Missing catalog ID\n", func() {
+			req := validReq()
+			req.CatalogID = ""
+			err := ValidateDiscoverScheduleRequest(context.Background(), req)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Missing cron expression\n", func() {
+			req := validReq()
+			req.CronExpr = ""
+			err := ValidateDiscoverScheduleRequest(context.Background(), req)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Invalid cron expression\n", func() {
+			req := validReq()
+			req.CronExpr = "invalid"
+			err := ValidateDiscoverScheduleRequest(context.Background(), req)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Invalid strategy\n", func() {
+			req := validReq()
+			req.Strategies = []string{"unknown"}
+			err := ValidateDiscoverScheduleRequest(context.Background(), req)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Invalid time range\n", func() {
+			req := validReq()
+			req.StartTime = 2000
+			req.EndTime = 1000
+			err := ValidateDiscoverScheduleRequest(context.Background(), req)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Valid time range without end time\n", func() {
+			req := validReq()
+			req.StartTime = 0
+			req.EndTime = 0
+			err := ValidateDiscoverScheduleRequest(context.Background(), req)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Negative start time\n", func() {
+			req := validReq()
+			req.StartTime = -1
+			err := ValidateDiscoverScheduleRequest(context.Background(), req)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Negative end time\n", func() {
+			req := validReq()
+			req.EndTime = -1
+			err := ValidateDiscoverScheduleRequest(context.Background(), req)
+			So(err, ShouldNotBeNil)
+		})
+	})
+}

--- a/adp/vega/vega-backend/server/errors/discover_schedule.go
+++ b/adp/vega/vega-backend/server/errors/discover_schedule.go
@@ -13,6 +13,7 @@ const (
 	// 400 Bad Request
 	VegaBackend_DiscoverSchedule_InvalidCronExpr   = "VegaBackend.DiscoverSchedule.InvalidCronExpr"
 	VegaBackend_DiscoverSchedule_InvalidStrategies = "VegaBackend.DiscoverSchedule.InvalidStrategies"
+	VegaBackend_DiscoverSchedule_InvalidTimeRange  = "VegaBackend.DiscoverSchedule.InvalidTimeRange"
 
 	// 409 Conflict
 	VegaBackend_DiscoverSchedule_IdMismatch             = "VegaBackend.DiscoverSchedule.IdMismatch"
@@ -31,6 +32,7 @@ var (
 		VegaBackend_DiscoverSchedule_NotFound,
 		VegaBackend_DiscoverSchedule_InvalidCronExpr,
 		VegaBackend_DiscoverSchedule_InvalidStrategies,
+		VegaBackend_DiscoverSchedule_InvalidTimeRange,
 		VegaBackend_DiscoverSchedule_IdMismatch,
 		VegaBackend_DiscoverSchedule_CatalogMismatch,
 		VegaBackend_DiscoverSchedule_EnabledFieldNotAllowed,

--- a/adp/vega/vega-backend/server/interfaces/catalog.go
+++ b/adp/vega/vega-backend/server/interfaces/catalog.go
@@ -67,8 +67,8 @@ type CatalogsQueryParams struct {
 	Type              string
 	HealthCheckStatus string
 	// ExtensionKeys / ExtensionValues 成对等长，多对 AND（列表筛选）
-	ExtensionKeys   []string
-	ExtensionValues []string
+	ExtensionKeys        []string
+	ExtensionValues      []string
 	IncludeExtensions    bool
 	IncludeExtensionKeys string
 }
@@ -84,9 +84,6 @@ type CatalogRequest struct {
 
 	// Extensions 根对象出现该键（含 null 需客户端避免）时整包替换；指针为 nil 表示请求体未携带该字段
 	Extensions *map[string]string `json:"extensions,omitempty"`
-
-	IfNameModify  bool     `json:"-"`
-	OriginCatalog *Catalog `json:"-"`
 }
 
 type ListCatalogsQueryParams struct {

--- a/adp/vega/vega-backend/server/interfaces/catalog_service.go
+++ b/adp/vega/vega-backend/server/interfaces/catalog_service.go
@@ -20,7 +20,7 @@ type CatalogService interface {
 	// List lists Catalogs with filters.
 	List(ctx context.Context, params CatalogsQueryParams) ([]*Catalog, int64, error)
 	// Update updates a Catalog.
-	Update(ctx context.Context, id string, req *CatalogRequest) error
+	Update(ctx context.Context, catalog *Catalog, req *CatalogRequest) error
 	// DeleteByIDs deletes Catalogs by IDs.
 	DeleteByIDs(ctx context.Context, ids []string) error
 	// CheckExistByID checks if a Catalog exists by ID.

--- a/adp/vega/vega-backend/server/interfaces/connector_type.go
+++ b/adp/vega/vega-backend/server/interfaces/connector_type.go
@@ -106,7 +106,4 @@ type ConnectorTypeReq struct {
 	Endpoint    string                          `json:"endpoint"`     // 仅 remote 模式，远程服务地址
 	FieldConfig map[string]ConnectorFieldConfig `json:"field_config"` // 字段配置（兼容 JSON Schema properties）
 	Enabled     bool                            `json:"enabled"`      // 是否启用
-
-	IfNameModify        bool           `json:"-"`
-	OriginConnectorType *ConnectorType `json:"-"`
 }

--- a/adp/vega/vega-backend/server/interfaces/connector_type_service.go
+++ b/adp/vega/vega-backend/server/interfaces/connector_type_service.go
@@ -14,7 +14,7 @@ type ConnectorTypeService interface {
 	// Register 注册 connector 类型
 	Register(ctx context.Context, ct *ConnectorTypeReq) error
 	// Update 更新 connector 类型
-	Update(ctx context.Context, ct *ConnectorTypeReq) error
+	Update(ctx context.Context, ct *ConnectorType, req *ConnectorTypeReq) error
 	// Delete 删除 connector 类型
 	DeleteByType(ctx context.Context, tp string) error
 	// GetByType 根据类型获取 connector 类型

--- a/adp/vega/vega-backend/server/interfaces/discover_schedule_access.go
+++ b/adp/vega/vega-backend/server/interfaces/discover_schedule_access.go
@@ -19,6 +19,10 @@ type DiscoverScheduleAccess interface {
 	List(ctx context.Context, params DiscoverScheduleQueryParams) ([]*DiscoverSchedule, int64, error)
 	// Update updates a discover schedule.
 	Update(ctx context.Context, schedule *DiscoverSchedule) error
+	// Enable enables a discover schedule.
+	Enable(ctx context.Context, id string) error
+	// Disable disables a discover schedule.
+	Disable(ctx context.Context, id string) error
 	// Delete deletes a discover schedule by ID.
 	Delete(ctx context.Context, id string) error
 	// GetEnabledSchedules retrieves all enabled discover schedules.

--- a/adp/vega/vega-backend/server/interfaces/discover_schedule_service.go
+++ b/adp/vega/vega-backend/server/interfaces/discover_schedule_service.go
@@ -18,7 +18,7 @@ type DiscoverScheduleService interface {
 	// List lists discover schedules.
 	List(ctx context.Context, params DiscoverScheduleQueryParams) ([]*DiscoverSchedule, int64, error)
 	// Update updates a discover schedule.
-	Update(ctx context.Context, id string, req *DiscoverSchedule) error
+	Update(ctx context.Context, current *DiscoverSchedule, req *DiscoverScheduleRequest) error
 	// Delete deletes a discover schedule by ID.
 	Delete(ctx context.Context, id string) error
 	// Enable enables a discover schedule.

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_catalog_access.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_catalog_access.go
@@ -41,6 +41,20 @@ func (m *MockCatalogAccess) EXPECT() *MockCatalogAccessMockRecorder {
 	return m.recorder
 }
 
+// AttachListExtensions mocks base method.
+func (m *MockCatalogAccess) AttachListExtensions(ctx context.Context, params interfaces.CatalogsQueryParams, catalogs []*interfaces.Catalog) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AttachListExtensions", ctx, params, catalogs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AttachListExtensions indicates an expected call of AttachListExtensions.
+func (mr *MockCatalogAccessMockRecorder) AttachListExtensions(ctx, params, catalogs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachListExtensions", reflect.TypeOf((*MockCatalogAccess)(nil).AttachListExtensions), ctx, params, catalogs)
+}
+
 // Create mocks base method.
 func (m *MockCatalogAccess) Create(ctx context.Context, catalog *interfaces.Catalog) error {
 	m.ctrl.T.Helper()
@@ -97,20 +111,6 @@ func (m *MockCatalogAccess) GetByIDs(ctx context.Context, ids []string) ([]*inte
 func (mr *MockCatalogAccessMockRecorder) GetByIDs(ctx, ids any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByIDs", reflect.TypeOf((*MockCatalogAccess)(nil).GetByIDs), ctx, ids)
-}
-
-// AttachListExtensions mocks base method.
-func (m *MockCatalogAccess) AttachListExtensions(ctx context.Context, params interfaces.CatalogsQueryParams, catalogs []*interfaces.Catalog) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AttachListExtensions", ctx, params, catalogs)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// AttachListExtensions indicates an expected call of AttachListExtensions.
-func (mr *MockCatalogAccessMockRecorder) AttachListExtensions(ctx, params, catalogs any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachListExtensions", reflect.TypeOf((*MockCatalogAccess)(nil).AttachListExtensions), ctx, params, catalogs)
 }
 
 // GetByName mocks base method.

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_catalog_service.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_catalog_service.go
@@ -178,17 +178,17 @@ func (mr *MockCatalogServiceMockRecorder) TestConnection(ctx, catalog any) *gomo
 }
 
 // Update mocks base method.
-func (m *MockCatalogService) Update(ctx context.Context, id string, req *interfaces.CatalogRequest) error {
+func (m *MockCatalogService) Update(ctx context.Context, catalog *interfaces.Catalog, req *interfaces.CatalogRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Update", ctx, id, req)
+	ret := m.ctrl.Call(m, "Update", ctx, catalog, req)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Update indicates an expected call of Update.
-func (mr *MockCatalogServiceMockRecorder) Update(ctx, id, req any) *gomock.Call {
+func (mr *MockCatalogServiceMockRecorder) Update(ctx, catalog, req any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockCatalogService)(nil).Update), ctx, id, req)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockCatalogService)(nil).Update), ctx, catalog, req)
 }
 
 // UpdateMetadata mocks base method.

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_connector_type_service.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_connector_type_service.go
@@ -145,15 +145,15 @@ func (mr *MockConnectorTypeServiceMockRecorder) SetEnabled(ctx, tp, enabled any)
 }
 
 // Update mocks base method.
-func (m *MockConnectorTypeService) Update(ctx context.Context, ct *interfaces.ConnectorTypeReq) error {
+func (m *MockConnectorTypeService) Update(ctx context.Context, ct *interfaces.ConnectorType, req *interfaces.ConnectorTypeReq) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Update", ctx, ct)
+	ret := m.ctrl.Call(m, "Update", ctx, ct, req)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Update indicates an expected call of Update.
-func (mr *MockConnectorTypeServiceMockRecorder) Update(ctx, ct any) *gomock.Call {
+func (mr *MockConnectorTypeServiceMockRecorder) Update(ctx, ct, req any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockConnectorTypeService)(nil).Update), ctx, ct)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockConnectorTypeService)(nil).Update), ctx, ct, req)
 }

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_discover_schedule_access.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_discover_schedule_access.go
@@ -69,6 +69,34 @@ func (mr *MockDiscoverScheduleAccessMockRecorder) Delete(ctx, id any) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockDiscoverScheduleAccess)(nil).Delete), ctx, id)
 }
 
+// Disable mocks base method.
+func (m *MockDiscoverScheduleAccess) Disable(ctx context.Context, id string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Disable", ctx, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Disable indicates an expected call of Disable.
+func (mr *MockDiscoverScheduleAccessMockRecorder) Disable(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Disable", reflect.TypeOf((*MockDiscoverScheduleAccess)(nil).Disable), ctx, id)
+}
+
+// Enable mocks base method.
+func (m *MockDiscoverScheduleAccess) Enable(ctx context.Context, id string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Enable", ctx, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Enable indicates an expected call of Enable.
+func (mr *MockDiscoverScheduleAccessMockRecorder) Enable(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Enable", reflect.TypeOf((*MockDiscoverScheduleAccess)(nil).Enable), ctx, id)
+}
+
 // GetByID mocks base method.
 func (m *MockDiscoverScheduleAccess) GetByID(ctx context.Context, id string) (*interfaces.DiscoverSchedule, error) {
 	m.ctrl.T.Helper()

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_discover_schedule_service.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_discover_schedule_service.go
@@ -159,17 +159,17 @@ func (mr *MockDiscoverScheduleServiceMockRecorder) List(ctx, params any) *gomock
 }
 
 // Update mocks base method.
-func (m *MockDiscoverScheduleService) Update(ctx context.Context, id string, req *interfaces.DiscoverSchedule) error {
+func (m *MockDiscoverScheduleService) Update(ctx context.Context, current *interfaces.DiscoverSchedule, req *interfaces.DiscoverScheduleRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Update", ctx, id, req)
+	ret := m.ctrl.Call(m, "Update", ctx, current, req)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Update indicates an expected call of Update.
-func (mr *MockDiscoverScheduleServiceMockRecorder) Update(ctx, id, req any) *gomock.Call {
+func (mr *MockDiscoverScheduleServiceMockRecorder) Update(ctx, current, req any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockDiscoverScheduleService)(nil).Update), ctx, id, req)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockDiscoverScheduleService)(nil).Update), ctx, current, req)
 }
 
 // UpdateLastRun mocks base method.

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_resource_access.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_resource_access.go
@@ -41,6 +41,20 @@ func (m *MockResourceAccess) EXPECT() *MockResourceAccessMockRecorder {
 	return m.recorder
 }
 
+// AttachListExtensions mocks base method.
+func (m *MockResourceAccess) AttachListExtensions(ctx context.Context, params interfaces.ResourcesQueryParams, resources []*interfaces.Resource) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AttachListExtensions", ctx, params, resources)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AttachListExtensions indicates an expected call of AttachListExtensions.
+func (mr *MockResourceAccessMockRecorder) AttachListExtensions(ctx, params, resources any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachListExtensions", reflect.TypeOf((*MockResourceAccess)(nil).AttachListExtensions), ctx, params, resources)
+}
+
 // CheckExistByCategories mocks base method.
 func (m *MockResourceAccess) CheckExistByCategories(ctx context.Context, catalogID string, categories []string) (bool, error) {
 	m.ctrl.T.Helper()
@@ -156,20 +170,6 @@ func (m *MockResourceAccess) GetByIDsBasic(ctx context.Context, ids []string) ([
 func (mr *MockResourceAccessMockRecorder) GetByIDsBasic(ctx, ids any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByIDsBasic", reflect.TypeOf((*MockResourceAccess)(nil).GetByIDsBasic), ctx, ids)
-}
-
-// AttachListExtensions mocks base method.
-func (m *MockResourceAccess) AttachListExtensions(ctx context.Context, params interfaces.ResourcesQueryParams, resources []*interfaces.Resource) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AttachListExtensions", ctx, params, resources)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// AttachListExtensions indicates an expected call of AttachListExtensions.
-func (mr *MockResourceAccessMockRecorder) AttachListExtensions(ctx, params, resources any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachListExtensions", reflect.TypeOf((*MockResourceAccess)(nil).AttachListExtensions), ctx, params, resources)
 }
 
 // GetByName mocks base method.

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_resource_service.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_resource_service.go
@@ -208,17 +208,17 @@ func (mr *MockResourceServiceMockRecorder) ListResourceSrcs(ctx, params any) *go
 }
 
 // Update mocks base method.
-func (m *MockResourceService) Update(ctx context.Context, id string, req *interfaces.ResourceRequest) error {
+func (m *MockResourceService) Update(ctx context.Context, resource *interfaces.Resource, req *interfaces.ResourceRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Update", ctx, id, req)
+	ret := m.ctrl.Call(m, "Update", ctx, resource, req)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Update indicates an expected call of Update.
-func (mr *MockResourceServiceMockRecorder) Update(ctx, id, req any) *gomock.Call {
+func (mr *MockResourceServiceMockRecorder) Update(ctx, resource, req any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockResourceService)(nil).Update), ctx, id, req)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockResourceService)(nil).Update), ctx, resource, req)
 }
 
 // UpdateResource mocks base method.

--- a/adp/vega/vega-backend/server/interfaces/resource.go
+++ b/adp/vega/vega-backend/server/interfaces/resource.go
@@ -94,12 +94,12 @@ type PropertyFeature struct {
 // ResourcesQueryParams holds resource list query parameters.
 type ResourcesQueryParams struct {
 	PaginationQueryParams
-	CatalogID string
-	Category  string
-	Status    string
-	Database  string
-	ExtensionKeys   []string
-	ExtensionValues []string
+	CatalogID            string
+	Category             string
+	Status               string
+	Database             string
+	ExtensionKeys        []string
+	ExtensionValues      []string
 	IncludeExtensions    bool
 	IncludeExtensionKeys string
 }
@@ -123,9 +123,6 @@ type ResourceRequest struct {
 	LogicDefinition  []*LogicDefinitionNode `json:"logic_definition,omitempty"`  // 逻辑定义
 
 	Extensions *map[string]string `json:"extensions,omitempty"`
-
-	IfNameModify   bool      `json:"-"`
-	OriginResource *Resource `json:"-"`
 }
 
 type ListResourcesQueryParams struct {

--- a/adp/vega/vega-backend/server/interfaces/resource_service.go
+++ b/adp/vega/vega-backend/server/interfaces/resource_service.go
@@ -24,7 +24,7 @@ type ResourceService interface {
 	// List lists Resources with filters.
 	List(ctx context.Context, params ResourcesQueryParams) ([]*Resource, int64, error)
 	// Update updates a Resource.
-	Update(ctx context.Context, id string, req *ResourceRequest) error
+	Update(ctx context.Context, resource *Resource, req *ResourceRequest) error
 	// UpdateStatus updates a Resource's status.
 	UpdateStatus(ctx context.Context, id string, status string, statusMessage string) error
 	// DeleteByIDs deletes Resources by IDs.

--- a/adp/vega/vega-backend/server/locale/discover_schedule.en-US.toml
+++ b/adp/vega/vega-backend/server/locale/discover_schedule.en-US.toml
@@ -13,6 +13,11 @@ Description = "Invalid discover strategies"
 Solution = "Strategies must be a subset of [insert, delete, update]; empty array means all"
 ErrorLink = "No solution"
 
+[VegaBackend.DiscoverSchedule.InvalidTimeRange]
+Description = "Invalid discover schedule time range"
+Solution = "start_time and end_time must be greater than or equal to 0; end_time may be 0 for no end time, otherwise start_time must be less than or equal to end_time"
+ErrorLink = "No solution"
+
 [VegaBackend.DiscoverSchedule.IdMismatch]
 Description = "Body id does not match path id"
 Solution = "Either omit body.id or set it equal to the path id"

--- a/adp/vega/vega-backend/server/locale/discover_schedule.zh-CN.toml
+++ b/adp/vega/vega-backend/server/locale/discover_schedule.zh-CN.toml
@@ -13,6 +13,11 @@ Description = "采集策略非法"
 Solution = "strategies 必须是 [insert, delete, update] 的子集；空数组表示全部"
 ErrorLink = "暂无"
 
+[VegaBackend.DiscoverSchedule.InvalidTimeRange]
+Description = "采集调度时间范围非法"
+Solution = "start_time 和 end_time 必须大于等于 0；end_time 为 0 表示无结束时间，否则 start_time 必须小于等于 end_time"
+ErrorLink = "暂无"
+
 [VegaBackend.DiscoverSchedule.IdMismatch]
 Description = "请求体中的 id 与 path 中的 id 不一致"
 Solution = "请保持两者一致或省略 body.id"

--- a/adp/vega/vega-backend/server/logics/catalog/catalog_service.go
+++ b/adp/vega/vega-backend/server/logics/catalog/catalog_service.go
@@ -443,15 +443,15 @@ func (cs *catalogService) List(ctx context.Context, params interfaces.CatalogsQu
 }
 
 // Update updates a Catalog.
-func (cs *catalogService) Update(ctx context.Context, id string, req *interfaces.CatalogRequest) error {
+func (cs *catalogService) Update(ctx context.Context, catalog *interfaces.Catalog, req *interfaces.CatalogRequest) error {
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "Update catalog")
 	defer span.End()
 
-	catalog := req.OriginCatalog
 	if catalog == nil {
 		span.SetStatus(codes.Error, "Catalog not found")
 		return rest.NewHTTPError(ctx, http.StatusNotFound, verrors.VegaBackend_Catalog_NotFound)
 	}
+	nameModified := req.Name != catalog.Name
 
 	// 判断userid是否有修改权限
 	err := cs.ps.CheckPermission(ctx, interfaces.PermissionResource{
@@ -530,7 +530,7 @@ func (cs *catalogService) Update(ctx context.Context, id string, req *interfaces
 	}
 
 	// 请求更新资源名称的接口，更新资源的名称
-	if req.IfNameModify {
+	if nameModified {
 		err = cs.ps.UpdateResource(ctx, interfaces.PermissionResource{
 			ID:   catalog.ID,
 			Type: interfaces.RESOURCE_TYPE_CATALOG,

--- a/adp/vega/vega-backend/server/logics/connector_type/connector_type_service.go
+++ b/adp/vega/vega-backend/server/logics/connector_type/connector_type_service.go
@@ -186,15 +186,15 @@ func (cts *connectorTypeService) List(ctx context.Context, params interfaces.Con
 }
 
 // Update updates a ConnectorType.
-func (cts *connectorTypeService) Update(ctx context.Context, req *interfaces.ConnectorTypeReq) error {
+func (cts *connectorTypeService) Update(ctx context.Context, ct *interfaces.ConnectorType, req *interfaces.ConnectorTypeReq) error {
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "Update connector type")
 	defer span.End()
 
-	ct := req.OriginConnectorType
 	if ct == nil {
 		span.SetStatus(codes.Error, "Connector type not found")
 		return rest.NewHTTPError(ctx, http.StatusNotFound, verrors.VegaBackend_ConnectorType_NotFound)
 	}
+	nameModified := req.Name != ct.Name
 
 	// 判断userid是否有创建业务知识网络的权限（策略决策）
 	err := cts.ps.CheckPermission(ctx, interfaces.PermissionResource{
@@ -242,7 +242,7 @@ func (cts *connectorTypeService) Update(ctx context.Context, req *interfaces.Con
 	}
 
 	// 请求更新资源名称的接口，更新资源的名称
-	if req.IfNameModify {
+	if nameModified {
 		err = cts.ps.UpdateResource(ctx, interfaces.PermissionResource{
 			ID:   ct.Type,
 			Type: interfaces.RESOURCE_TYPE_CONNECTOR_TYPE,

--- a/adp/vega/vega-backend/server/logics/discover_schedule/discover_schedule_service.go
+++ b/adp/vega/vega-backend/server/logics/discover_schedule/discover_schedule_service.go
@@ -116,14 +116,12 @@ func (dss *discoverScheduleService) List(ctx context.Context, params interfaces.
 }
 
 // Update updates a discover schedule.
-func (dss *discoverScheduleService) Update(ctx context.Context, id string, req *interfaces.DiscoverSchedule) error {
+func (dss *discoverScheduleService) Update(ctx context.Context, schedule *interfaces.DiscoverSchedule, req *interfaces.DiscoverScheduleRequest) error {
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "DiscoverScheduleService.Update")
 	defer span.End()
 
-	// Validate cron expression
-	if req.CronExpr == "" {
-		otellog.LogError(ctx, "Cron expression is required", nil)
-		return fmt.Errorf("cron_expr is required")
+	if schedule == nil {
+		return fmt.Errorf("discover schedule not found")
 	}
 
 	accountInfo := interfaces.AccountInfo{}
@@ -131,16 +129,19 @@ func (dss *discoverScheduleService) Update(ctx context.Context, id string, req *
 		accountInfo = ctx.Value(interfaces.ACCOUNT_INFO_KEY).(interfaces.AccountInfo)
 	}
 
-	// Set updater
-	req.Updater = accountInfo
-	req.UpdateTime = time.Now().UnixMilli()
+	schedule.CronExpr = req.CronExpr
+	schedule.StartTime = req.StartTime
+	schedule.EndTime = req.EndTime
+	schedule.Strategies = req.Strategies
+	schedule.Updater = accountInfo
+	schedule.UpdateTime = time.Now().UnixMilli()
 
 	// Update schedule
-	if err := dss.dsa.Update(ctx, req); err != nil {
+	if err := dss.dsa.Update(ctx, schedule); err != nil {
 		otellog.LogError(ctx, "Failed to update discover schedule", err)
 		return err
 	}
-	logger.Infof("Updated discover schedule: id=%s", id)
+	logger.Infof("Updated discover schedule: id=%s", schedule.ID)
 	return nil
 }
 
@@ -164,14 +165,12 @@ func (dss *discoverScheduleService) Enable(ctx context.Context, id string) error
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "DiscoverScheduleService.Enable")
 	defer span.End()
 
-	schedule, err := dss.dsa.GetByID(ctx, id)
-	if err != nil {
-		otellog.LogError(ctx, "Failed to get discover schedule", err)
+	if err := dss.dsa.Enable(ctx, id); err != nil {
+		otellog.LogError(ctx, "Failed to enable discover schedule", err)
 		return err
 	}
 
-	schedule.Enabled = true
-	return dss.Update(ctx, id, schedule)
+	return nil
 }
 
 // Disable disables a discover schedule.
@@ -179,14 +178,12 @@ func (dss *discoverScheduleService) Disable(ctx context.Context, id string) erro
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "DiscoverScheduleService.Disable")
 	defer span.End()
 
-	schedule, err := dss.dsa.GetByID(ctx, id)
-	if err != nil {
-		otellog.LogError(ctx, "Failed to get discover schedule", err)
+	if err := dss.dsa.Disable(ctx, id); err != nil {
+		otellog.LogError(ctx, "Failed to disable discover schedule", err)
 		return err
 	}
 
-	schedule.Enabled = false
-	return dss.Update(ctx, id, schedule)
+	return nil
 }
 
 // GetEnabledSchedules retrieves all enabled discover schedules.

--- a/adp/vega/vega-backend/server/logics/resource/resource_service.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service.go
@@ -455,15 +455,15 @@ func (rs *resourceService) List(ctx context.Context, params interfaces.Resources
 }
 
 // Update updates a Resource.
-func (rs *resourceService) Update(ctx context.Context, id string, req *interfaces.ResourceRequest) error {
+func (rs *resourceService) Update(ctx context.Context, resource *interfaces.Resource, req *interfaces.ResourceRequest) error {
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "Update resource")
 	defer span.End()
 
-	resource := req.OriginResource
 	if resource == nil {
 		span.SetStatus(codes.Error, "Resource not found")
 		return rest.NewHTTPError(ctx, http.StatusNotFound, verrors.VegaBackend_Resource_NotFound)
 	}
+	nameModified := req.Name != resource.Name
 
 	// 判断userid是否有修改权限
 	err := rs.ps.CheckPermission(ctx, interfaces.PermissionResource{
@@ -474,7 +474,7 @@ func (rs *resourceService) Update(ctx context.Context, id string, req *interface
 		return err
 	}
 
-	switch req.OriginResource.Category {
+	switch resource.Category {
 	case interfaces.ResourceCategoryLogicView:
 		logicType, err := rs.validateLogicDefinition(ctx, req)
 		if err != nil {
@@ -537,7 +537,7 @@ func (rs *resourceService) Update(ctx context.Context, id string, req *interface
 	}
 
 	// 请求更新资源名称的接口，更新资源的名称
-	if req.IfNameModify {
+	if nameModified {
 		err = rs.ps.UpdateResource(ctx, interfaces.PermissionResource{
 			ID:   resource.ID,
 			Type: interfaces.RESOURCE_TYPE_RESOURCE,

--- a/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
@@ -408,13 +408,11 @@ func TestUpdateStatus_Error(t *testing.T) {
 
 // ===== Update =====
 
-func TestUpdate_NilOrigin(t *testing.T) {
+func TestUpdate_NilResource(t *testing.T) {
 	rs, _, _, _, _, _, _ := newTestService(t)
-	err := rs.Update(context.Background(), "r1", &interfaces.ResourceRequest{
-		OriginResource: nil,
-	})
+	err := rs.Update(context.Background(), nil, &interfaces.ResourceRequest{})
 	if err == nil {
-		t.Fatal("expected error for nil origin resource")
+		t.Fatal("expected error for nil resource")
 	}
 }
 
@@ -424,9 +422,8 @@ func TestUpdate_Success(t *testing.T) {
 	mockCS.EXPECT().CheckExistByID(gomock.Any(), gomock.Any()).Return(true, nil)
 	mockRA.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
 
-	err := rs.Update(context.Background(), "r1", &interfaces.ResourceRequest{
-		OriginResource: &interfaces.Resource{ID: "r1"},
-		Name:           "updated",
+	err := rs.Update(context.Background(), &interfaces.Resource{ID: "r1", Name: "updated"}, &interfaces.ResourceRequest{
+		Name: "updated",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/adp/vega/vega-backend/server/worker/schedule_worker.go
+++ b/adp/vega/vega-backend/server/worker/schedule_worker.go
@@ -243,8 +243,14 @@ func (sw *ScheduleWorker) executeSchedule(scheduleID string) {
 		return
 	}
 
+	now := time.Now().UnixMilli()
+	if schedule.StartTime > 0 && now < schedule.StartTime {
+		logger.Infof("Schedule %s has not reached start_time, skipping execution", schedule.ID)
+		return
+	}
+
 	// 检查任务是否已过期
-	if schedule.EndTime > 0 && time.Now().UnixMilli() > schedule.EndTime {
+	if schedule.EndTime > 0 && now > schedule.EndTime {
 		logger.Warnf("Schedule %s has expired, disabling and unscheduling", schedule.ID)
 
 		// 禁用过期任务


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] 新增采集调度的 `start_time` / `end_time` 时间范围校验，调度执行前判断是否到达启动时间或已过期
- [x] 新增错误码 `VegaBackend.DiscoverSchedule.InvalidTimeRange` 及中英文文案
- [x] 重构 ConnectorType / Catalog / Resource / DiscoverSchedule 的 Update 服务接口：从"请求体携带原始对象"改为"由 handler 查询实体后直接传入"
- [x] 移除请求结构体中的 `IfNameModify` / `OriginXXX` 等内部辅助标记字段，改为通过比对请求参数与实体对象判断是否改名
- [x] 简化 enable / disable 调度逻辑，直接调用数据层接口，不再复用 Update
- [x] 同步更新所有相关 handler / mock / 单元测试
- [x] 更新 discover-schedule API 文档：补充时间范围校验说明、调整 PUT 字段约束表

---

## Why

- Related Issue: #459
- Background:
  - 调度任务缺少 `start_time` / `end_time` 校验，到达 `end_time` 后仍会继续执行；启动前也无生效控制
  - Update 接口通过请求体携带 `OriginXXX` / `IfNameModify` 等"内部状态"字段，污染对外契约且容易被误填
  - enable/disable 走 Update 路径，链路冗长且与"状态切换"语义不符

---

## How

- 关键实现点：
  - `errors/discover_schedule.go` + `locale/discover_schedule.{en-US,zh-CN}.toml`：新增 `InvalidTimeRange` errcode
  - `driveradapters/validate_discover_schedule.go`：新增时间范围校验函数 + 单测
  - `worker/schedule_worker.go`：执行前判断 `start_time` / `end_time`，未到 / 已过则跳过
  - `interfaces/{catalog,resource,connector_type,discover_schedule}_service.go`：Update 签名改为 `(ctx, req, origin)`，移除 `IfNameModify` 等字段
  - `logics/.../*_service.go`：基于 `req.Name != origin.Name` 自行判断改名场景
  - `driveradapters/*_handler.go`：在调用 Update 前先 Get 出原对象
  - mock 文件全量同步
  - `docs/api/vega/vega-backend-api/discover-schedule.yaml`：补充时间范围校验、重写 PUT 字段约束表
- Breaking changes：
  - 服务层 Update 接口签名变更（仅影响 vega-backend 内部调用方，已在同 PR 内同步）
  - 对外 PUT 接口语义未变；新增 400 `VegaBackend.DiscoverSchedule.InvalidTimeRange` 错误码

---

## Testing

- [x] Unit tests passed locally（新增 `validate_discover_schedule_test.go` 覆盖时间范围校验；`resource_service_test.go` / `connector_type_handler_test.go` 等同步更新）
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes：

- `go test ./adp/vega/vega-backend/server/...`

---

## Risk & Rollback

- 潜在风险：
  - Update 接口签名变更需确认无下游业务旁路依赖旧字段（`IfNameModify` / `OriginXXX`）
  - 调度时间校验上线后，历史中 `end_time` 已过期的任务会停止执行——属于预期行为，但需周知运维
- 回滚方案：revert 本 PR；errcode 与 locale 文件独立无存储变更

---

## Additional Notes

- 相关 commits：
  - feat: 新增采集调度时间范围校验与执行控制逻辑
  - refactor(service): 统一更新接口参数，移除冗余内部标记字段
  - docs(vega-backend-api): update discover-schedule api docs with time range validation