### PR TITLE
feat(vega-backend): 列表接口新增排序/分页能力并重构访问层

### DIFF
--- a/adp/docs/api/vega/vega-backend-api/discover-schedule.yaml
+++ b/adp/docs/api/vega/vega-backend-api/discover-schedule.yaml
@@ -76,6 +76,40 @@ paths:
           in: query
           schema:
             type: boolean
+        - name: offset
+          description: 分页偏移量，>=0，默认 0
+          in: query
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+            default: 0
+        - name: limit
+          description: 每页数量，1-1000，-1 表示不分页，默认 20
+          in: query
+          schema:
+            type: integer
+            format: int64
+            default: 20
+        - name: sort
+          description: 排序字段
+          in: query
+          schema:
+            type: string
+            enum:
+              - create_time
+              - update_time
+              - next_run
+            default: update_time
+        - name: direction
+          description: 排序方向
+          in: query
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
+            default: desc
       responses:
         "200":
           description: ok

--- a/adp/vega/vega-backend/server/drivenadapters/build_task/build_task_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/build_task/build_task_access.go
@@ -418,19 +418,12 @@ func (bta *buildTaskAccess) List(ctx context.Context, params interfaces.BuildTas
 	}
 
 	orderBy := "f_update_time"
-	switch params.Sort {
-	case "create_time":
-		orderBy = "f_create_time"
-	case "update_time":
-		orderBy = "f_update_time"
-	case "status":
-		orderBy = "f_status"
-	case "mode":
-		orderBy = "f_mode"
+	if params.Sort != "" {
+		orderBy = params.Sort
 	}
-	direction := "DESC"
-	if params.Direction == interfaces.ASC_DIRECTION {
-		direction = "ASC"
+	direction := strings.ToUpper(params.Direction)
+	if direction == "" {
+		direction = "DESC"
 	}
 
 	query := `
@@ -439,9 +432,12 @@ func (bta *buildTaskAccess) List(ctx context.Context, params interfaces.BuildTas
 			f_creator, f_creator_type, f_create_time, f_updater, f_updater_type, f_update_time, f_embedding_fields, f_build_key_fields, f_embedding_model, f_model_dimensions
 		FROM ` + BUILD_TASK_TABLE_NAME + ` ` + whereClause + `
 		ORDER BY ` + orderBy + ` ` + direction + `
-		LIMIT ? OFFSET ?
 	`
-	queryArgs := append(args, params.Limit, params.Offset)
+	queryArgs := args
+	if params.Limit > 0 {
+		query += ` LIMIT ? OFFSET ?`
+		queryArgs = append(queryArgs, params.Limit, params.Offset)
+	}
 	rows, err := bta.db.QueryContext(ctx, query, queryArgs...)
 	if err != nil {
 		otellog.LogError(ctx, "Get build tasks with filters failed", err)

--- a/adp/vega/vega-backend/server/drivenadapters/build_task/build_task_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/build_task/build_task_access.go
@@ -32,27 +32,29 @@ const (
 	BUILD_TASK_TABLE_NAME = "t_build_task"
 )
 
-var buildTaskColumns = []string{
-	"f_id",
-	"f_resource_id",
-	"f_catalog_id",
-	"f_status",
-	"f_mode",
-	"f_total_count",
-	"f_synced_count",
-	"f_vectorized_count",
-	"f_synced_mark",
-	"f_error_msg",
-	"f_creator",
-	"f_creator_type",
-	"f_create_time",
-	"f_updater",
-	"f_updater_type",
-	"f_update_time",
-	"f_embedding_fields",
-	"f_build_key_fields",
-	"f_embedding_model",
-	"f_model_dimensions",
+func buildTaskColumns() []string {
+	return []string{
+		"f_id",
+		"f_resource_id",
+		"f_catalog_id",
+		"f_status",
+		"f_mode",
+		"f_total_count",
+		"f_synced_count",
+		"f_vectorized_count",
+		"f_synced_mark",
+		"f_error_msg",
+		"f_creator",
+		"f_creator_type",
+		"f_create_time",
+		"f_updater",
+		"f_updater_type",
+		"f_update_time",
+		"f_embedding_fields",
+		"f_build_key_fields",
+		"f_embedding_model",
+		"f_model_dimensions",
+	}
 }
 
 type buildTaskAccess struct {
@@ -114,7 +116,7 @@ func (bta *buildTaskAccess) Create(ctx context.Context, buildTask *interfaces.Bu
 	defer span.End()
 
 	sqlStr, vals, err := sq.Insert(BUILD_TASK_TABLE_NAME).
-		Columns(buildTaskColumns...).
+		Columns(buildTaskColumns()...).
 		Values(
 			buildTask.ID,
 			buildTask.ResourceID,
@@ -157,7 +159,7 @@ func (bta *buildTaskAccess) GetByID(ctx context.Context, id string) (*interfaces
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Get build task by ID")
 	defer span.End()
 
-	sqlStr, vals, err := sq.Select(buildTaskColumns...).
+	sqlStr, vals, err := sq.Select(buildTaskColumns()...).
 		From(BUILD_TASK_TABLE_NAME).
 		Where(sq.Eq{"f_id": id}).
 		ToSql()
@@ -166,7 +168,8 @@ func (bta *buildTaskAccess) GetByID(ctx context.Context, id string) (*interfaces
 		return nil, err
 	}
 
-	buildTask, err := scanBuildTask(bta.db.QueryRowContext(ctx, sqlStr, vals...))
+	row := bta.db.QueryRowContext(ctx, sqlStr, vals...)
+	buildTask, err := scanBuildTask(row)
 	if err == sql.ErrNoRows {
 		span.SetStatus(codes.Ok, "Build task not found")
 		return nil, nil
@@ -186,7 +189,7 @@ func (bta *buildTaskAccess) GetByResourceID(ctx context.Context, resourceID stri
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Get build task by resource ID")
 	defer span.End()
 
-	sqlStr, vals, err := sq.Select(buildTaskColumns...).
+	sqlStr, vals, err := sq.Select(buildTaskColumns()...).
 		From(BUILD_TASK_TABLE_NAME).
 		Where(sq.Eq{"f_resource_id": resourceID}).
 		Limit(1).
@@ -196,7 +199,8 @@ func (bta *buildTaskAccess) GetByResourceID(ctx context.Context, resourceID stri
 		return nil, err
 	}
 
-	buildTask, err := scanBuildTask(bta.db.QueryRowContext(ctx, sqlStr, vals...))
+	row := bta.db.QueryRowContext(ctx, sqlStr, vals...)
+	buildTask, err := scanBuildTask(row)
 	if err == sql.ErrNoRows {
 		span.SetStatus(codes.Ok, "Build task not found")
 		return nil, nil
@@ -216,7 +220,7 @@ func (bta *buildTaskAccess) GetByCatalogID(ctx context.Context, catalogID string
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Get build tasks by catalog ID")
 	defer span.End()
 
-	sqlStr, vals, err := sq.Select(buildTaskColumns...).
+	sqlStr, vals, err := sq.Select(buildTaskColumns()...).
 		From(BUILD_TASK_TABLE_NAME).
 		Where(sq.Eq{"f_catalog_id": catalogID}).
 		ToSql()
@@ -327,9 +331,11 @@ func (bta *buildTaskAccess) List(ctx context.Context, params interfaces.BuildTas
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Get build tasks with filters")
 	defer span.End()
 
-	builder := sq.Select(buildTaskColumns...).From(BUILD_TASK_TABLE_NAME)
+	builder := sq.Select(buildTaskColumns()...).
+		From(BUILD_TASK_TABLE_NAME)
 
-	countBuilder := sq.Select("COUNT(*)").From(BUILD_TASK_TABLE_NAME)
+	countBuilder := sq.Select("COUNT(*)").
+		From(BUILD_TASK_TABLE_NAME)
 
 	if params.ResourceID != "" {
 		builder = builder.Where(sq.Eq{"f_resource_id": params.ResourceID})

--- a/adp/vega/vega-backend/server/drivenadapters/build_task/build_task_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/build_task/build_task_access.go
@@ -10,10 +10,10 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
+	sq "github.com/Masterminds/squirrel"
 	"github.com/kweaver-ai/kweaver-go-lib/db"
 	"github.com/kweaver-ai/kweaver-go-lib/otel/otellog"
 	"github.com/kweaver-ai/kweaver-go-lib/otel/oteltrace"
@@ -32,8 +32,70 @@ const (
 	BUILD_TASK_TABLE_NAME = "t_build_task"
 )
 
+var buildTaskColumns = []string{
+	"f_id",
+	"f_resource_id",
+	"f_catalog_id",
+	"f_status",
+	"f_mode",
+	"f_total_count",
+	"f_synced_count",
+	"f_vectorized_count",
+	"f_synced_mark",
+	"f_error_msg",
+	"f_creator",
+	"f_creator_type",
+	"f_create_time",
+	"f_updater",
+	"f_updater_type",
+	"f_update_time",
+	"f_embedding_fields",
+	"f_build_key_fields",
+	"f_embedding_model",
+	"f_model_dimensions",
+}
+
 type buildTaskAccess struct {
 	db *sql.DB
+}
+
+type buildTaskScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanBuildTask(scanner buildTaskScanner) (*interfaces.BuildTask, error) {
+	buildTask := &interfaces.BuildTask{}
+	var creatorID, creatorType, updaterID, updaterType string
+
+	err := scanner.Scan(
+		&buildTask.ID,
+		&buildTask.ResourceID,
+		&buildTask.CatalogID,
+		&buildTask.Status,
+		&buildTask.Mode,
+		&buildTask.TotalCount,
+		&buildTask.SyncedCount,
+		&buildTask.VectorizedCount,
+		&buildTask.SyncedMark,
+		&buildTask.ErrorMsg,
+		&creatorID,
+		&creatorType,
+		&buildTask.CreateTime,
+		&updaterID,
+		&updaterType,
+		&buildTask.UpdateTime,
+		&buildTask.EmbeddingFields,
+		&buildTask.BuildKeyFields,
+		&buildTask.EmbeddingModel,
+		&buildTask.ModelDimensions,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	buildTask.Creator = interfaces.AccountInfo{ID: creatorID, Type: creatorType}
+	buildTask.Updater = interfaces.AccountInfo{ID: updaterID, Type: updaterType}
+	return buildTask, nil
 }
 
 // NewBuildTaskAccess creates a new BuildTaskAccess.
@@ -51,38 +113,36 @@ func (bta *buildTaskAccess) Create(ctx context.Context, buildTask *interfaces.Bu
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Create build task")
 	defer span.End()
 
-	query := `
-		INSERT INTO ` + BUILD_TASK_TABLE_NAME + ` (
-			f_id, f_resource_id, f_catalog_id, f_status, f_mode, f_total_count, f_synced_count, f_vectorized_count, f_synced_mark, f_error_msg,
-			f_creator, f_creator_type, f_create_time, f_updater, f_updater_type, f_update_time, f_embedding_fields, f_build_key_fields, f_embedding_model, f_model_dimensions
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`
+	sqlStr, vals, err := sq.Insert(BUILD_TASK_TABLE_NAME).
+		Columns(buildTaskColumns...).
+		Values(
+			buildTask.ID,
+			buildTask.ResourceID,
+			buildTask.CatalogID,
+			buildTask.Status,
+			buildTask.Mode,
+			buildTask.TotalCount,
+			buildTask.SyncedCount,
+			buildTask.VectorizedCount,
+			buildTask.SyncedMark,
+			buildTask.ErrorMsg,
+			buildTask.Creator.ID,
+			buildTask.Creator.Type,
+			buildTask.CreateTime,
+			buildTask.Updater.ID,
+			buildTask.Updater.Type,
+			buildTask.UpdateTime,
+			buildTask.EmbeddingFields,
+			buildTask.BuildKeyFields,
+			buildTask.EmbeddingModel,
+			buildTask.ModelDimensions,
+		).ToSql()
+	if err != nil {
+		span.SetStatus(codes.Error, "Build sql failed")
+		return err
+	}
 
-	_, err := bta.db.ExecContext(
-		ctx,
-		query,
-		buildTask.ID,
-		buildTask.ResourceID,
-		buildTask.CatalogID,
-		buildTask.Status,
-		buildTask.Mode,
-		buildTask.TotalCount,
-		buildTask.SyncedCount,
-		buildTask.VectorizedCount,
-		buildTask.SyncedMark,
-		buildTask.ErrorMsg,
-		buildTask.Creator.ID,
-		buildTask.Creator.Type,
-		buildTask.CreateTime,
-		buildTask.Updater.ID,
-		buildTask.Updater.Type,
-		buildTask.UpdateTime,
-		buildTask.EmbeddingFields,
-		buildTask.BuildKeyFields,
-		buildTask.EmbeddingModel,
-		buildTask.ModelDimensions,
-	)
-
+	_, err = bta.db.ExecContext(ctx, sqlStr, vals...)
 	if err != nil {
 		otellog.LogError(ctx, "Create build task failed", err)
 		return err
@@ -97,42 +157,16 @@ func (bta *buildTaskAccess) GetByID(ctx context.Context, id string) (*interfaces
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Get build task by ID")
 	defer span.End()
 
-	query := `
-		SELECT 
-			f_id, f_resource_id, f_catalog_id, f_status, f_mode, f_total_count, f_synced_count, f_vectorized_count, f_synced_mark, f_error_msg,
-			f_creator, f_creator_type, f_create_time, f_updater, f_updater_type, f_update_time, f_embedding_fields, f_build_key_fields, f_embedding_model, f_model_dimensions
-		FROM ` + BUILD_TASK_TABLE_NAME + `
-		WHERE f_id = ?
-	`
+	sqlStr, vals, err := sq.Select(buildTaskColumns...).
+		From(BUILD_TASK_TABLE_NAME).
+		Where(sq.Eq{"f_id": id}).
+		ToSql()
+	if err != nil {
+		span.SetStatus(codes.Error, "Build sql failed")
+		return nil, err
+	}
 
-	row := bta.db.QueryRowContext(ctx, query, id)
-
-	buildTask := &interfaces.BuildTask{}
-	var creatorID, creatorType, updaterID, updaterType string
-
-	err := row.Scan(
-		&buildTask.ID,
-		&buildTask.ResourceID,
-		&buildTask.CatalogID,
-		&buildTask.Status,
-		&buildTask.Mode,
-		&buildTask.TotalCount,
-		&buildTask.SyncedCount,
-		&buildTask.VectorizedCount,
-		&buildTask.SyncedMark,
-		&buildTask.ErrorMsg,
-		&creatorID,
-		&creatorType,
-		&buildTask.CreateTime,
-		&updaterID,
-		&updaterType,
-		&buildTask.UpdateTime,
-		&buildTask.EmbeddingFields,
-		&buildTask.BuildKeyFields,
-		&buildTask.EmbeddingModel,
-		&buildTask.ModelDimensions,
-	)
-
+	buildTask, err := scanBuildTask(bta.db.QueryRowContext(ctx, sqlStr, vals...))
 	if err == sql.ErrNoRows {
 		span.SetStatus(codes.Ok, "Build task not found")
 		return nil, nil
@@ -141,16 +175,6 @@ func (bta *buildTaskAccess) GetByID(ctx context.Context, id string) (*interfaces
 	if err != nil {
 		otellog.LogError(ctx, "Get build task by ID failed", err)
 		return nil, err
-	}
-
-	buildTask.Creator = interfaces.AccountInfo{
-		ID:   creatorID,
-		Type: creatorType,
-	}
-
-	buildTask.Updater = interfaces.AccountInfo{
-		ID:   updaterID,
-		Type: updaterType,
 	}
 
 	span.SetStatus(codes.Ok, "")
@@ -162,43 +186,17 @@ func (bta *buildTaskAccess) GetByResourceID(ctx context.Context, resourceID stri
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Get build task by resource ID")
 	defer span.End()
 
-	query := `
-		SELECT 
-			f_id, f_resource_id, f_catalog_id, f_status, f_mode, f_total_count, f_synced_count, f_vectorized_count, f_synced_mark, f_error_msg,
-			f_creator, f_creator_type, f_create_time, f_updater, f_updater_type, f_update_time, f_embedding_fields, f_build_key_fields, f_embedding_model, f_model_dimensions
-		FROM ` + BUILD_TASK_TABLE_NAME + `
-		WHERE f_resource_id = ?
-		LIMIT 1
-	`
+	sqlStr, vals, err := sq.Select(buildTaskColumns...).
+		From(BUILD_TASK_TABLE_NAME).
+		Where(sq.Eq{"f_resource_id": resourceID}).
+		Limit(1).
+		ToSql()
+	if err != nil {
+		span.SetStatus(codes.Error, "Build sql failed")
+		return nil, err
+	}
 
-	row := bta.db.QueryRowContext(ctx, query, resourceID)
-
-	buildTask := &interfaces.BuildTask{}
-	var creatorID, creatorType, updaterID, updaterType string
-
-	err := row.Scan(
-		&buildTask.ID,
-		&buildTask.ResourceID,
-		&buildTask.CatalogID,
-		&buildTask.Status,
-		&buildTask.Mode,
-		&buildTask.TotalCount,
-		&buildTask.SyncedCount,
-		&buildTask.VectorizedCount,
-		&buildTask.SyncedMark,
-		&buildTask.ErrorMsg,
-		&creatorID,
-		&creatorType,
-		&buildTask.CreateTime,
-		&updaterID,
-		&updaterType,
-		&buildTask.UpdateTime,
-		&buildTask.EmbeddingFields,
-		&buildTask.BuildKeyFields,
-		&buildTask.EmbeddingModel,
-		&buildTask.ModelDimensions,
-	)
-
+	buildTask, err := scanBuildTask(bta.db.QueryRowContext(ctx, sqlStr, vals...))
 	if err == sql.ErrNoRows {
 		span.SetStatus(codes.Ok, "Build task not found")
 		return nil, nil
@@ -207,16 +205,6 @@ func (bta *buildTaskAccess) GetByResourceID(ctx context.Context, resourceID stri
 	if err != nil {
 		otellog.LogError(ctx, "Scan build task row failed", err)
 		return nil, err
-	}
-
-	buildTask.Creator = interfaces.AccountInfo{
-		ID:   creatorID,
-		Type: creatorType,
-	}
-
-	buildTask.Updater = interfaces.AccountInfo{
-		ID:   updaterID,
-		Type: updaterType,
 	}
 
 	span.SetStatus(codes.Ok, "")
@@ -228,15 +216,16 @@ func (bta *buildTaskAccess) GetByCatalogID(ctx context.Context, catalogID string
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Get build tasks by catalog ID")
 	defer span.End()
 
-	query := `
-		SELECT 
-			f_id, f_resource_id, f_catalog_id, f_status, f_mode, f_total_count, f_synced_count, f_vectorized_count, f_synced_mark, f_error_msg,
-			f_creator, f_creator_type, f_create_time, f_updater, f_updater_type, f_update_time, f_embedding_fields, f_build_key_fields, f_embedding_model, f_model_dimensions
-		FROM ` + BUILD_TASK_TABLE_NAME + `
-		WHERE f_catalog_id = ?
-	`
+	sqlStr, vals, err := sq.Select(buildTaskColumns...).
+		From(BUILD_TASK_TABLE_NAME).
+		Where(sq.Eq{"f_catalog_id": catalogID}).
+		ToSql()
+	if err != nil {
+		span.SetStatus(codes.Error, "Build sql failed")
+		return nil, err
+	}
 
-	rows, err := bta.db.QueryContext(ctx, query, catalogID)
+	rows, err := bta.db.QueryContext(ctx, sqlStr, vals...)
 	if err != nil {
 		otellog.LogError(ctx, "Get build tasks by catalog ID failed", err)
 		return nil, err
@@ -245,45 +234,10 @@ func (bta *buildTaskAccess) GetByCatalogID(ctx context.Context, catalogID string
 
 	buildTasks := []*interfaces.BuildTask{}
 	for rows.Next() {
-		buildTask := &interfaces.BuildTask{}
-		var creatorID, creatorType, updaterID, updaterType string
-
-		err := rows.Scan(
-			&buildTask.ID,
-			&buildTask.ResourceID,
-			&buildTask.CatalogID,
-			&buildTask.Status,
-			&buildTask.Mode,
-			&buildTask.TotalCount,
-			&buildTask.SyncedCount,
-			&buildTask.VectorizedCount,
-			&buildTask.SyncedMark,
-			&buildTask.ErrorMsg,
-			&creatorID,
-			&creatorType,
-			&buildTask.CreateTime,
-			&updaterID,
-			&updaterType,
-			&buildTask.UpdateTime,
-			&buildTask.EmbeddingFields,
-			&buildTask.BuildKeyFields,
-			&buildTask.EmbeddingModel,
-			&buildTask.ModelDimensions,
-		)
-
+		buildTask, err := scanBuildTask(rows)
 		if err != nil {
 			otellog.LogError(ctx, "Scan build task row failed", err)
 			return nil, err
-		}
-
-		buildTask.Creator = interfaces.AccountInfo{
-			ID:   creatorID,
-			Type: creatorType,
-		}
-
-		buildTask.Updater = interfaces.AccountInfo{
-			ID:   updaterID,
-			Type: updaterType,
 		}
 
 		buildTasks = append(buildTasks, buildTask)
@@ -303,11 +257,6 @@ func (bta *buildTaskAccess) UpdateStatus(ctx context.Context, id string, updates
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Update build task status")
 	defer span.End()
 
-	// Build update query dynamically
-	setClauses := []string{}
-	args := []interface{}{}
-
-	// Map field names to column names
 	fieldMap := map[string]string{
 		"status":          "f_status",
 		"totalCount":      "f_total_count",
@@ -317,35 +266,23 @@ func (bta *buildTaskAccess) UpdateStatus(ctx context.Context, id string, updates
 		"errorMsg":        "f_error_msg",
 	}
 
-	// Add fields to update
+	builder := sq.Update(BUILD_TASK_TABLE_NAME)
 	for field, value := range updates {
 		if column, ok := fieldMap[field]; ok {
-			setClauses = append(setClauses, column+" = ?")
-			args = append(args, value)
+			builder = builder.Set(column, value)
 		}
 	}
 
-	// Always update update time
-	setClauses = append(setClauses, "f_update_time = ?")
-	updateTime := time.Now().UnixMilli()
-	args = append(args, updateTime)
+	sqlStr, vals, err := builder.
+		Set("f_update_time", time.Now().UnixMilli()).
+		Where(sq.Eq{"f_id": id}).
+		ToSql()
+	if err != nil {
+		span.SetStatus(codes.Error, "Build sql failed")
+		return err
+	}
 
-	// Add id to args
-	args = append(args, id)
-
-	// Build final query
-	query := `
-		UPDATE ` + BUILD_TASK_TABLE_NAME + `
-		SET ` + strings.Join(setClauses, ", ") + `
-		WHERE f_id = ?
-	`
-
-	_, err := bta.db.ExecContext(
-		ctx,
-		query,
-		args...,
-	)
-
+	_, err = bta.db.ExecContext(ctx, sqlStr, vals...)
 	if err != nil {
 		otellog.LogError(ctx, "Update build task status failed", err)
 		return err
@@ -360,14 +297,17 @@ func (bta *buildTaskAccess) GetStatus(ctx context.Context, id string) (string, e
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Get build task status")
 	defer span.End()
 
-	query := `
-		SELECT f_status
-		FROM ` + BUILD_TASK_TABLE_NAME + `
-		WHERE f_id = ?
-	`
-
 	var status string
-	err := bta.db.QueryRowContext(ctx, query, id).Scan(&status)
+	sqlStr, vals, err := sq.Select("f_status").
+		From(BUILD_TASK_TABLE_NAME).
+		Where(sq.Eq{"f_id": id}).
+		ToSql()
+	if err != nil {
+		span.SetStatus(codes.Error, "Build sql failed")
+		return "", err
+	}
+
+	err = bta.db.QueryRowContext(ctx, sqlStr, vals...).Scan(&status)
 	if err == sql.ErrNoRows {
 		span.SetStatus(codes.Ok, "Build task not found")
 		return "", fmt.Errorf("build task not found")
@@ -387,56 +327,52 @@ func (bta *buildTaskAccess) List(ctx context.Context, params interfaces.BuildTas
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Get build tasks with filters")
 	defer span.End()
 
-	whereClauses := []string{}
-	args := []interface{}{}
+	builder := sq.Select(buildTaskColumns...).From(BUILD_TASK_TABLE_NAME)
+
+	countBuilder := sq.Select("COUNT(*)").From(BUILD_TASK_TABLE_NAME)
+
 	if params.ResourceID != "" {
-		whereClauses = append(whereClauses, "f_resource_id = ?")
-		args = append(args, params.ResourceID)
+		builder = builder.Where(sq.Eq{"f_resource_id": params.ResourceID})
+		countBuilder = countBuilder.Where(sq.Eq{"f_resource_id": params.ResourceID})
 	}
 	if params.CatalogID != "" {
-		whereClauses = append(whereClauses, "f_catalog_id = ?")
-		args = append(args, params.CatalogID)
+		builder = builder.Where(sq.Eq{"f_catalog_id": params.CatalogID})
+		countBuilder = countBuilder.Where(sq.Eq{"f_catalog_id": params.CatalogID})
 	}
 	if params.Status != "" {
-		whereClauses = append(whereClauses, "f_status = ?")
-		args = append(args, params.Status)
+		builder = builder.Where(sq.Eq{"f_status": params.Status})
+		countBuilder = countBuilder.Where(sq.Eq{"f_status": params.Status})
 	}
 	if params.Mode != "" {
-		whereClauses = append(whereClauses, "f_mode = ?")
-		args = append(args, params.Mode)
-	}
-	whereClause := ""
-	if len(whereClauses) > 0 {
-		whereClause = "WHERE " + strings.Join(whereClauses, " AND ")
+		builder = builder.Where(sq.Eq{"f_mode": params.Mode})
+		countBuilder = countBuilder.Where(sq.Eq{"f_mode": params.Mode})
 	}
 
+	countSQL, countVals, err := countBuilder.ToSql()
+	if err != nil {
+		span.SetStatus(codes.Error, "Build count sql failed")
+		return nil, 0, err
+	}
 	var totalCount int64
-	countQuery := `SELECT COUNT(*) FROM ` + BUILD_TASK_TABLE_NAME + ` ` + whereClause
-	if err := bta.db.QueryRowContext(ctx, countQuery, args...).Scan(&totalCount); err != nil {
+	if err := bta.db.QueryRowContext(ctx, countSQL, countVals...).Scan(&totalCount); err != nil {
 		otellog.LogError(ctx, "Count build tasks failed", err)
 		return nil, 0, err
 	}
 
-	orderBy := "f_update_time"
-	if params.Sort != "" {
-		orderBy = params.Sort
-	}
-	direction := strings.ToUpper(params.Direction)
-	if direction == "" {
-		direction = "DESC"
+	if params.Sort != "" && params.Direction != "" {
+		builder = builder.OrderBy(fmt.Sprintf("%s %s", params.Sort, params.Direction))
+	} else {
+		builder = builder.OrderBy("f_update_time DESC")
 	}
 
-	query := `
-		SELECT
-			f_id, f_resource_id, f_catalog_id, f_status, f_mode, f_total_count, f_synced_count, f_vectorized_count, f_synced_mark, f_error_msg,
-			f_creator, f_creator_type, f_create_time, f_updater, f_updater_type, f_update_time, f_embedding_fields, f_build_key_fields, f_embedding_model, f_model_dimensions
-		FROM ` + BUILD_TASK_TABLE_NAME + ` ` + whereClause + `
-		ORDER BY ` + orderBy + ` ` + direction + `
-	`
-	queryArgs := args
 	if params.Limit > 0 {
-		query += ` LIMIT ? OFFSET ?`
-		queryArgs = append(queryArgs, params.Limit, params.Offset)
+		builder = builder.Limit(uint64(params.Limit)).Offset(uint64(params.Offset))
+	}
+
+	query, queryArgs, err := builder.ToSql()
+	if err != nil {
+		span.SetStatus(codes.Error, "Build sql failed")
+		return nil, 0, err
 	}
 	rows, err := bta.db.QueryContext(ctx, query, queryArgs...)
 	if err != nil {
@@ -447,19 +383,11 @@ func (bta *buildTaskAccess) List(ctx context.Context, params interfaces.BuildTas
 
 	buildTasks := []*interfaces.BuildTask{}
 	for rows.Next() {
-		buildTask := &interfaces.BuildTask{}
-		var creatorID, creatorType, updaterID, updaterType string
-		if err := rows.Scan(
-			&buildTask.ID, &buildTask.ResourceID, &buildTask.CatalogID, &buildTask.Status, &buildTask.Mode,
-			&buildTask.TotalCount, &buildTask.SyncedCount, &buildTask.VectorizedCount, &buildTask.SyncedMark, &buildTask.ErrorMsg,
-			&creatorID, &creatorType, &buildTask.CreateTime, &updaterID, &updaterType, &buildTask.UpdateTime,
-			&buildTask.EmbeddingFields, &buildTask.BuildKeyFields, &buildTask.EmbeddingModel, &buildTask.ModelDimensions,
-		); err != nil {
+		buildTask, err := scanBuildTask(rows)
+		if err != nil {
 			otellog.LogError(ctx, "Scan build task row failed", err)
 			return nil, 0, err
 		}
-		buildTask.Creator = interfaces.AccountInfo{ID: creatorID, Type: creatorType}
-		buildTask.Updater = interfaces.AccountInfo{ID: updaterID, Type: updaterType}
 		buildTasks = append(buildTasks, buildTask)
 	}
 	if err := rows.Err(); err != nil {
@@ -476,12 +404,15 @@ func (bta *buildTaskAccess) Delete(ctx context.Context, id string) error {
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Delete build task")
 	defer span.End()
 
-	query := `
-		DELETE FROM ` + BUILD_TASK_TABLE_NAME + `
-		WHERE f_id = ?
-	`
+	sqlStr, vals, err := sq.Delete(BUILD_TASK_TABLE_NAME).
+		Where(sq.Eq{"f_id": id}).
+		ToSql()
+	if err != nil {
+		span.SetStatus(codes.Error, "Build sql failed")
+		return err
+	}
 
-	result, err := bta.db.ExecContext(ctx, query, id)
+	result, err := bta.db.ExecContext(ctx, sqlStr, vals...)
 	if err != nil {
 		otellog.LogError(ctx, "Delete build task failed", err)
 		return err

--- a/adp/vega/vega-backend/server/drivenadapters/catalog/catalog_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/catalog/catalog_access.go
@@ -567,10 +567,7 @@ func (ca *catalogAccess) List(ctx context.Context, params interfaces.CatalogsQue
 		return nil, 0, err
 	}
 
-	// 分页
-	// if params.Limit > 0 {
-	// 	builder = builder.Limit(uint64(params.Limit)).Offset(uint64(params.Offset))
-	// }
+	// Pagination is applied in service after permission filtering.
 	// 排序
 	if params.Sort != "" {
 		builder = builder.OrderBy(catalogListOrderExpr(params))

--- a/adp/vega/vega-backend/server/drivenadapters/connector_type/connector_type_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/connector_type/connector_type_access.go
@@ -288,10 +288,7 @@ func (cta *connectorTypeAccess) List(ctx context.Context, params interfaces.Conn
 		return nil, 0, err
 	}
 
-	// 分页
-	// if params.Limit > 0 {
-	// 	builder = builder.Limit(uint64(params.Limit)).Offset(uint64(params.Offset))
-	// }
+	// Pagination is applied in service after permission filtering.
 	// 排序
 	if params.Sort != "" {
 		builder = builder.OrderBy(fmt.Sprintf("%s %s", params.Sort, params.Direction))

--- a/adp/vega/vega-backend/server/drivenadapters/connector_type/connector_type_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/connector_type/connector_type_access.go
@@ -40,6 +40,55 @@ type connectorTypeAccess struct {
 	db         *sql.DB
 }
 
+type connectorTypeScanner interface {
+	Scan(dest ...any) error
+}
+
+func connectorTypeColumns() []string {
+	return []string{
+		"f_type",
+		"f_name",
+		"f_tags",
+		"f_description",
+		"f_mode",
+		"f_category",
+		"f_endpoint",
+		"f_field_config",
+		"f_enabled",
+	}
+}
+
+func scanConnectorType(scanner connectorTypeScanner) (*interfaces.ConnectorType, error) {
+	ct := &interfaces.ConnectorType{}
+	var tagsStr string
+	var fieldConfigStr string
+
+	err := scanner.Scan(
+		&ct.Type,
+		&ct.Name,
+		&tagsStr,
+		&ct.Description,
+		&ct.Mode,
+		&ct.Category,
+		&ct.Endpoint,
+		&fieldConfigStr,
+		&ct.Enabled,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	ct.Tags = libCommon.TagString2TagSlice(tagsStr)
+
+	if fieldConfigStr != "" {
+		if err := sonic.UnmarshalString(fieldConfigStr, &ct.FieldConfig); err != nil {
+			return nil, err
+		}
+	}
+
+	return ct, nil
+}
+
 // NewConnectorTypeAccess creates a new ConnectorTypeAccess.
 func NewConnectorTypeAccess(appSetting *common.AppSetting) interfaces.ConnectorTypeAccess {
 	ctAccessOnce.Do(func() {
@@ -71,17 +120,7 @@ func (cta *connectorTypeAccess) Create(ctx context.Context, ct *interfaces.Conne
 	}
 
 	sqlStr, vals, err := sq.Insert(CONNECTOR_TYPE_TABLE_NAME).
-		Columns(
-			"f_type",
-			"f_name",
-			"f_tags",
-			"f_description",
-			"f_mode",
-			"f_category",
-			"f_endpoint",
-			"f_field_config",
-			"f_enabled",
-		).
+		Columns(connectorTypeColumns()...).
 		Values(
 			ct.Type,
 			ct.Name,
@@ -117,17 +156,8 @@ func (cta *connectorTypeAccess) GetByType(ctx context.Context, tp string) (*inte
 
 	span.SetAttributes(attr.Key("connector_type").String(tp))
 
-	sqlStr, vals, err := sq.Select(
-		"f_type",
-		"f_name",
-		"f_tags",
-		"f_description",
-		"f_mode",
-		"f_category",
-		"f_endpoint",
-		"f_field_config",
-		"f_enabled",
-	).From(CONNECTOR_TYPE_TABLE_NAME).
+	sqlStr, vals, err := sq.Select(connectorTypeColumns()...).
+		From(CONNECTOR_TYPE_TABLE_NAME).
 		Where(sq.Eq{"f_type": tp}).
 		ToSql()
 	if err != nil {
@@ -136,22 +166,8 @@ func (cta *connectorTypeAccess) GetByType(ctx context.Context, tp string) (*inte
 		return nil, err
 	}
 
-	ct := &interfaces.ConnectorType{}
-	var tagsStr string
-	var fieldConfigStr string
-
 	row := cta.db.QueryRowContext(ctx, sqlStr, vals...)
-	err = row.Scan(
-		&ct.Type,
-		&ct.Name,
-		&tagsStr,
-		&ct.Description,
-		&ct.Mode,
-		&ct.Category,
-		&ct.Endpoint,
-		&fieldConfigStr,
-		&ct.Enabled,
-	)
+	ct, err := scanConnectorType(row)
 	if err == sql.ErrNoRows {
 		span.SetStatus(codes.Ok, "")
 		return nil, nil
@@ -160,18 +176,6 @@ func (cta *connectorTypeAccess) GetByType(ctx context.Context, tp string) (*inte
 		logger.Errorf("Scan connector_type failed: %v", err)
 		span.SetStatus(codes.Error, "Scan failed")
 		return nil, err
-	}
-
-	// tags string 转成数组的格式
-	ct.Tags = libCommon.TagString2TagSlice(tagsStr)
-
-	// Deserialize FieldConfig
-	if fieldConfigStr != "" {
-		err = sonic.UnmarshalString(fieldConfigStr, &ct.FieldConfig)
-		if err != nil {
-			otellog.LogError(ctx, "Failed to unmarshal field config", err)
-			return nil, err
-		}
 	}
 
 	span.SetStatus(codes.Ok, "")
@@ -185,17 +189,8 @@ func (cta *connectorTypeAccess) GetByName(ctx context.Context, name string) (*in
 
 	span.SetAttributes(attr.Key("name").String(name))
 
-	sqlStr, vals, err := sq.Select(
-		"f_type",
-		"f_name",
-		"f_tags",
-		"f_description",
-		"f_mode",
-		"f_category",
-		"f_endpoint",
-		"f_field_config",
-		"f_enabled",
-	).From(CONNECTOR_TYPE_TABLE_NAME).
+	sqlStr, vals, err := sq.Select(connectorTypeColumns()...).
+		From(CONNECTOR_TYPE_TABLE_NAME).
 		Where(sq.Eq{"f_name": name}).
 		ToSql()
 	if err != nil {
@@ -204,22 +199,8 @@ func (cta *connectorTypeAccess) GetByName(ctx context.Context, name string) (*in
 		return nil, err
 	}
 
-	ct := &interfaces.ConnectorType{}
-	var tagsStr string
-	var fieldConfigStr string
-
 	row := cta.db.QueryRowContext(ctx, sqlStr, vals...)
-	err = row.Scan(
-		&ct.Type,
-		&ct.Name,
-		&tagsStr,
-		&ct.Description,
-		&ct.Mode,
-		&ct.Category,
-		&ct.Endpoint,
-		&fieldConfigStr,
-		&ct.Enabled,
-	)
+	ct, err := scanConnectorType(row)
 	if err == sql.ErrNoRows {
 		span.SetStatus(codes.Ok, "")
 		return nil, nil
@@ -228,18 +209,6 @@ func (cta *connectorTypeAccess) GetByName(ctx context.Context, name string) (*in
 		logger.Errorf("Scan connector_type failed: %v", err)
 		span.SetStatus(codes.Error, "Scan failed")
 		return nil, err
-	}
-
-	// tags string 转成数组的格式
-	ct.Tags = libCommon.TagString2TagSlice(tagsStr)
-
-	// Deserialize FieldConfig
-	if fieldConfigStr != "" {
-		err = sonic.UnmarshalString(fieldConfigStr, &ct.FieldConfig)
-		if err != nil {
-			otellog.LogError(ctx, "Failed to unmarshal field config", err)
-			return nil, err
-		}
 	}
 
 	span.SetStatus(codes.Ok, "")
@@ -251,19 +220,11 @@ func (cta *connectorTypeAccess) List(ctx context.Context, params interfaces.Conn
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "List connector_types")
 	defer span.End()
 
-	builder := sq.Select(
-		"f_type",
-		"f_name",
-		"f_tags",
-		"f_description",
-		"f_mode",
-		"f_category",
-		"f_endpoint",
-		"f_field_config",
-		"f_enabled",
-	).From(CONNECTOR_TYPE_TABLE_NAME)
+	builder := sq.Select(connectorTypeColumns()...).
+		From(CONNECTOR_TYPE_TABLE_NAME)
 
-	countBuilder := sq.Select("COUNT(*)").From(CONNECTOR_TYPE_TABLE_NAME)
+	countBuilder := sq.Select("COUNT(*)").
+		From(CONNECTOR_TYPE_TABLE_NAME)
 
 	// Apply filters
 	if params.Mode != "" {
@@ -311,35 +272,10 @@ func (cta *connectorTypeAccess) List(ctx context.Context, params interfaces.Conn
 
 	connectorTypes := make([]*interfaces.ConnectorType, 0)
 	for rows.Next() {
-		ct := &interfaces.ConnectorType{}
-		var tagsStr string
-		var fieldConfigStr string
-		err := rows.Scan(
-			&ct.Type,
-			&ct.Name,
-			&tagsStr,
-			&ct.Description,
-			&ct.Mode,
-			&ct.Category,
-			&ct.Endpoint,
-			&fieldConfigStr,
-			&ct.Enabled,
-		)
+		ct, err := scanConnectorType(rows)
 		if err != nil {
 			span.SetStatus(codes.Error, "Scan row failed")
 			return nil, 0, err
-		}
-
-		// tags string 转成数组的格式
-		ct.Tags = libCommon.TagString2TagSlice(tagsStr)
-
-		// Deserialize FieldConfig
-		if fieldConfigStr != "" {
-			err = sonic.UnmarshalString(fieldConfigStr, &ct.FieldConfig)
-			if err != nil {
-				otellog.LogError(ctx, "Failed to unmarshal field config", err)
-				return nil, 0, err
-			}
 		}
 
 		connectorTypes = append(connectorTypes, ct)

--- a/adp/vega/vega-backend/server/drivenadapters/discover_schedule/discover_schedule_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/discover_schedule/discover_schedule_access.go
@@ -66,6 +66,59 @@ type discoverScheduleAccess struct {
 	db         *sql.DB
 }
 
+type discoverScheduleScanner interface {
+	Scan(dest ...any) error
+}
+
+func discoverScheduleColumns() []string {
+	return []string{
+		"f_id",
+		"f_catalog_id",
+		"f_cron_expr",
+		"f_start_time",
+		"f_end_time",
+		"f_enabled",
+		"f_strategies",
+		"f_last_run",
+		"f_next_run",
+		"f_creator",
+		"f_creator_type",
+		"f_create_time",
+		"f_updater",
+		"f_updater_type",
+		"f_update_time",
+	}
+}
+
+func scanDiscoverSchedule(scanner discoverScheduleScanner) (*interfaces.DiscoverSchedule, error) {
+	schedule := &interfaces.DiscoverSchedule{}
+	var strategiesStr string
+
+	err := scanner.Scan(
+		&schedule.ID,
+		&schedule.CatalogID,
+		&schedule.CronExpr,
+		&schedule.StartTime,
+		&schedule.EndTime,
+		&schedule.Enabled,
+		&strategiesStr,
+		&schedule.LastRun,
+		&schedule.NextRun,
+		&schedule.Creator.ID,
+		&schedule.Creator.Type,
+		&schedule.CreateTime,
+		&schedule.Updater.ID,
+		&schedule.Updater.Type,
+		&schedule.UpdateTime,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	schedule.Strategies = stringToStrategies(strategiesStr)
+	return schedule, nil
+}
+
 // NewDiscoverScheduleAccess creates a new DiscoverScheduleAccess.
 func NewDiscoverScheduleAccess(appSetting *common.AppSetting) interfaces.DiscoverScheduleAccess {
 	dsAccessOnce.Do(func() {
@@ -232,23 +285,8 @@ func (dsa *discoverScheduleAccess) GetByID(ctx context.Context, id string) (*int
 	span.SetAttributes(attr.Key("schedule_id").String(id))
 
 	// Build select SQL
-	sqlStr, vals, err := sq.Select(
-		"f_id",
-		"f_catalog_id",
-		"f_cron_expr",
-		"f_start_time",
-		"f_end_time",
-		"f_enabled",
-		"f_strategies",
-		"f_last_run",
-		"f_next_run",
-		"f_creator",
-		"f_creator_type",
-		"f_create_time",
-		"f_updater",
-		"f_updater_type",
-		"f_update_time",
-	).From(DISCOVER_SCHEDULE_TABLE_NAME).
+	sqlStr, vals, err := sq.Select(discoverScheduleColumns()...).
+		From(DISCOVER_SCHEDULE_TABLE_NAME).
 		Where(sq.Eq{"f_id": id}).
 		ToSql()
 	if err != nil {
@@ -257,28 +295,9 @@ func (dsa *discoverScheduleAccess) GetByID(ctx context.Context, id string) (*int
 		return nil, err
 	}
 
-	schedule := &interfaces.DiscoverSchedule{}
-	var strategiesStr string
-
 	// Execute query
 	row := dsa.db.QueryRowContext(ctx, sqlStr, vals...)
-	err = row.Scan(
-		&schedule.ID,
-		&schedule.CatalogID,
-		&schedule.CronExpr,
-		&schedule.StartTime,
-		&schedule.EndTime,
-		&schedule.Enabled,
-		&strategiesStr,
-		&schedule.LastRun,
-		&schedule.NextRun,
-		&schedule.Creator.ID,
-		&schedule.Creator.Type,
-		&schedule.CreateTime,
-		&schedule.Updater.ID,
-		&schedule.Updater.Type,
-		&schedule.UpdateTime,
-	)
+	schedule, err := scanDiscoverSchedule(row)
 	if err == sql.ErrNoRows {
 		span.SetStatus(codes.Ok, "")
 		return nil, nil
@@ -288,9 +307,6 @@ func (dsa *discoverScheduleAccess) GetByID(ctx context.Context, id string) (*int
 		span.SetStatus(codes.Error, "Scan failed")
 		return nil, err
 	}
-
-	// Parse strategies string to array
-	schedule.Strategies = stringToStrategies(strategiesStr)
 
 	span.SetStatus(codes.Ok, "")
 	return schedule, nil
@@ -302,23 +318,8 @@ func (dsa *discoverScheduleAccess) List(ctx context.Context, params interfaces.D
 	defer span.End()
 
 	// Build select query
-	builder := sq.Select(
-		"f_id",
-		"f_catalog_id",
-		"f_cron_expr",
-		"f_start_time",
-		"f_end_time",
-		"f_enabled",
-		"f_strategies",
-		"f_last_run",
-		"f_next_run",
-		"f_creator",
-		"f_creator_type",
-		"f_create_time",
-		"f_updater",
-		"f_updater_type",
-		"f_update_time",
-	).From(DISCOVER_SCHEDULE_TABLE_NAME)
+	builder := sq.Select(discoverScheduleColumns()...).
+		From(DISCOVER_SCHEDULE_TABLE_NAME)
 
 	// Apply filters
 	if params.CatalogID != "" {
@@ -381,32 +382,12 @@ func (dsa *discoverScheduleAccess) List(ctx context.Context, params interfaces.D
 
 	schedules := []*interfaces.DiscoverSchedule{}
 	for rows.Next() {
-		schedule := &interfaces.DiscoverSchedule{}
-		var strategiesStr string
-		err := rows.Scan(
-			&schedule.ID,
-			&schedule.CatalogID,
-			&schedule.CronExpr,
-			&schedule.StartTime,
-			&schedule.EndTime,
-			&schedule.Enabled,
-			&strategiesStr,
-			&schedule.LastRun,
-			&schedule.NextRun,
-			&schedule.Creator.ID,
-			&schedule.Creator.Type,
-			&schedule.CreateTime,
-			&schedule.Updater.ID,
-			&schedule.Updater.Type,
-			&schedule.UpdateTime,
-		)
+		schedule, err := scanDiscoverSchedule(rows)
 		if err != nil {
 			logger.Errorf("Scan discover_schedule failed: %v", err)
 			span.SetStatus(codes.Error, "Scan failed")
 			return nil, 0, err
 		}
-		// Parse strategies string to array
-		schedule.Strategies = stringToStrategies(strategiesStr)
 		schedules = append(schedules, schedule)
 	}
 

--- a/adp/vega/vega-backend/server/drivenadapters/discover_schedule/discover_schedule_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/discover_schedule/discover_schedule_access.go
@@ -356,7 +356,7 @@ func (dsa *discoverScheduleAccess) List(ctx context.Context, params interfaces.D
 	if params.Sort != "" {
 		builder = builder.OrderBy(fmt.Sprintf("%s %s", params.Sort, params.Direction))
 	} else {
-		builder = builder.OrderBy("f_create_time DESC")
+		builder = builder.OrderBy("f_update_time DESC")
 	}
 	// Pagination
 	if params.Limit > 0 {

--- a/adp/vega/vega-backend/server/drivenadapters/discover_schedule/discover_schedule_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/discover_schedule/discover_schedule_access.go
@@ -353,7 +353,11 @@ func (dsa *discoverScheduleAccess) List(ctx context.Context, params interfaces.D
 	}
 
 	// Apply ordering and pagination
-	builder = builder.OrderBy("f_create_time DESC")
+	if params.Sort != "" {
+		builder = builder.OrderBy(fmt.Sprintf("%s %s", params.Sort, params.Direction))
+	} else {
+		builder = builder.OrderBy("f_create_time DESC")
+	}
 	// Pagination
 	if params.Limit > 0 {
 		builder = builder.Limit(uint64(params.Limit)).Offset(uint64(params.Offset))

--- a/adp/vega/vega-backend/server/drivenadapters/discover_task/discover_task_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/discover_task/discover_task_access.go
@@ -301,7 +301,11 @@ func (da *discoverTaskAccess) List(ctx context.Context, params interfaces.Discov
 	if params.Limit > 0 {
 		builder = builder.Limit(uint64(params.Limit)).Offset(uint64(params.Offset))
 	}
-	builder = builder.OrderBy("f_create_time DESC")
+	if params.Sort != "" && params.Direction != "" {
+		builder = builder.OrderBy(fmt.Sprintf("%s %s", params.Sort, params.Direction))
+	} else {
+		builder = builder.OrderBy("f_create_time DESC")
+	}
 
 	sqlStr, vals, err := builder.ToSql()
 	if err != nil {

--- a/adp/vega/vega-backend/server/drivenadapters/discover_task/discover_task_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/discover_task/discover_task_access.go
@@ -40,6 +40,71 @@ type discoverTaskAccess struct {
 	db         *sql.DB
 }
 
+type discoverTaskScanner interface {
+	Scan(dest ...any) error
+}
+
+func discoverTaskColumns() []string {
+	return []string{
+		"f_id",
+		"f_catalog_id",
+		"f_schedule_id",
+		"f_strategies",
+		"f_trigger_type",
+		"f_status",
+		"f_progress",
+		"f_message",
+		"f_start_time",
+		"f_finish_time",
+		"f_result",
+		"f_creator",
+		"f_creator_type",
+		"f_create_time",
+	}
+}
+
+func scanDiscoverTask(scanner discoverTaskScanner) (*interfaces.DiscoverTask, error) {
+	task := &interfaces.DiscoverTask{}
+	var resultStr sql.NullString
+	var strategiesStr sql.NullString
+
+	err := scanner.Scan(
+		&task.ID,
+		&task.CatalogID,
+		&task.ScheduleID,
+		&strategiesStr,
+		&task.TriggerType,
+		&task.Status,
+		&task.Progress,
+		&task.Message,
+		&task.StartTime,
+		&task.FinishTime,
+		&resultStr,
+		&task.Creator.ID,
+		&task.Creator.Type,
+		&task.CreateTime,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if strategiesStr.Valid && strategiesStr.String != "" {
+		if err := sonic.Unmarshal([]byte(strategiesStr.String), &task.Strategies); err != nil {
+			logger.Errorf("Failed to unmarshal strategies: %v", err)
+			task.Strategies = []string{}
+		}
+	} else {
+		task.Strategies = []string{}
+	}
+
+	if resultStr.Valid && resultStr.String != "" {
+		task.Result = &interfaces.DiscoverResult{}
+		_ = sonic.UnmarshalString(resultStr.String, task.Result)
+	}
+
+	return task, nil
+}
+
 // NewDiscoverTaskAccess creates a new DiscoverTaskAccess.
 func NewDiscoverTaskAccess(appSetting *common.AppSetting) interfaces.DiscoverTaskAccess {
 	dtAccessOnce.Do(func() {
@@ -52,7 +117,7 @@ func NewDiscoverTaskAccess(appSetting *common.AppSetting) interfaces.DiscoverTas
 }
 
 // GetScheduledTaskStrategies retrieves strategies from t_discover_schedule table by ID.
-func (da *discoverTaskAccess) GetScheduledTaskStrategies(ctx context.Context, scheduledTaskID string) ([]string, error) {
+func (dta *discoverTaskAccess) GetScheduledTaskStrategies(ctx context.Context, scheduledTaskID string) ([]string, error) {
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Query discover_schedule by ID")
 	defer span.End()
 
@@ -70,7 +135,7 @@ func (da *discoverTaskAccess) GetScheduledTaskStrategies(ctx context.Context, sc
 	}
 
 	var strategiesStr string
-	err = da.db.QueryRowContext(ctx, sqlStr, vals...).Scan(&strategiesStr)
+	err = dta.db.QueryRowContext(ctx, sqlStr, vals...).Scan(&strategiesStr)
 	if err == sql.ErrNoRows {
 		span.SetStatus(codes.Ok, "")
 		return []string{}, nil
@@ -96,7 +161,7 @@ func (da *discoverTaskAccess) GetScheduledTaskStrategies(ctx context.Context, sc
 }
 
 // Create creates a new DiscoverTask.
-func (da *discoverTaskAccess) Create(ctx context.Context, task *interfaces.DiscoverTask) error {
+func (dta *discoverTaskAccess) Create(ctx context.Context, task *interfaces.DiscoverTask) error {
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Insert into discover_task")
 	defer span.End()
 
@@ -116,22 +181,7 @@ func (da *discoverTaskAccess) Create(ctx context.Context, task *interfaces.Disco
 	}
 
 	sqlStr, vals, err := sq.Insert(DISCOVER_TASK_TABLE_NAME).
-		Columns(
-			"f_id",
-			"f_catalog_id",
-			"f_schedule_id",
-			"f_strategies",
-			"f_trigger_type",
-			"f_status",
-			"f_progress",
-			"f_message",
-			"f_start_time",
-			"f_finish_time",
-			"f_result",
-			"f_creator",
-			"f_creator_type",
-			"f_create_time",
-		).
+		Columns(discoverTaskColumns()...).
 		Values(
 			task.ID,
 			task.CatalogID,
@@ -155,7 +205,7 @@ func (da *discoverTaskAccess) Create(ctx context.Context, task *interfaces.Disco
 
 	otellog.LogInfo(ctx, fmt.Sprintf("Insert discover_task SQL: %s", sqlStr))
 
-	_, err = da.db.ExecContext(ctx, sqlStr, vals...)
+	_, err = dta.db.ExecContext(ctx, sqlStr, vals...)
 	if err != nil {
 		otellog.LogError(ctx, "Insert discover_schedule failed", err)
 		return err
@@ -166,28 +216,14 @@ func (da *discoverTaskAccess) Create(ctx context.Context, task *interfaces.Disco
 }
 
 // GetByID retrieves a DiscoverTask by ID.
-func (da *discoverTaskAccess) GetByID(ctx context.Context, id string) (*interfaces.DiscoverTask, error) {
+func (dta *discoverTaskAccess) GetByID(ctx context.Context, id string) (*interfaces.DiscoverTask, error) {
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Query discover_task by ID")
 	defer span.End()
 
 	span.SetAttributes(attr.Key("task_id").String(id))
 
-	sqlStr, vals, err := sq.Select(
-		"f_id",
-		"f_catalog_id",
-		"f_schedule_id",
-		"f_strategies",
-		"f_trigger_type",
-		"f_status",
-		"f_progress",
-		"f_message",
-		"f_start_time",
-		"f_finish_time",
-		"f_result",
-		"f_creator",
-		"f_creator_type",
-		"f_create_time",
-	).From(DISCOVER_TASK_TABLE_NAME).
+	sqlStr, vals, err := sq.Select(discoverTaskColumns()...).
+		From(DISCOVER_TASK_TABLE_NAME).
 		Where(sq.Eq{"f_id": id}).
 		ToSql()
 	if err != nil {
@@ -196,27 +232,8 @@ func (da *discoverTaskAccess) GetByID(ctx context.Context, id string) (*interfac
 		return nil, err
 	}
 
-	task := &interfaces.DiscoverTask{}
-	var resultStr sql.NullString
-	var strategiesStr sql.NullString
-
-	row := da.db.QueryRowContext(ctx, sqlStr, vals...)
-	err = row.Scan(
-		&task.ID,
-		&task.CatalogID,
-		&task.ScheduleID,
-		&strategiesStr,
-		&task.TriggerType,
-		&task.Status,
-		&task.Progress,
-		&task.Message,
-		&task.StartTime,
-		&task.FinishTime,
-		&resultStr,
-		&task.Creator.ID,
-		&task.Creator.Type,
-		&task.CreateTime,
-	)
+	row := dta.db.QueryRowContext(ctx, sqlStr, vals...)
+	task, err := scanDiscoverTask(row)
 	if err == sql.ErrNoRows {
 		span.SetStatus(codes.Ok, "")
 		return nil, nil
@@ -227,47 +244,16 @@ func (da *discoverTaskAccess) GetByID(ctx context.Context, id string) (*interfac
 		return nil, err
 	}
 
-	// Parse strategies string to array
-	if strategiesStr.Valid && strategiesStr.String != "" {
-		if err := sonic.Unmarshal([]byte(strategiesStr.String), &task.Strategies); err != nil {
-			logger.Errorf("Failed to unmarshal strategies: %v", err)
-			task.Strategies = []string{} // Set to empty array on error
-		}
-	} else {
-		task.Strategies = []string{}
-	}
-
-	// Deserialize result
-	if resultStr.Valid && resultStr.String != "" {
-		task.Result = &interfaces.DiscoverResult{}
-		_ = sonic.UnmarshalString(resultStr.String, task.Result)
-	}
-
 	span.SetStatus(codes.Ok, "")
 	return task, nil
 }
 
 // List lists DiscoverTasks with filters.
-func (da *discoverTaskAccess) List(ctx context.Context, params interfaces.DiscoverTaskQueryParams) ([]*interfaces.DiscoverTask, int64, error) {
+func (dta *discoverTaskAccess) List(ctx context.Context, params interfaces.DiscoverTaskQueryParams) ([]*interfaces.DiscoverTask, int64, error) {
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "List discover_tasks")
 	defer span.End()
 
-	builder := sq.Select(
-		"f_id",
-		"f_catalog_id",
-		"f_schedule_id",
-		"f_strategies",
-		"f_trigger_type",
-		"f_status",
-		"f_progress",
-		"f_message",
-		"f_start_time",
-		"f_finish_time",
-		"f_result",
-		"f_creator",
-		"f_creator_type",
-		"f_create_time",
-	).From(DISCOVER_TASK_TABLE_NAME)
+	builder := sq.Select(discoverTaskColumns()...).From(DISCOVER_TASK_TABLE_NAME)
 
 	countBuilder := sq.Select("COUNT(*)").From(DISCOVER_TASK_TABLE_NAME)
 
@@ -290,7 +276,7 @@ func (da *discoverTaskAccess) List(ctx context.Context, params interfaces.Discov
 
 	countSql, countVals, _ := countBuilder.ToSql()
 	var total int64
-	err := da.db.QueryRowContext(ctx, countSql, countVals...).Scan(&total)
+	err := dta.db.QueryRowContext(ctx, countSql, countVals...).Scan(&total)
 	if err != nil {
 		logger.Errorf("Failed to count discover_tasks: %v", err)
 		span.SetStatus(codes.Error, "Count failed")
@@ -313,7 +299,7 @@ func (da *discoverTaskAccess) List(ctx context.Context, params interfaces.Discov
 		return nil, 0, err
 	}
 
-	rows, err := da.db.QueryContext(ctx, sqlStr, vals...)
+	rows, err := dta.db.QueryContext(ctx, sqlStr, vals...)
 	if err != nil {
 		span.SetStatus(codes.Error, "Query failed")
 		return nil, 0, err
@@ -322,45 +308,10 @@ func (da *discoverTaskAccess) List(ctx context.Context, params interfaces.Discov
 
 	tasks := make([]*interfaces.DiscoverTask, 0)
 	for rows.Next() {
-		task := &interfaces.DiscoverTask{}
-		var resultStr sql.NullString
-		var strategiesStr sql.NullString
-
-		err := rows.Scan(
-			&task.ID,
-			&task.CatalogID,
-			&task.ScheduleID,
-			&strategiesStr,
-			&task.TriggerType,
-			&task.Status,
-			&task.Progress,
-			&task.Message,
-			&task.StartTime,
-			&task.FinishTime,
-			&resultStr,
-			&task.Creator.ID,
-			&task.Creator.Type,
-			&task.CreateTime,
-		)
+		task, err := scanDiscoverTask(rows)
 		if err != nil {
 			span.SetStatus(codes.Error, "Scan row failed")
 			return nil, 0, err
-		}
-
-		// Parse strategies string to array
-		if strategiesStr.Valid && strategiesStr.String != "" {
-			if err := sonic.Unmarshal([]byte(strategiesStr.String), &task.Strategies); err != nil {
-				logger.Errorf("Failed to unmarshal strategies: %v", err)
-				task.Strategies = []string{} // Set to empty array on error
-			}
-		} else {
-			task.Strategies = []string{}
-		}
-
-		// Deserialize result
-		if resultStr.Valid && resultStr.String != "" {
-			task.Result = &interfaces.DiscoverResult{}
-			_ = sonic.UnmarshalString(resultStr.String, task.Result)
 		}
 
 		tasks = append(tasks, task)
@@ -371,7 +322,7 @@ func (da *discoverTaskAccess) List(ctx context.Context, params interfaces.Discov
 }
 
 // UpdateStatus updates a DiscoverTask's status and message.
-func (da *discoverTaskAccess) UpdateStatus(ctx context.Context, id, status, message string, stime int64) error {
+func (dta *discoverTaskAccess) UpdateStatus(ctx context.Context, id, status, message string, stime int64) error {
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Update discover_task status")
 	defer span.End()
 
@@ -396,7 +347,7 @@ func (da *discoverTaskAccess) UpdateStatus(ctx context.Context, id, status, mess
 		return err
 	}
 
-	_, err = da.db.ExecContext(ctx, sqlStr, vals...)
+	_, err = dta.db.ExecContext(ctx, sqlStr, vals...)
 	if err != nil {
 		span.SetStatus(codes.Error, "Update failed")
 		return err
@@ -407,7 +358,7 @@ func (da *discoverTaskAccess) UpdateStatus(ctx context.Context, id, status, mess
 }
 
 // UpdateProgress updates a DiscoverTask's progress.
-func (da *discoverTaskAccess) UpdateProgress(ctx context.Context, id string, progress int) error {
+func (dta *discoverTaskAccess) UpdateProgress(ctx context.Context, id string, progress int) error {
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Update discover_task progress")
 	defer span.End()
 
@@ -421,7 +372,7 @@ func (da *discoverTaskAccess) UpdateProgress(ctx context.Context, id string, pro
 		return err
 	}
 
-	_, err = da.db.ExecContext(ctx, sqlStr, vals...)
+	_, err = dta.db.ExecContext(ctx, sqlStr, vals...)
 	if err != nil {
 		span.SetStatus(codes.Error, "Update failed")
 		return err
@@ -432,7 +383,7 @@ func (da *discoverTaskAccess) UpdateProgress(ctx context.Context, id string, pro
 }
 
 // UpdateResult updates a DiscoverTask's result and sets status to completed.
-func (da *discoverTaskAccess) UpdateResult(ctx context.Context, id string, result *interfaces.DiscoverResult, stime int64) error {
+func (dta *discoverTaskAccess) UpdateResult(ctx context.Context, id string, result *interfaces.DiscoverResult, stime int64) error {
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Update discover_task result")
 	defer span.End()
 
@@ -450,7 +401,7 @@ func (da *discoverTaskAccess) UpdateResult(ctx context.Context, id string, resul
 		return err
 	}
 
-	_, err = da.db.ExecContext(ctx, sqlStr, vals...)
+	_, err = dta.db.ExecContext(ctx, sqlStr, vals...)
 	if err != nil {
 		span.SetStatus(codes.Error, "Update failed")
 		return err
@@ -461,7 +412,7 @@ func (da *discoverTaskAccess) UpdateResult(ctx context.Context, id string, resul
 }
 
 // CheckExistByStatuses checks if DiscoverTasks exist by catalog ID and statuses.
-func (da *discoverTaskAccess) CheckExistByStatuses(ctx context.Context, catalogID string, statuses []string) (bool, error) {
+func (dta *discoverTaskAccess) CheckExistByStatuses(ctx context.Context, catalogID string, statuses []string) (bool, error) {
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Check discover_tasks exist")
 	defer span.End()
 
@@ -476,7 +427,7 @@ func (da *discoverTaskAccess) CheckExistByStatuses(ctx context.Context, catalogI
 
 	countSql, countVals, _ := countBuilder.ToSql()
 	var total int64
-	err := da.db.QueryRowContext(ctx, countSql, countVals...).Scan(&total)
+	err := dta.db.QueryRowContext(ctx, countSql, countVals...).Scan(&total)
 	if err != nil {
 		logger.Errorf("Failed to count discover_tasks: %v", err)
 		span.SetStatus(codes.Error, "Count failed")
@@ -488,7 +439,7 @@ func (da *discoverTaskAccess) CheckExistByStatuses(ctx context.Context, catalogI
 }
 
 // Delete deletes a DiscoverTask by ID. Returns sql.ErrNoRows if no row was affected.
-func (da *discoverTaskAccess) Delete(ctx context.Context, id string) error {
+func (dta *discoverTaskAccess) Delete(ctx context.Context, id string) error {
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Delete discover_task")
 	defer span.End()
 
@@ -503,7 +454,7 @@ func (da *discoverTaskAccess) Delete(ctx context.Context, id string) error {
 		return err
 	}
 
-	res, err := da.db.ExecContext(ctx, sqlStr, vals...)
+	res, err := dta.db.ExecContext(ctx, sqlStr, vals...)
 	if err != nil {
 		otellog.LogError(ctx, "Delete discover_task failed", err)
 		return err

--- a/adp/vega/vega-backend/server/drivenadapters/discover_task/discover_task_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/discover_task/discover_task_access.go
@@ -40,6 +40,17 @@ type discoverTaskAccess struct {
 	db         *sql.DB
 }
 
+// NewDiscoverTaskAccess creates a new DiscoverTaskAccess.
+func NewDiscoverTaskAccess(appSetting *common.AppSetting) interfaces.DiscoverTaskAccess {
+	dtAccessOnce.Do(func() {
+		dtAccess = &discoverTaskAccess{
+			appSetting: appSetting,
+			db:         libdb.NewDB(&appSetting.DBSetting),
+		}
+	})
+	return dtAccess
+}
+
 // GetScheduledTaskStrategies retrieves strategies from t_discover_schedule table by ID.
 func (da *discoverTaskAccess) GetScheduledTaskStrategies(ctx context.Context, scheduledTaskID string) ([]string, error) {
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Query discover_schedule by ID")
@@ -82,17 +93,6 @@ func (da *discoverTaskAccess) GetScheduledTaskStrategies(ctx context.Context, sc
 
 	span.SetStatus(codes.Ok, "")
 	return strategies, nil
-}
-
-// NewDiscoverTaskAccess creates a new DiscoverTaskAccess.
-func NewDiscoverTaskAccess(appSetting *common.AppSetting) interfaces.DiscoverTaskAccess {
-	dtAccessOnce.Do(func() {
-		dtAccess = &discoverTaskAccess{
-			appSetting: appSetting,
-			db:         libdb.NewDB(&appSetting.DBSetting),
-		}
-	})
-	return dtAccess
 }
 
 // Create creates a new DiscoverTask.

--- a/adp/vega/vega-backend/server/drivenadapters/resource/resource_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/resource/resource_access.go
@@ -670,10 +670,7 @@ func (ra *resourceAccess) List(ctx context.Context, params interfaces.ResourcesQ
 		return nil, 0, err
 	}
 
-	// 分页
-	// if params.Limit > 0 {
-	// 	builder = builder.Limit(uint64(params.Limit)).Offset(uint64(params.Offset))
-	// }
+	// Pagination is applied in service after permission filtering.
 	// 排序
 	if params.Sort != "" {
 		builder = builder.OrderBy(resourceListOrderExpr(params))

--- a/adp/vega/vega-backend/server/driveradapters/build_task_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/build_task_handler.go
@@ -15,22 +15,15 @@ import (
 	"github.com/kweaver-ai/kweaver-go-lib/audit"
 	"github.com/kweaver-ai/kweaver-go-lib/hydra"
 	"github.com/kweaver-ai/kweaver-go-lib/logger"
+	"github.com/kweaver-ai/kweaver-go-lib/otel/otellog"
 	"github.com/kweaver-ai/kweaver-go-lib/otel/oteltrace"
 	"github.com/kweaver-ai/kweaver-go-lib/rest"
 
+	"vega-backend/common"
 	"vega-backend/common/visitor"
 	verrors "vega-backend/errors"
 	"vega-backend/interfaces"
 )
-
-// buildTaskListQuery captures filter + pagination from query string.
-type buildTaskListQuery struct {
-	interfaces.PaginationQueryParams
-	ResourceID string `form:"resource_id"`
-	CatalogID  string `form:"catalog_id"`
-	Status     string `form:"status"`
-	Mode       string `form:"mode"`
-}
 
 // =========================== POST /build-tasks ===========================
 
@@ -199,46 +192,37 @@ func (r *restHandler) listBuildTasks(c *gin.Context, visitor hydra.Visitor) {
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, accountInfo)
 	oteltrace.AddHttpAttrs4API(span, oteltrace.GetAttrsByGinCtx(c))
 
-	var q buildTaskListQuery
-	if err := c.ShouldBindQuery(&q); err != nil {
-		httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_RequestBody).
-			WithErrorDetails(err.Error())
-		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
-		rest.ReplyError(c, httpErr)
-		return
-	}
-	if q.Limit == 0 {
-		q.Limit = 20
-	}
-	if q.Sort == "" {
-		q.Sort = "update_time"
-	}
-	if q.Direction == "" {
-		q.Direction = interfaces.DESC_DIRECTION
-	}
+	offset := common.GetQueryOrDefault(c, "offset", interfaces.DEFAULT_OFFSET)
+	limit := common.GetQueryOrDefault(c, "limit", interfaces.DEFAULT_LIMIT)
+	sort := common.GetQueryOrDefault(c, "sort", "update_time")
+	direction := common.GetQueryOrDefault(c, "direction", interfaces.DESC_DIRECTION)
 
-	if q.Status != "" && !isValidBuildTaskStatus(q.Status) {
-		httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidStatus).
-			WithErrorDetails(fmt.Sprintf("invalid status: %s", q.Status))
-		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
-		rest.ReplyError(c, httpErr)
-		return
-	}
-	if q.Mode != "" && !isValidBuildTaskMode(q.Mode) {
-		httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_Mode).
-			WithErrorDetails(fmt.Sprintf("invalid mode: %s", q.Mode))
+	pageParam, err := validatePaginationQueryParams(ctx,
+		offset, limit, sort, direction, interfaces.BUILD_TASK_SORT)
+	if err != nil {
+		httpErr := err.(*rest.HTTPError)
+		otellog.LogError(ctx, fmt.Sprintf("%s. %v", httpErr.BaseError.Description,
+			httpErr.BaseError.ErrorDetails), nil)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
 		return
 	}
 
 	params := interfaces.BuildTasksQueryParams{
-		PaginationQueryParams: q.PaginationQueryParams,
-		ResourceID:            q.ResourceID,
-		CatalogID:             q.CatalogID,
-		Status:                q.Status,
-		Mode:                  q.Mode,
+		PaginationQueryParams: pageParam,
+		ResourceID:            c.Query("resource_id"),
+		CatalogID:             c.Query("catalog_id"),
+		Status:                c.Query("status"),
+		Mode:                  c.Query("mode"),
 	}
+
+	if err := ValidateBuildTaskQueryParams(ctx, params); err != nil {
+		httpErr := err.(*rest.HTTPError)
+		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
+		rest.ReplyError(c, httpErr)
+		return
+	}
+
 	tasks, total, err := r.bts.ListBuildTasks(ctx, params)
 	if err != nil {
 		httpErr := err.(*rest.HTTPError)
@@ -404,25 +388,3 @@ func (r *restHandler) stopBuildTask(c *gin.Context, visitor hydra.Visitor) {
 }
 
 // =========================== helpers ===========================
-
-func isValidBuildTaskStatus(s string) bool {
-	switch s {
-	case interfaces.BuildTaskStatusInit,
-		interfaces.BuildTaskStatusRunning,
-		interfaces.BuildTaskStatusStopping,
-		interfaces.BuildTaskStatusStopped,
-		interfaces.BuildTaskStatusCompleted,
-		interfaces.BuildTaskStatusFailed:
-		return true
-	}
-	return false
-}
-
-func isValidBuildTaskMode(m string) bool {
-	switch m {
-	case interfaces.BuildTaskModeStreaming,
-		interfaces.BuildTaskModeBatch:
-		return true
-	}
-	return false
-}

--- a/adp/vega/vega-backend/server/driveradapters/build_task_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/build_task_handler_test.go
@@ -1,0 +1,132 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package driveradapters
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+
+	"vega-backend/common"
+	"vega-backend/interfaces"
+	vmock "vega-backend/interfaces/mock"
+)
+
+func Test_BuildTaskRestHandler_ListBuildTasks(t *testing.T) {
+	Convey("Test BuildTaskHandler ListBuildTasks\n", t, func() {
+		test := setGinMode()
+		defer test()
+
+		engine := gin.New()
+		engine.Use(gin.Recovery())
+
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		bts := vmock.NewMockBuildTaskService(mockCtrl)
+		handler := MockNewRestHandler(&common.AppSetting{}, nil, nil, nil, bts, nil, nil, nil, nil, nil, nil)
+		handler.RegisterPublic(engine)
+
+		url := "/api/vega-backend/in/v1/build-tasks"
+
+		Convey("Invalid offset\n", func() {
+			req := httptest.NewRequest(http.MethodGet, url+"?offset=-1", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+			So(w.Body.String(), ShouldContainSubstring, "VegaBackend.InvalidParameter.Offset")
+		})
+
+		Convey("Invalid limit\n", func() {
+			req := httptest.NewRequest(http.MethodGet, url+"?limit=99999999", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+			So(w.Body.String(), ShouldContainSubstring, "VegaBackend.InvalidParameter.Limit")
+		})
+
+		Convey("Invalid sort field\n", func() {
+			req := httptest.NewRequest(http.MethodGet, url+"?sort=unknown_field", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+			So(w.Body.String(), ShouldContainSubstring, "VegaBackend.InvalidParameter.Sort")
+		})
+
+		Convey("Invalid direction\n", func() {
+			req := httptest.NewRequest(http.MethodGet, url+"?direction=foo", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+			So(w.Body.String(), ShouldContainSubstring, "VegaBackend.InvalidParameter.Direction")
+		})
+
+		Convey("Invalid status\n", func() {
+			req := httptest.NewRequest(http.MethodGet, url+"?status=foo", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+			So(w.Body.String(), ShouldContainSubstring, "VegaBackend.BuildTask.InvalidStatus")
+		})
+
+		Convey("Invalid mode\n", func() {
+			req := httptest.NewRequest(http.MethodGet, url+"?mode=foo", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+			So(w.Body.String(), ShouldContainSubstring, "VegaBackend.BuildTask.InvalidParameter.Mode")
+		})
+
+		Convey("Success with default pagination\n", func() {
+			bts.EXPECT().ListBuildTasks(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, params interfaces.BuildTasksQueryParams) ([]*interfaces.BuildTask, int64, error) {
+					So(params.Offset, ShouldEqual, 0)
+					So(params.Limit, ShouldEqual, 20)
+					So(params.Sort, ShouldEqual, "f_update_time")
+					So(params.Direction, ShouldEqual, interfaces.DESC_DIRECTION)
+					return []*interfaces.BuildTask{}, int64(0), nil
+				})
+
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusOK)
+		})
+
+		Convey("Success with explicit query params\n", func() {
+			bts.EXPECT().ListBuildTasks(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, params interfaces.BuildTasksQueryParams) ([]*interfaces.BuildTask, int64, error) {
+					So(params.ResourceID, ShouldEqual, "res-1")
+					So(params.CatalogID, ShouldEqual, "cat-1")
+					So(params.Status, ShouldEqual, interfaces.BuildTaskStatusCompleted)
+					So(params.Mode, ShouldEqual, interfaces.BuildTaskModeBatch)
+					So(params.Offset, ShouldEqual, 5)
+					So(params.Limit, ShouldEqual, 10)
+					So(params.Sort, ShouldEqual, "f_create_time")
+					So(params.Direction, ShouldEqual, interfaces.ASC_DIRECTION)
+					return []*interfaces.BuildTask{}, int64(0), nil
+				})
+
+			req := httptest.NewRequest(http.MethodGet, url+"?resource_id=res-1&catalog_id=cat-1&status=completed&mode=batch&offset=5&limit=10&sort=create_time&direction=asc", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusOK)
+		})
+	})
+}

--- a/adp/vega/vega-backend/server/driveradapters/discover_schedule_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/discover_schedule_handler.go
@@ -15,9 +15,11 @@ import (
 	"github.com/kweaver-ai/kweaver-go-lib/audit"
 	"github.com/kweaver-ai/kweaver-go-lib/hydra"
 	"github.com/kweaver-ai/kweaver-go-lib/logger"
+	"github.com/kweaver-ai/kweaver-go-lib/otel/otellog"
 	"github.com/kweaver-ai/kweaver-go-lib/otel/oteltrace"
 	"github.com/kweaver-ai/kweaver-go-lib/rest"
 
+	"vega-backend/common"
 	"vega-backend/common/visitor"
 	verrors "vega-backend/errors"
 	"vega-backend/interfaces"
@@ -126,8 +128,25 @@ func (r *restHandler) listDiscoverSchedules(c *gin.Context, visitor hydra.Visito
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, accountInfo)
 	oteltrace.AddHttpAttrs4API(span, oteltrace.GetAttrsByGinCtx(c))
 
+	offset := common.GetQueryOrDefault(c, "offset", interfaces.DEFAULT_OFFSET)
+	limit := common.GetQueryOrDefault(c, "limit", interfaces.DEFAULT_LIMIT)
+	sort := common.GetQueryOrDefault(c, "sort", "update_time")
+	direction := common.GetQueryOrDefault(c, "direction", interfaces.DESC_DIRECTION)
+
+	pageParam, err := validatePaginationQueryParams(ctx,
+		offset, limit, sort, direction, interfaces.DISCOVER_SCHEDULE_SORT)
+	if err != nil {
+		httpErr := err.(*rest.HTTPError)
+		otellog.LogError(ctx, fmt.Sprintf("%s. %v", httpErr.BaseError.Description,
+			httpErr.BaseError.ErrorDetails), nil)
+		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
+		rest.ReplyError(c, httpErr)
+		return
+	}
+
 	params := interfaces.DiscoverScheduleQueryParams{
-		CatalogID: c.Query("catalog_id"),
+		PaginationQueryParams: pageParam,
+		CatalogID:             c.Query("catalog_id"),
 	}
 	if enabledStr := c.Query("enabled"); enabledStr != "" {
 		v, err := strconv.ParseBool(enabledStr)

--- a/adp/vega/vega-backend/server/driveradapters/discover_schedule_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/discover_schedule_handler_test.go
@@ -1,0 +1,135 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package driveradapters
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+
+	"vega-backend/common"
+	"vega-backend/interfaces"
+	vmock "vega-backend/interfaces/mock"
+)
+
+func Test_DiscoverScheduleRestHandler_ListDiscoverSchedules(t *testing.T) {
+	Convey("Test DiscoverScheduleHandler ListDiscoverSchedules\n", t, func() {
+		test := setGinMode()
+		defer test()
+
+		engine := gin.New()
+		engine.Use(gin.Recovery())
+
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		dss := vmock.NewMockDiscoverScheduleService(mockCtrl)
+		handler := MockNewRestHandler(&common.AppSetting{}, nil, nil, nil, nil, nil, nil, nil, dss, nil, nil)
+		handler.RegisterPublic(engine)
+
+		url := "/api/vega-backend/in/v1/discover-schedules"
+
+		Convey("Invalid offset\n", func() {
+			req := httptest.NewRequest(http.MethodGet, url+"?offset=-1", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+			So(w.Body.String(), ShouldContainSubstring, "VegaBackend.InvalidParameter.Offset")
+		})
+
+		Convey("Invalid offset non-numeric\n", func() {
+			req := httptest.NewRequest(http.MethodGet, url+"?offset=abc", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+			So(w.Body.String(), ShouldContainSubstring, "VegaBackend.InvalidParameter.Offset")
+		})
+
+		Convey("Invalid limit exceeds max\n", func() {
+			req := httptest.NewRequest(http.MethodGet, url+"?limit=99999999", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+			So(w.Body.String(), ShouldContainSubstring, "VegaBackend.InvalidParameter.Limit")
+		})
+
+		Convey("Invalid sort field\n", func() {
+			req := httptest.NewRequest(http.MethodGet, url+"?sort=unknown_field", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+			So(w.Body.String(), ShouldContainSubstring, "VegaBackend.InvalidParameter.Sort")
+		})
+
+		Convey("Invalid direction\n", func() {
+			req := httptest.NewRequest(http.MethodGet, url+"?direction=foo", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+			So(w.Body.String(), ShouldContainSubstring, "VegaBackend.InvalidParameter.Direction")
+		})
+
+		Convey("Success with default pagination\n", func() {
+			dss.EXPECT().List(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, params interfaces.DiscoverScheduleQueryParams) ([]*interfaces.DiscoverSchedule, int64, error) {
+					So(params.Offset, ShouldEqual, 0)
+					So(params.Limit, ShouldEqual, 20)
+					So(params.Sort, ShouldEqual, "f_update_time")
+					So(params.Direction, ShouldEqual, interfaces.DESC_DIRECTION)
+					return []*interfaces.DiscoverSchedule{}, int64(0), nil
+				})
+
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusOK)
+		})
+
+		Convey("Success with explicit sort and direction\n", func() {
+			dss.EXPECT().List(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, params interfaces.DiscoverScheduleQueryParams) ([]*interfaces.DiscoverSchedule, int64, error) {
+					So(params.Sort, ShouldEqual, "f_next_run")
+					So(params.Direction, ShouldEqual, interfaces.ASC_DIRECTION)
+					So(params.Offset, ShouldEqual, 5)
+					So(params.Limit, ShouldEqual, 10)
+					return []*interfaces.DiscoverSchedule{}, int64(0), nil
+				})
+
+			req := httptest.NewRequest(http.MethodGet, url+"?sort=next_run&direction=asc&offset=5&limit=10", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusOK)
+		})
+
+		Convey("Success with catalog_id and enabled filters preserved\n", func() {
+			dss.EXPECT().List(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, params interfaces.DiscoverScheduleQueryParams) ([]*interfaces.DiscoverSchedule, int64, error) {
+					So(params.CatalogID, ShouldEqual, "cat-1")
+					So(params.Enabled, ShouldNotBeNil)
+					So(*params.Enabled, ShouldBeTrue)
+					return []*interfaces.DiscoverSchedule{}, int64(0), nil
+				})
+
+			req := httptest.NewRequest(http.MethodGet, url+"?catalog_id=cat-1&enabled=true", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusOK)
+		})
+	})
+}

--- a/adp/vega/vega-backend/server/driveradapters/discover_task_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/discover_task_handler.go
@@ -16,9 +16,11 @@ import (
 	"github.com/kweaver-ai/kweaver-go-lib/audit"
 	"github.com/kweaver-ai/kweaver-go-lib/hydra"
 	"github.com/kweaver-ai/kweaver-go-lib/logger"
+	"github.com/kweaver-ai/kweaver-go-lib/otel/otellog"
 	"github.com/kweaver-ai/kweaver-go-lib/otel/oteltrace"
 	"github.com/kweaver-ai/kweaver-go-lib/rest"
 
+	"vega-backend/common"
 	"vega-backend/common/visitor"
 	verrors "vega-backend/errors"
 	"vega-backend/interfaces"
@@ -49,21 +51,32 @@ func (r *restHandler) listDiscoverTasks(c *gin.Context, visitor hydra.Visitor) {
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, accountInfo)
 	oteltrace.AddHttpAttrs4API(span, oteltrace.GetAttrsByGinCtx(c))
 
-	var params interfaces.DiscoverTaskQueryParams
-	if err := c.ShouldBindQuery(&params); err != nil {
-		httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_RequestBody).
-			WithErrorDetails(err.Error())
+	offset := common.GetQueryOrDefault(c, "offset", interfaces.DEFAULT_OFFSET)
+	limit := common.GetQueryOrDefault(c, "limit", interfaces.DEFAULT_LIMIT)
+	sort := common.GetQueryOrDefault(c, "sort", "create_time")
+	direction := common.GetQueryOrDefault(c, "direction", interfaces.DESC_DIRECTION)
+
+	pageParam, err := validatePaginationQueryParams(ctx,
+		offset, limit, sort, direction, interfaces.DISCOVER_TASK_SORT)
+	if err != nil {
+		httpErr := err.(*rest.HTTPError)
+		otellog.LogError(ctx, fmt.Sprintf("%s. %v", httpErr.BaseError.Description,
+			httpErr.BaseError.ErrorDetails), nil)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
 		return
 	}
-	if params.Limit == 0 {
-		params.Limit = 20
+
+	params := interfaces.DiscoverTaskQueryParams{
+		PaginationQueryParams: pageParam,
+		CatalogID:             c.Query("catalog_id"),
+		ScheduleID:            c.Query("schedule_id"),
+		Status:                c.Query("status"),
+		TriggerType:           c.Query("trigger_type"),
 	}
 
-	if params.Status != "" && !isValidDiscoverTaskStatus(params.Status) {
-		httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_DiscoverTask_InvalidStatus).
-			WithErrorDetails(fmt.Sprintf("invalid status: %s", params.Status))
+	if err := ValidateDiscoverTaskQueryParams(ctx, params); err != nil {
+		httpErr := err.(*rest.HTTPError)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
 		return
@@ -191,17 +204,4 @@ func (r *restHandler) deleteDiscoverTasks(c *gin.Context, visitor hydra.Visitor)
 	logger.Debug("Handler DeleteDiscoverTasksByEx Success")
 	oteltrace.AddHttpAttrs4Ok(span, http.StatusNoContent)
 	rest.ReplyOK(c, http.StatusNoContent, nil)
-}
-
-// =========================== helpers ===========================
-
-func isValidDiscoverTaskStatus(s string) bool {
-	switch s {
-	case interfaces.DiscoverTaskStatusPending,
-		interfaces.DiscoverTaskStatusRunning,
-		interfaces.DiscoverTaskStatusCompleted,
-		interfaces.DiscoverTaskStatusFailed:
-		return true
-	}
-	return false
 }

--- a/adp/vega/vega-backend/server/driveradapters/discover_task_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/discover_task_handler_test.go
@@ -1,0 +1,123 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package driveradapters
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+
+	"vega-backend/common"
+	"vega-backend/interfaces"
+	vmock "vega-backend/interfaces/mock"
+)
+
+func Test_DiscoverTaskRestHandler_ListDiscoverTasks(t *testing.T) {
+	Convey("Test DiscoverTaskHandler ListDiscoverTasks\n", t, func() {
+		test := setGinMode()
+		defer test()
+
+		engine := gin.New()
+		engine.Use(gin.Recovery())
+
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		dts := vmock.NewMockDiscoverTaskService(mockCtrl)
+		handler := MockNewRestHandler(&common.AppSetting{}, nil, nil, nil, nil, nil, nil, dts, nil, nil, nil)
+		handler.RegisterPublic(engine)
+
+		url := "/api/vega-backend/in/v1/discover-tasks"
+
+		Convey("Invalid offset\n", func() {
+			req := httptest.NewRequest(http.MethodGet, url+"?offset=-1", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+			So(w.Body.String(), ShouldContainSubstring, "VegaBackend.InvalidParameter.Offset")
+		})
+
+		Convey("Invalid limit\n", func() {
+			req := httptest.NewRequest(http.MethodGet, url+"?limit=99999999", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+			So(w.Body.String(), ShouldContainSubstring, "VegaBackend.InvalidParameter.Limit")
+		})
+
+		Convey("Invalid sort field\n", func() {
+			req := httptest.NewRequest(http.MethodGet, url+"?sort=unknown_field", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+			So(w.Body.String(), ShouldContainSubstring, "VegaBackend.InvalidParameter.Sort")
+		})
+
+		Convey("Invalid direction\n", func() {
+			req := httptest.NewRequest(http.MethodGet, url+"?direction=foo", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+			So(w.Body.String(), ShouldContainSubstring, "VegaBackend.InvalidParameter.Direction")
+		})
+
+		Convey("Invalid trigger type\n", func() {
+			req := httptest.NewRequest(http.MethodGet, url+"?trigger_type=foo", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+			So(w.Body.String(), ShouldContainSubstring, "invalid trigger_type")
+		})
+
+		Convey("Success with default pagination\n", func() {
+			dts.EXPECT().List(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, params interfaces.DiscoverTaskQueryParams) ([]*interfaces.DiscoverTask, int64, error) {
+					So(params.Offset, ShouldEqual, 0)
+					So(params.Limit, ShouldEqual, 20)
+					So(params.Sort, ShouldEqual, "f_create_time")
+					So(params.Direction, ShouldEqual, interfaces.DESC_DIRECTION)
+					return []*interfaces.DiscoverTask{}, int64(0), nil
+				})
+
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusOK)
+		})
+
+		Convey("Success with explicit query params\n", func() {
+			dts.EXPECT().List(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, params interfaces.DiscoverTaskQueryParams) ([]*interfaces.DiscoverTask, int64, error) {
+					So(params.CatalogID, ShouldEqual, "cat-1")
+					So(params.ScheduleID, ShouldEqual, "sch-1")
+					So(params.Status, ShouldEqual, interfaces.DiscoverTaskStatusCompleted)
+					So(params.TriggerType, ShouldEqual, interfaces.DiscoverTaskTriggerScheduled)
+					So(params.Offset, ShouldEqual, 5)
+					So(params.Limit, ShouldEqual, 10)
+					So(params.Sort, ShouldEqual, "f_start_time")
+					So(params.Direction, ShouldEqual, interfaces.ASC_DIRECTION)
+					return []*interfaces.DiscoverTask{}, int64(0), nil
+				})
+
+			req := httptest.NewRequest(http.MethodGet, url+"?catalog_id=cat-1&schedule_id=sch-1&status=completed&trigger_type=scheduled&offset=5&limit=10&sort=start_time&direction=asc", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusOK)
+		})
+	})
+}

--- a/adp/vega/vega-backend/server/driveradapters/validate_build_task.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_build_task.go
@@ -1,0 +1,53 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package driveradapters
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/kweaver-ai/kweaver-go-lib/rest"
+
+	verrors "vega-backend/errors"
+	"vega-backend/interfaces"
+)
+
+func ValidateBuildTaskQueryParams(ctx context.Context, params interfaces.BuildTasksQueryParams) error {
+	if params.Status != "" && !isValidBuildTaskStatus(params.Status) {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidStatus).
+			WithErrorDetails(fmt.Sprintf("invalid status: %s", params.Status))
+	}
+
+	if params.Mode != "" && !isValidBuildTaskMode(params.Mode) {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_Mode).
+			WithErrorDetails(fmt.Sprintf("invalid mode: %s", params.Mode))
+	}
+
+	return nil
+}
+
+func isValidBuildTaskStatus(s string) bool {
+	switch s {
+	case interfaces.BuildTaskStatusInit,
+		interfaces.BuildTaskStatusRunning,
+		interfaces.BuildTaskStatusStopping,
+		interfaces.BuildTaskStatusStopped,
+		interfaces.BuildTaskStatusCompleted,
+		interfaces.BuildTaskStatusFailed:
+		return true
+	}
+	return false
+}
+
+func isValidBuildTaskMode(m string) bool {
+	switch m {
+	case interfaces.BuildTaskModeStreaming,
+		interfaces.BuildTaskModeBatch:
+		return true
+	}
+	return false
+}

--- a/adp/vega/vega-backend/server/driveradapters/validate_build_task_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_build_task_test.go
@@ -1,0 +1,48 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package driveradapters
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"vega-backend/interfaces"
+)
+
+func Test_ValidateBuildTaskQueryParams(t *testing.T) {
+	Convey("Test ValidateBuildTaskQueryParams\n", t, func() {
+		ctx := context.Background()
+
+		Convey("Valid empty params\n", func() {
+			err := ValidateBuildTaskQueryParams(ctx, interfaces.BuildTasksQueryParams{})
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Valid status and mode\n", func() {
+			err := ValidateBuildTaskQueryParams(ctx, interfaces.BuildTasksQueryParams{
+				Status: interfaces.BuildTaskStatusCompleted,
+				Mode:   interfaces.BuildTaskModeBatch,
+			})
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Invalid status\n", func() {
+			err := ValidateBuildTaskQueryParams(ctx, interfaces.BuildTasksQueryParams{
+				Status: "unknown",
+			})
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Invalid mode\n", func() {
+			err := ValidateBuildTaskQueryParams(ctx, interfaces.BuildTasksQueryParams{
+				Mode: "unknown",
+			})
+			So(err, ShouldNotBeNil)
+		})
+	})
+}

--- a/adp/vega/vega-backend/server/driveradapters/validate_discover_task.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_discover_task.go
@@ -1,0 +1,51 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package driveradapters
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/kweaver-ai/kweaver-go-lib/rest"
+
+	verrors "vega-backend/errors"
+	"vega-backend/interfaces"
+)
+
+func ValidateDiscoverTaskQueryParams(ctx context.Context, params interfaces.DiscoverTaskQueryParams) error {
+	if params.Status != "" && !isValidDiscoverTaskStatus(params.Status) {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_DiscoverTask_InvalidStatus).
+			WithErrorDetails(fmt.Sprintf("invalid status: %s", params.Status))
+	}
+
+	if params.TriggerType != "" && !isValidDiscoverTaskTriggerType(params.TriggerType) {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_RequestBody).
+			WithErrorDetails(fmt.Sprintf("invalid trigger_type: %s", params.TriggerType))
+	}
+
+	return nil
+}
+
+func isValidDiscoverTaskStatus(s string) bool {
+	switch s {
+	case interfaces.DiscoverTaskStatusPending,
+		interfaces.DiscoverTaskStatusRunning,
+		interfaces.DiscoverTaskStatusCompleted,
+		interfaces.DiscoverTaskStatusFailed:
+		return true
+	}
+	return false
+}
+
+func isValidDiscoverTaskTriggerType(s string) bool {
+	switch s {
+	case interfaces.DiscoverTaskTriggerManual,
+		interfaces.DiscoverTaskTriggerScheduled:
+		return true
+	}
+	return false
+}

--- a/adp/vega/vega-backend/server/driveradapters/validate_discover_task_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_discover_task_test.go
@@ -1,0 +1,48 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package driveradapters
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"vega-backend/interfaces"
+)
+
+func Test_ValidateDiscoverTaskQueryParams(t *testing.T) {
+	Convey("Test ValidateDiscoverTaskQueryParams\n", t, func() {
+		ctx := context.Background()
+
+		Convey("Valid empty params\n", func() {
+			err := ValidateDiscoverTaskQueryParams(ctx, interfaces.DiscoverTaskQueryParams{})
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Valid status and trigger type\n", func() {
+			err := ValidateDiscoverTaskQueryParams(ctx, interfaces.DiscoverTaskQueryParams{
+				Status:      interfaces.DiscoverTaskStatusCompleted,
+				TriggerType: interfaces.DiscoverTaskTriggerScheduled,
+			})
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Invalid status\n", func() {
+			err := ValidateDiscoverTaskQueryParams(ctx, interfaces.DiscoverTaskQueryParams{
+				Status: "unknown",
+			})
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Invalid trigger type\n", func() {
+			err := ValidateDiscoverTaskQueryParams(ctx, interfaces.DiscoverTaskQueryParams{
+				TriggerType: "unknown",
+			})
+			So(err, ShouldNotBeNil)
+		})
+	})
+}

--- a/adp/vega/vega-backend/server/interfaces/build_task.go
+++ b/adp/vega/vega-backend/server/interfaces/build_task.go
@@ -31,6 +31,15 @@ const (
 	BUILD_PREFIX = "vega-build"
 )
 
+var (
+	BUILD_TASK_SORT = map[string]string{
+		"create_time": "f_create_time",
+		"update_time": "f_update_time",
+		"status":      "f_status",
+		"mode":        "f_mode",
+	}
+)
+
 // BuildTask represents a build task entity.
 type BuildTask struct {
 	ID              string      `json:"id"`

--- a/adp/vega/vega-backend/server/interfaces/discover_schedule.go
+++ b/adp/vega/vega-backend/server/interfaces/discover_schedule.go
@@ -23,6 +23,14 @@ type DiscoverSchedule struct {
 	UpdateTime int64       `json:"update_time"`
 }
 
+var (
+	DISCOVER_SCHEDULE_SORT = map[string]string{
+		"create_time": "f_create_time",
+		"update_time": "f_update_time",
+		"next_run":    "f_next_run",
+	}
+)
+
 // DiscoverScheduleQueryParams holds query parameters for scheduled discover tasks.
 type DiscoverScheduleQueryParams struct {
 	PaginationQueryParams

--- a/adp/vega/vega-backend/server/interfaces/discover_task.go
+++ b/adp/vega/vega-backend/server/interfaces/discover_task.go
@@ -24,6 +24,14 @@ const (
 	DiscoverTaskTopic = "adp-vega-discover-task"
 )
 
+var (
+	DISCOVER_TASK_SORT = map[string]string{
+		"create_time": "f_create_time",
+		"start_time":  "f_start_time",
+		"finish_time": "f_finish_time",
+	}
+)
+
 // DiscoverTask represents a discover task entity.
 type DiscoverTask struct {
 	ID          string   `json:"id"`


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] discover-schedule / discover-task / build-task 列表接口新增排序（sort + direction）与分页（offset + limit）支持
- [x] 新增排序字段映射常量（`BUILD_TASK_SORT` 等），统一管理外部字段名 → DB 列名转换
- [x] 抽离并补全列表查询的参数校验（状态、触发类型、分页、排序方向）；提取公共分页参数处理
- [x] 移除 catalog / resource / connector_type 访问层内置分页逻辑，统一迁移到服务层做"权限过滤后分页"
- [x] 将 discover_schedule 默认排序由 `f_create_time` 改为 `f_update_time`
- [x] 用 squirrel 重构 build_task_access 的 SQL 构建；抽离各 DAO 的列定义与行扫描公共函数
- [x] 新增 handler/校验函数单元测试，覆盖参数校验与列表查询场景
- [x] 更新 discover-schedule API 文档，补充 offset/limit/sort/direction 参数说明

---

## Why

- Related Issue: #460
- Background:
  - discover-schedule / discover-task / build-task 列表接口此前只能默认排序、无分页参数，无法满足前端列表 UI 的查询需求
  - catalog / resource / connector_type 在 access 层做分页会导致先分页再过滤权限，结果集错位；需要把分页下推到服务层
  - build_task_access 大量字符串拼 SQL，可读性差且易出错；各 DAO 的列与扫描逻辑重复，维护成本高

---

## How

- 关键实现点：
  - `interfaces/{build_task,discover_schedule,discover_task}.go`：新增排序字段常量映射
  - `driveradapters/validate_{build_task,discover_task}.go`：独立的参数校验函数 + 单测
  - `driveradapters/{build_task,discover_schedule,discover_task}_handler.go`：复用公共校验、提取分页处理；新增 handler 单测
  - `drivenadapters/build_task/build_task_access.go`：squirrel 改写 SQL；列与扫描函数化（-258 / +191）
  - `drivenadapters/{catalog,resource,connector_type}/...`：移除 access 层分页（各 -4）
  - `drivenadapters/discover_schedule/discover_schedule_access.go`：默认排序切到 `f_update_time`
  - `drivenadapters/discover_task/discover_task_access.go`：构造函数位置整理 + 列/扫描函数化
  - `docs/api/vega/vega-backend-api/discover-schedule.yaml`：补充 offset/limit/sort/direction 参数定义
- Breaking changes：
  - catalog / resource / connector_type 的 access 层分页参数语义变化（移交服务层）——仅影响仓库内部调用
  - discover_schedule 列表默认排序字段变更（`f_create_time` → `f_update_time`）——对外行为差异，需周知前端
  - 对外列表接口新增 `sort` / `direction` / `offset` / `limit` 查询参数，向前兼容

---

## Testing

- [x] Unit tests passed locally（新增 `validate_build_task_test.go` / `validate_discover_task_test.go` / `*_handler_test.go` 共 4 组测试文件）
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes：

- `go test ./adp/vega/vega-backend/server/...`

---

## Risk & Rollback

- 潜在风险：
  - 默认排序变化（discover_schedule）可能影响依赖默认顺序的前端 / 脚本
  - access 层分页下沉，需确认服务层在所有调用路径上都正确传递了 offset/limit
  - squirrel 重构覆盖面较大，需重点回归 build_task 列表 / 详情查询
- 回滚方案：revert 本 PR；access 层与 SQL 重构内聚，无数据库 schema 变更

---

## Additional Notes

- 相关 commits：
  - feat(discover-schedule): 新增排序、分页参数支持并补充单元测试
  - docs(vega-backend-api): add pagination and sorting query params for discover schedule
  - feat(discover-task): 新增排序、参数校验及分页查询能力
  - refactor(build-task): 重构构建任务列表查询逻辑，新增参数校验
  - refactor(access-layer): 调整数据访问层分页与排序逻辑
  - refactor(build_task_access): 使用 squirrel 重构 SQL 构建逻辑
  - refactor(access): 统一数据库访问层的列管理和扫描逻辑